### PR TITLE
Fixing a null pointer exception while deleting a queue from UI, fixing a subscription related bug

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -310,6 +310,16 @@ public enum AndesConfiguration implements ConfigurationProperty {
             "/messageBatchSizeForBrowserSubscriptions", "200", Integer.class),
 
     /**
+     * This property defines the maximum message content length that can be displayed at the management console when
+     * browsing queues. If the message length exceeds the value, a truncated content will be displayed with a statement
+     * "message content too large to display." at the end. default value is 100000 (can roughly display a 100KB message.)
+     * NOTE : Increasing this value could cause delays when loading the message content page.
+     * (Introduced as per jira MB_939.)
+     */
+    MANAGEMENT_CONSOLE_MAX_DISPLAY_LENGTH_FOR_MESSAGE_CONTENT("managementConsole" +
+            "/maximumMessageDisplayLength", "100000", Integer.class),
+
+    /**
      * This is the per publisher buffer size low limit which disable the flow control for a channel if the flow-control
      * was enabled previously.
      */

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -314,7 +314,7 @@ public enum AndesConfiguration implements ConfigurationProperty {
      * browsing queues. If the message length exceeds the value, a truncated content will be displayed with a statement
      * "message content too large to display." at the end. default value is 100000 (can roughly display a 100KB message.)
      * NOTE : Increasing this value could cause delays when loading the message content page.
-     * (Introduced as per jira MB_939.)
+     * (Introduced as per jira MB_939. )
      */
     MANAGEMENT_CONSOLE_MAX_DISPLAY_LENGTH_FOR_MESSAGE_CONTENT("managementConsole" +
             "/maximumMessageDisplayLength", "100000", Integer.class),

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -152,7 +152,7 @@ public class Andes {
     }
 
     public void closeLocalSubscription(InboundSubscriptionEvent subscriptionEvent) throws AndesException {
-        subscriptionEvent.prepareForNewSubscription(subscriptionManager);
+        subscriptionEvent.prepareForCloseSubscription(subscriptionManager);
         inboundEventManager.publishStateEvent(subscriptionEvent);
         try {
             subscriptionEvent.waitForCompletion();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundQueueEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundQueueEvent.java
@@ -86,6 +86,7 @@ public class InboundQueueEvent extends AndesQueue implements AndesInboundStateEv
     public InboundQueueEvent(String queueName, String queueOwner, boolean isExclusive, boolean isDurable) {
         super(queueName, queueOwner, isExclusive, isDurable);
         purgedCount = SettableFuture.create();
+        isQueueDeletable = SettableFuture.create();
         isTopic = false;
     }
 


### PR DESCRIPTION
Fixing a null pointer exception while deleting a queue from UI, fixing a subscription related bug