### PR TITLE
[MB-958] Fixing the problems with the build of andes with oracle jdk 1.8

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/qpid/ConfigStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/qpid/ConfigStore.java
@@ -110,7 +110,7 @@ public class ConfigStore
         }
     }
 
-    public <T extends ConfigObjectType<T, C>, C extends ConfiguredObject<T, C>> void addConfigEventListener(T type, ConfigEventListener<T,C> listener)
+    public <T extends ConfigObjectType<T, C>, C extends ConfiguredObject<T, C>> void addConfigEventListener(ConfigObjectType<T,C> type, ConfigEventListener<T,C> listener)
     {
         CopyOnWriteArrayList listeners = _listenerMap.get(type);
         if(listeners == null)
@@ -128,7 +128,7 @@ public class ConfigStore
 
     }
 
-    public <T extends ConfigObjectType<T, C>, C extends ConfiguredObject<T, C>> void removeConfigEventListener(T type, ConfigEventListener<T,C> listener)
+    public <T extends ConfigObjectType<T, C>, C extends ConfiguredObject<T, C>> void removeConfigEventListener(ConfigObjectType<T,C> type, ConfigEventListener<T,C> listener)
     {
         CopyOnWriteArrayList listeners = _listenerMap.get(type);
         if(listeners != null)


### PR DESCRIPTION
Changes are compatible with both jdk 1.8 and jdk 1.6