### PR TITLE
Fix Jiras 964 and 970

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -182,6 +182,11 @@ public class Andes {
         inboundEventManager.publishStateEvent(channelEvent);
     }
 
+    /**
+     * Close the local subscription with reference to the input subscription event.
+     * @param subscriptionEvent disruptor event containing the subscription to close.
+     * @throws AndesException
+     */
     public void closeLocalSubscription(InboundSubscriptionEvent subscriptionEvent) throws AndesException {
         subscriptionEvent.prepareForCloseSubscription(subscriptionManager);
         inboundEventManager.publishStateEvent(subscriptionEvent);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -212,9 +212,8 @@ public class Andes {
     /**
      * Notify client connection is closed from protocol level
      * State related to connection will be updated within Andes
-     * @throws Exception
      */
-    public void startMessageDelivery() throws Exception {
+    public void startMessageDelivery() {
         InboundKernelOpsEvent kernelOpsEvent = new InboundKernelOpsEvent();
         kernelOpsEvent.prepareForStartMessageDelivery(messagingEngine);
         inboundEventManager.publishStateEvent(kernelOpsEvent);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -232,7 +232,7 @@ public class Andes {
      * Shut down Andes.
      * NOTE: This is package specific. We don't need access outside from kernel for this task
      */
-    void shutDown() {
+    public void shutDown() {
         InboundKernelOpsEvent kernelOpsEvent = new InboundKernelOpsEvent();
         kernelOpsEvent.prepareForShutdownMessagingEngine(messagingEngine);
         inboundEventManager.publishStateEvent(kernelOpsEvent);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
@@ -40,6 +40,8 @@ import org.wso2.andes.subscription.SubscriptionStore;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.UserStoreException;
 
+import javax.management.JMException;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -71,7 +73,7 @@ public class AndesKernelBoot {
     /**
      * This will boot up all the components in Andes kernel and bring the server to working state
      */
-    public static void bootAndesKernel() throws Exception {
+    public static void bootAndesKernel() throws AndesException, UnknownHostException, JMException {
 
         isKernelShuttingDown = false;
         //loadConfigurations - done from outside
@@ -290,7 +292,7 @@ public class AndesKernelBoot {
      *
      * @throws Exception
      */
-    public static void syncNodeWithClusterState() throws Exception {
+    public static void syncNodeWithClusterState() throws AndesException {
         //at the startup reload exchanges/queues/bindings and subscriptions
         log.info("Syncing exchanges, queues, bindings and subscriptions");
         ClusterResourceHolder.getInstance().getAndesRecoveryTask()
@@ -350,7 +352,7 @@ public class AndesKernelBoot {
      *
      * @throws Exception
      */
-    public static void registerMBeans() throws Exception {
+    public static void registerMBeans() throws JMException {
 
         ClusterManagementInformationMBean clusterManagementMBean = new
                 ClusterManagementInformationMBean(
@@ -371,7 +373,7 @@ public class AndesKernelBoot {
      *
      * @throws Exception
      */
-    public static void startAndesComponents() throws Exception {
+    public static void startAndesComponents() throws AndesException, UnknownHostException {
 
         /**
          * initialize cluster manager for managing nodes in MB cluster
@@ -400,7 +402,7 @@ public class AndesKernelBoot {
      *
      * @throws Exception
      */
-    public static void startMessaging() throws Exception {
+    public static void startMessaging() {
         Andes.getInstance().startMessageDelivery();
 
         // NOTE: Feature Message Expiration moved to a future release

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesSubscriptionManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesSubscriptionManager.java
@@ -133,13 +133,7 @@ public class AndesSubscriptionManager {
 
         if (!activeSubscriptions.isEmpty()) {
             for (LocalSubscription sub : activeSubscriptions) {
-                //close and notify
-                try {
-                    subscriptionStore.createDisconnectOrRemoveLocalSubscription(sub, SubscriptionListener.SubscriptionChange.DELETED);
-                } catch (SubscriptionAlreadyExistsException ignore) {
-                    // newer thrown for close subscriptions
-                }
-                notifyLocalSubscriptionHasChanged(sub, SubscriptionListener.SubscriptionChange.DELETED);
+                closeLocalSubscription(sub);
             }
         }
 
@@ -177,7 +171,7 @@ public class AndesSubscriptionManager {
      * @throws AndesException
      */
     public void closeLocalSubscription(LocalSubscription subscription) throws AndesException {
-        SubscriptionListener.SubscriptionChange chageType;
+        SubscriptionListener.SubscriptionChange changeType;
         /**
          * For durable topic subscriptions, mark this as a offline subscription.
          * When a new one comes with same subID, same topic it will become online again
@@ -194,22 +188,22 @@ public class AndesSubscriptionManager {
              */
             if (allowSharedSubscribers) {
                 if (subscriptionStore.getActiveLocalSubscribers(subscription.getTargetQueue(), false).size() == 1) {
-                    chageType = SubscriptionListener.SubscriptionChange.DISCONNECTED;
+                    changeType = SubscriptionListener.SubscriptionChange.DISCONNECTED;
                 } else {
-                    chageType = SubscriptionListener.SubscriptionChange.DELETED;
+                    changeType = SubscriptionListener.SubscriptionChange.DELETED;
                 }
             } else {
-                chageType = SubscriptionListener.SubscriptionChange.DISCONNECTED;
+                changeType = SubscriptionListener.SubscriptionChange.DISCONNECTED;
             }
         } else {
-            chageType = SubscriptionListener.SubscriptionChange.DELETED;
+            changeType = SubscriptionListener.SubscriptionChange.DELETED;
         }
         try {
-            subscriptionStore.createDisconnectOrRemoveLocalSubscription(subscription, chageType);
+            subscriptionStore.createDisconnectOrRemoveLocalSubscription(subscription, changeType);
         } catch (SubscriptionAlreadyExistsException ignore) {
             // never thrown for close local subscription
         }
-        notifyLocalSubscriptionHasChanged(subscription, chageType);
+        notifyLocalSubscriptionHasChanged(subscription, changeType);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesSubscriptionManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesSubscriptionManager.java
@@ -128,6 +128,7 @@ public class AndesSubscriptionManager {
      */
     public void closeAllLocalSubscriptionsOfNode() throws AndesException {
 
+        log.info("Closing all existing local subscriptions.");
         List<LocalSubscription> activeSubscriptions = subscriptionStore.getActiveLocalSubscribers(true);
         activeSubscriptions.addAll(subscriptionStore.getActiveLocalSubscribers(false));
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -632,7 +632,6 @@ public class MessagingEngine {
             MBThriftClient.setReconnectingFlag(false);
         }
         SlotMessageCounter.getInstance().stop();
-        log.info("Stopping Disruptor workers from delivering messages to store.");
     }
 
     /**
@@ -644,6 +643,10 @@ public class MessagingEngine {
         stopMessageDelivery();
         stopMessageExpirationWorker();
 
+        completePendingStoreOperations();
+    }
+
+    public void completePendingStoreOperations() throws InterruptedException {
         try {
             asyncStoreTasksScheduler.shutdown();
             asyncStoreTasksScheduler.awaitTermination(5, TimeUnit.SECONDS);
@@ -653,11 +656,6 @@ public class MessagingEngine {
             messageStore.close();
             log.warn("Content remover task forcefully shutdown.");
             throw e;
-        }
-
-        //Stop Slot manager in coordinator
-        if (AndesContext.getInstance().isClusteringEnabled() && AndesContext.getInstance().getClusteringAgent().isCoordinator()) {
-            ClusterResourceHolder.getInstance().getClusterManager().getSlotManager().shutDownSlotManager();
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -635,6 +635,10 @@ public class MessagingEngine {
         log.info("Stopping Disruptor workers from delivering messages to store.");
     }
 
+    /**
+     * Properly shutdown all messaging related operations / tasks
+     * @throws InterruptedException
+     */
     public void close() throws InterruptedException {
 
         stopMessageDelivery();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/OrphanedMessageHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/OrphanedMessageHandler.java
@@ -90,9 +90,6 @@ public class OrphanedMessageHandler implements SubscriptionListener {
                     String subscribedDestination = localSubscription.getSubscribedDestination();
                     if(!subscriptionManager.checkIfActiveNonDurableLocalSubscriptionExistsForTopic
                             (subscribedDestination)) {
-                        if(log.isDebugEnabled()) {
-                            log.debug("Purging messages of this node persisted under " + subscribedDestination);
-                        }
                         log.info("Purging messages of this node persisted under " + subscribedDestination);
                         removeMessagesOfDestinationForNode(subscribedDestination,null,true);
                     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/DisruptorBasedInboundEventManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/DisruptorBasedInboundEventManager.java
@@ -209,8 +209,8 @@ public class DisruptorBasedInboundEventManager implements InboundEventManager {
             }
         }
     }
-    
-   /**
+
+    /**
      * Utility to get the in bound ring guage
      */
     private class InBoundRingGauge implements Gauge<Long> {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundSubscriptionEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundSubscriptionEvent.java
@@ -128,7 +128,7 @@ public abstract class InboundSubscriptionEvent extends BasicSubscription impleme
         this.subscriptionManager = subscriptionManager;
     }
     
-    public boolean waitForCompletion() throws AndesException, SubscriptionAlreadyExistsException {
+    public boolean waitForCompletion() throws SubscriptionAlreadyExistsException {
         try {
             return future.get();
         } catch (InterruptedException e) {
@@ -137,6 +137,7 @@ public abstract class InboundSubscriptionEvent extends BasicSubscription impleme
             if (e.getCause() instanceof SubscriptionAlreadyExistsException) {
                 throw (SubscriptionAlreadyExistsException) e.getCause();
             } else {
+                // No point in throwing an exception here and disrupting the server. A warning is sufficient.
                 log.warn("Error occurred while processing event '" + eventType  + "' for subscription id "
                         + getSubscriptionID());
             }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundSubscriptionEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundSubscriptionEvent.java
@@ -137,8 +137,8 @@ public abstract class InboundSubscriptionEvent extends BasicSubscription impleme
             if (e.getCause() instanceof SubscriptionAlreadyExistsException) {
                 throw (SubscriptionAlreadyExistsException) e.getCause();
             } else {
-                throw new AndesException("Error occurred while processing event '" + eventType  + "' for subscription id "
-                        + getSubscriptionID() , e);
+                log.warn("Error occurred while processing event '" + eventType  + "' for subscription id "
+                        + getSubscriptionID());
             }
         }
         return false;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
@@ -88,13 +88,6 @@ public class SlotDeliveryWorker extends Thread {
                         if (messageFlusher.getMessageDeliveryInfo(destinationOfMessagesInQueue)
                                 .isMessageBufferFull()) {
 
-                            //If hazelcast is inactive at this moment, we cannot proceed further with the clustered
-                            // data collections. therefore warning and skipping.
-                            if (AndesContext.getInstance().isClusteringEnabled() && !HazelcastAgent.getInstance().isActive()) {
-                                log.warn("Hazelcast instance is not active. Therefore the cluster is non-responsive.");
-                                continue;
-                            }
-
                             long startTime = System.currentTimeMillis();
                             Slot currentSlot = slotCoordinator.getSlot(storageQueueName);
                             currentSlot.setDestinationOfMessagesInSlot(destinationOfMessagesInQueue);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
@@ -88,6 +88,8 @@ public class SlotDeliveryWorker extends Thread {
                         if (messageFlusher.getMessageDeliveryInfo(destinationOfMessagesInQueue)
                                 .isMessageBufferFull()) {
 
+                            //If hazelcast is inactive at this moment, we cannot proceed further with the clustered
+                            // data collections. therefore warning and skipping.
                             if (AndesContext.getInstance().isClusteringEnabled() && !HazelcastAgent.getInstance().isActive()) {
                                 log.warn("Hazelcast instance is not active. Therefore the cluster is non-responsive.");
                                 continue;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.kernel.*;
 import org.wso2.andes.server.ClusterResourceHolder;
+import org.wso2.andes.server.cluster.coordination.hazelcast.HazelcastAgent;
 import org.wso2.andes.subscription.SubscriptionStore;
 
 import java.util.Collection;
@@ -86,6 +87,11 @@ public class SlotDeliveryWorker extends Thread {
                         //Check in memory buffer in MessageFlusher has room
                         if (messageFlusher.getMessageDeliveryInfo(destinationOfMessagesInQueue)
                                 .isMessageBufferFull()) {
+
+                            if (AndesContext.getInstance().isClusteringEnabled() && !HazelcastAgent.getInstance().isActive()) {
+                                log.warn("Hazelcast instance is not active. Therefore the cluster is non-responsive.");
+                                continue;
+                            }
 
                             long startTime = System.currentTimeMillis();
                             Slot currentSlot = slotCoordinator.getSlot(storageQueueName);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotManagerClusterMode.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotManagerClusterMode.java
@@ -177,7 +177,7 @@ public class SlotManagerClusterMode {
         Slot slotToBeAssigned = null;
         TreeSetLongWrapper wrapper = slotIDMap.get(queueName);
         TreeSet<Long> messageIDSet;
-        if (wrapper != null) {
+        if (null != wrapper) {
             messageIDSet = wrapper.getLongTreeSet();
             if (messageIDSet != null && !messageIDSet.isEmpty()) {
 
@@ -230,7 +230,7 @@ public class SlotManagerClusterMode {
 
             TreeSetSlotWrapper unAssignedSlotWrapper = unAssignedSlotMap.get(queueName);
 
-            if (unAssignedSlotWrapper != null) {
+            if (null != unAssignedSlotWrapper) {
                 TreeSet<Slot> slotsFromUnassignedSlotMap = unAssignedSlotWrapper.getSlotTreeSet();
                 if (slotsFromUnassignedSlotMap != null && !slotsFromUnassignedSlotMap.isEmpty()) {
 
@@ -338,7 +338,7 @@ public class SlotManagerClusterMode {
      */
     public void updateMessageID(String queueName, String nodeId, long startMessageIdInTheSlot, long lastMessageIdInTheSlot) {
 
-        if (!AndesKernelBoot.isKernelShuttingDown()) {
+        if (HazelcastAgent.getInstance().isActive()) {
             // Read message Id set for slots from hazelcast
             TreeSet<Long> messageIdSet = new TreeSet<Long>();
             TreeSetLongWrapper wrapper = slotIDMap.get(queueName);
@@ -443,7 +443,7 @@ public class SlotManagerClusterMode {
 
         HashmapStringTreeSetWrapper wrapper = slotAssignmentMap.remove(nodeId);
         HashMap<String, TreeSet<Slot>> queueToSlotMap = null;
-        if (wrapper != null) {
+        if (null != wrapper) {
             queueToSlotMap = wrapper.getStringListHashMap();
         }
         if (queueToSlotMap != null) {
@@ -511,7 +511,7 @@ public class SlotManagerClusterMode {
             synchronized (lockKey.intern()) {
                 HashMap<String, TreeSet<Slot>> queueToSlotMap = null;
                 HashmapStringTreeSetWrapper wrapper = slotAssignmentMap.get(nodeId);
-                if (wrapper != null) {
+                if (null != wrapper) {
                     queueToSlotMap = wrapper.getStringListHashMap();
                 }
                 if (queueToSlotMap != null) {
@@ -562,7 +562,7 @@ public class SlotManagerClusterMode {
     public void reAssignSlotWhenNoSubscribers(String nodeId, String queueName) {
 
         // Hazelcast could be shut down before hitting this method in case of a server shutdown event. Therefore the check.
-        if (AndesContext.getInstance().isClusteringEnabled() && HazelcastAgent.getInstance().isActive()) {
+        if (HazelcastAgent.getInstance().isActive()) {
             TreeSet<Slot> assignedSlotList = null;
             String lockKeyForNodeId = nodeId + SlotManagerClusterMode.class;
             synchronized (lockKeyForNodeId.intern()) {
@@ -571,7 +571,7 @@ public class SlotManagerClusterMode {
                 //and set back
                 HashmapStringTreeSetWrapper wrapper = slotAssignmentMap.get(nodeId);
                 HashMap<String, TreeSet<Slot>> queueToSlotMap = null;
-                if (wrapper != null) {
+                if (null != wrapper) {
                     queueToSlotMap = wrapper.getStringListHashMap();
                 }
                 if (queueToSlotMap != null) {
@@ -589,7 +589,7 @@ public class SlotManagerClusterMode {
                 //set back
                 HashmapStringTreeSetWrapper overlappedSlotWrapper = overLappedSlotMap.get(nodeId);
                 HashMap<String, TreeSet<Slot>> queueToOverlappedSlotMap = null;
-                if (overlappedSlotWrapper != null) {
+                if (null != overlappedSlotWrapper) {
                     queueToOverlappedSlotMap = overlappedSlotWrapper.getStringListHashMap();
                 }
                 if (queueToOverlappedSlotMap != null) {
@@ -613,7 +613,7 @@ public class SlotManagerClusterMode {
                     TreeSetSlotWrapper treeSetStringWrapper = unAssignedSlotMap.get(queueName);
 
                     TreeSet<Slot> unAssignedSlotSet = new TreeSet<Slot>();
-                    if (treeSetStringWrapper != null) {
+                    if (null != treeSetStringWrapper) {
                         unAssignedSlotSet = treeSetStringWrapper.getSlotTreeSet();
                     } else {
                         treeSetStringWrapper = new TreeSetSlotWrapper();
@@ -707,7 +707,7 @@ public class SlotManagerClusterMode {
                         //clear slot assignment map
                         HashmapStringTreeSetWrapper wrapper = slotAssignmentMap.get(nodeId);
                         HashMap<String, TreeSet<Slot>> queueToSlotMap = null;
-                        if (wrapper != null) {
+                        if (null != wrapper) {
                             queueToSlotMap = wrapper.getStringListHashMap();
                         }
                         if (queueToSlotMap != null) {
@@ -721,7 +721,7 @@ public class SlotManagerClusterMode {
                                 (nodeId);
                         if (null != overlappedSlotsWrapper) {
                             HashMap<String, TreeSet<Slot>> queueToOverlappedSlotMap = null;
-                            if (wrapper != null) {
+                            if (null != wrapper) {
                                 queueToOverlappedSlotMap = overlappedSlotsWrapper.getStringListHashMap();
                             }
                             if (queueToSlotMap != null) {
@@ -785,7 +785,7 @@ public class SlotManagerClusterMode {
                         overLappedSlotMap.set(nodeID, olWrapper);
                     }
 
-                    if (wrapper != null) {
+                    if (null != wrapper) {
                         HashMap<String, TreeSet<Slot>> queueToSlotMap = wrapper.getStringListHashMap();
                         if (queueToSlotMap != null) {
                             TreeSet<Slot> slotListForQueueOnNode = queueToSlotMap.get(queueName);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotManagerStandalone.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotManagerStandalone.java
@@ -40,7 +40,7 @@ public class SlotManagerStandalone {
      */
     private ConcurrentHashMap<String, Long> queueToLastAssignedIDMap;
 
-    private static Log log = LogFactory.getLog(SlotManagerClusterMode.class);
+    private static Log log = LogFactory.getLog(SlotManagerStandalone.class);
 
 
     public SlotManagerStandalone() {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotMessageCounter.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotMessageCounter.java
@@ -196,4 +196,12 @@ public class SlotMessageCounter {
         return slotMessageCounter;
     }
 
+    /**
+     * Shut down worker threads, submitSlotToCoordinatorTimer so that server can shut down properly without unexpected behaviour.
+     */
+    public void stop() {
+        log.info("Stopping slot message counter.");
+        submitSlotToCoordinatorTimer.cancel();
+    }
+
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/Broker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/Broker.java
@@ -23,6 +23,7 @@ import org.apache.log4j.xml.QpidLog4JConfigurator;
 import org.wso2.andes.AMQException;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
+import org.wso2.andes.kernel.Andes;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesKernelBoot;
 import org.wso2.andes.configuration.qpid.ServerConfiguration;
@@ -91,14 +92,7 @@ public class Broker
 
     public void shutdown()
     {
-        /**
-         * shutdown kernel first
-         */
-        try {
-            AndesKernelBoot.shutDownAndesKernel();
-        } catch (AndesException e) {
-            log.error("Error while shutting down andes kernel", e);
-        }
+        Andes.getInstance().shutDown();
     }
 
     public void startup() throws Exception

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/Broker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/Broker.java
@@ -23,6 +23,7 @@ import org.apache.log4j.xml.QpidLog4JConfigurator;
 import org.wso2.andes.AMQException;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
+import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesKernelBoot;
 import org.wso2.andes.configuration.qpid.ServerConfiguration;
 import org.wso2.andes.configuration.qpid.ServerNetworkTransportConfiguration;
@@ -95,10 +96,9 @@ public class Broker
          */
         try {
             AndesKernelBoot.shutDownAndesKernel();
-        } catch (Exception e) {
+        } catch (AndesException e) {
             log.error("Error while shutting down andes kernel", e);
         }
-        ApplicationRegistry.remove();
     }
 
     public void startup() throws Exception
@@ -261,6 +261,7 @@ public class Broker
                     ApplicationRegistry.getInstance().addAcceptor(new InetSocketAddress(bindAddress, port),
                             new QpidAcceptor(transport,"TCP"));
                     CurrentActor.get().message(BrokerMessages.LISTENING("TCP", port));
+
                 }
             }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/ClusterManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/ClusterManager.java
@@ -344,4 +344,8 @@ public class ClusterManager {
         }
         return addresses;
     }
+
+    public SlotManagerClusterMode getSlotManager() {
+        return slotManager;
+    }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/ClusterManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/ClusterManager.java
@@ -80,19 +80,14 @@ public class ClusterManager {
      *
      * @throws Exception
      */
-    public void init() throws Exception {
-        try {
-            if (!AndesContext.getInstance().isClusteringEnabled()) {
-                this.initStandaloneMode();
-                return;
-            }
+    public void init() throws AndesException, UnknownHostException {
 
-            initClusterMode();
-
-        } catch (Exception e) {
-            log.error("Error while initializing the Hazelcast coordination ", e);
-            throw e;
+        if (!AndesContext.getInstance().isClusteringEnabled()) {
+            this.initStandaloneMode();
+            return;
         }
+
+        initClusterMode();
     }
 
     /**
@@ -218,7 +213,7 @@ public class ClusterManager {
      *
      * @throws Exception
      */
-    private void initClusterMode() throws Exception {
+    private void initClusterMode() throws AndesException {
 
         this.hazelcastAgent = HazelcastAgent.getInstance();
         this.nodeId = this.hazelcastAgent.getNodeId();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HazelcastAgent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HazelcastAgent.java
@@ -362,38 +362,54 @@ public class HazelcastAgent {
 
 
     public void notifySubscriptionsChanged(ClusterNotification clusterNotification) {
-        log.debug("Sending GOSSIP: " + clusterNotification.getDescription());
-        this.subscriptionChangedNotifierChannel.publish(clusterNotification);
+        if (this.isActive()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Sending GOSSIP: " + clusterNotification.getDescription());
+            }
+            this.subscriptionChangedNotifierChannel.publish(clusterNotification);
+        }
     }
 
 
     public void notifyQueuesChanged(ClusterNotification clusterNotification) throws AndesException {
-        log.debug("Sending GOSSIP: " + clusterNotification.getDescription());
-        try {
-            this.queueChangedNotifierChannel.publish(clusterNotification);
-        } catch (Exception e) {
-            log.error("Error while sending queue change notification : " + clusterNotification.getEncodedObjectAsString(), e);
-            throw new AndesException("Error while sending queue change notification : " + clusterNotification.getEncodedObjectAsString(), e);
+        if (isActive()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Sending GOSSIP: " + clusterNotification.getDescription());
+            }
+            try {
+                this.queueChangedNotifierChannel.publish(clusterNotification);
+            } catch (Exception e) {
+                log.error("Error while sending queue change notification : " + clusterNotification.getEncodedObjectAsString(), e);
+                throw new AndesException("Error while sending queue change notification : " + clusterNotification.getEncodedObjectAsString(), e);
+            }
         }
     }
 
     public void notifyExchangesChanged(ClusterNotification clusterNotification) throws AndesException {
-        log.debug("Sending GOSSIP: " + clusterNotification.getDescription());
-        try {
-            this.exchangeChangeNotifierChannel.publish(clusterNotification);
-        } catch (Exception e) {
-            log.error("Error while sending exchange change notification" + clusterNotification.getEncodedObjectAsString(), e);
-            throw new AndesException("Error while sending exchange change notification" + clusterNotification.getEncodedObjectAsString(), e);
+        if (isActive()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Sending GOSSIP: " + clusterNotification.getDescription());
+            }
+            try {
+                this.exchangeChangeNotifierChannel.publish(clusterNotification);
+            } catch (Exception e) {
+                log.error("Error while sending exchange change notification" + clusterNotification.getEncodedObjectAsString(), e);
+                throw new AndesException("Error while sending exchange change notification" + clusterNotification.getEncodedObjectAsString(), e);
+            }
         }
     }
 
     public void notifyBindingsChanged(ClusterNotification clusterNotification) throws AndesException {
-        log.debug("GOSSIP: " + clusterNotification.getDescription());
-        try {
-            this.bindingChangeNotifierChannel.publish(clusterNotification);
-        } catch (Exception e) {
-            log.error("Error while sending binding change notification" + clusterNotification.getEncodedObjectAsString(), e);
-            throw new AndesException("Error while sending binding change notification" + clusterNotification.getEncodedObjectAsString(), e);
+        if (isActive()) {
+            if (log.isDebugEnabled()) {
+                log.debug("GOSSIP: " + clusterNotification.getDescription());
+            }
+            try {
+                this.bindingChangeNotifierChannel.publish(clusterNotification);
+            } catch (Exception e) {
+                log.error("Error while sending binding change notification" + clusterNotification.getEncodedObjectAsString(), e);
+                throw new AndesException("Error while sending binding change notification" + clusterNotification.getEncodedObjectAsString(), e);
+            }
         }
     }
 
@@ -477,6 +493,18 @@ public class HazelcastAgent {
 
         if (log.isDebugEnabled()) {
             log.debug("Initialization lock released.");
+        }
+    }
+
+    /**
+     * Method to check if the hazelcast instance has shutdown.
+     * @return boolean
+     */
+    public boolean isActive() {
+        if (null != hazelcastInstance) {
+            return hazelcastInstance.getLifecycleService().isRunning();
+        } else {
+            return false;
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HazelcastAgent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HazelcastAgent.java
@@ -361,55 +361,54 @@ public class HazelcastAgent {
     }
 
 
-    public void notifySubscriptionsChanged(ClusterNotification clusterNotification) {
-        if (this.isActive()) {
-            if (log.isDebugEnabled()) {
-                log.debug("Sending GOSSIP: " + clusterNotification.getDescription());
-            }
-            this.subscriptionChangedNotifierChannel.publish(clusterNotification);
+    public void notifySubscriptionsChanged(ClusterNotification clusterNotification) throws AndesException {
+        if (log.isDebugEnabled()) {
+            log.debug("Sending GOSSIP: " + clusterNotification.getDescription());
         }
+        try {
+            this.subscriptionChangedNotifierChannel.publish(clusterNotification);
+        } catch (Exception ex) {
+            log.error("Error while sending subscription change notification : " + clusterNotification.getEncodedObjectAsString(), ex);
+            throw new AndesException("Error while sending queue change notification : " + clusterNotification.getEncodedObjectAsString(), ex);
+        }
+
     }
 
 
     public void notifyQueuesChanged(ClusterNotification clusterNotification) throws AndesException {
-        if (isActive()) {
-            if (log.isDebugEnabled()) {
-                log.debug("Sending GOSSIP: " + clusterNotification.getDescription());
-            }
-            try {
-                this.queueChangedNotifierChannel.publish(clusterNotification);
-            } catch (Exception e) {
-                log.error("Error while sending queue change notification : " + clusterNotification.getEncodedObjectAsString(), e);
-                throw new AndesException("Error while sending queue change notification : " + clusterNotification.getEncodedObjectAsString(), e);
-            }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Sending GOSSIP: " + clusterNotification.getDescription());
+        }
+        try {
+            this.queueChangedNotifierChannel.publish(clusterNotification);
+        } catch (Exception e) {
+            log.error("Error while sending queue change notification : " + clusterNotification.getEncodedObjectAsString(), e);
+            throw new AndesException("Error while sending queue change notification : " + clusterNotification.getEncodedObjectAsString(), e);
         }
     }
 
     public void notifyExchangesChanged(ClusterNotification clusterNotification) throws AndesException {
-        if (isActive()) {
-            if (log.isDebugEnabled()) {
-                log.debug("Sending GOSSIP: " + clusterNotification.getDescription());
-            }
-            try {
-                this.exchangeChangeNotifierChannel.publish(clusterNotification);
-            } catch (Exception e) {
-                log.error("Error while sending exchange change notification" + clusterNotification.getEncodedObjectAsString(), e);
-                throw new AndesException("Error while sending exchange change notification" + clusterNotification.getEncodedObjectAsString(), e);
-            }
+        if (log.isDebugEnabled()) {
+            log.debug("Sending GOSSIP: " + clusterNotification.getDescription());
+        }
+        try {
+            this.exchangeChangeNotifierChannel.publish(clusterNotification);
+        } catch (Exception e) {
+            log.error("Error while sending exchange change notification" + clusterNotification.getEncodedObjectAsString(), e);
+            throw new AndesException("Error while sending exchange change notification" + clusterNotification.getEncodedObjectAsString(), e);
         }
     }
 
     public void notifyBindingsChanged(ClusterNotification clusterNotification) throws AndesException {
-        if (isActive()) {
-            if (log.isDebugEnabled()) {
-                log.debug("GOSSIP: " + clusterNotification.getDescription());
-            }
-            try {
-                this.bindingChangeNotifierChannel.publish(clusterNotification);
-            } catch (Exception e) {
-                log.error("Error while sending binding change notification" + clusterNotification.getEncodedObjectAsString(), e);
-                throw new AndesException("Error while sending binding change notification" + clusterNotification.getEncodedObjectAsString(), e);
-            }
+        if (log.isDebugEnabled()) {
+            log.debug("GOSSIP: " + clusterNotification.getDescription());
+        }
+        try {
+            this.bindingChangeNotifierChannel.publish(clusterNotification);
+        } catch (Exception e) {
+            log.error("Error while sending binding change notification" + clusterNotification.getEncodedObjectAsString(), e);
+            throw new AndesException("Error while sending binding change notification" + clusterNotification.getEncodedObjectAsString(), e);
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/management/JMXManagedObjectRegistry.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/management/JMXManagedObjectRegistry.java
@@ -36,6 +36,7 @@ import java.rmi.server.RMIServerSocketFactory;
 import java.rmi.server.UnicastRemoteObject;
 import java.util.HashMap;
 
+import javax.management.InstanceNotFoundException;
 import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
@@ -361,7 +362,13 @@ public class JMXManagedObjectRegistry implements ManagedObjectRegistry
     public void unregisterObject(ManagedObject managedObject) throws JMException
     {
         if (_mbeanServer.isRegistered(managedObject.getObjectName())) {
-            _mbeanServer.unregisterMBean(managedObject.getObjectName());
+            try {
+                _mbeanServer.unregisterMBean(managedObject.getObjectName());
+            } catch (InstanceNotFoundException ex) {
+                //Can ignore this since the method is anyway trying to un-register the MBean
+                _log.warn("Could not un-register MBean " + managedObject.getObjectName() + " since it had already been removed.");
+            }
+
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionStore.java
@@ -833,8 +833,10 @@ public class SubscriptionStore {
                 //topic subscription record for all of them. Thus when closing there can be no subscriber
                 //to close in multiple durable topic subscription case
                 if (!allowSharedSubscribers) {
-                    throw new AndesException("There is no active subscriber to close subscribed to " + subscription.
-                            getSubscribedDestination() + " with the queue " + subscription.getTargetQueue());
+                    // We cannot guarantee that the subscription has not been removed before,
+                    // if the server is in shutting down state. No need to throw this exception. Warning is enough.
+                    log.warn("There is no active subscriber to close subscribed to " + subscription
+                            .getSubscribedDestination() + " with the queue " + subscription.getTargetQueue());
                 }
             } else if (hasExternalSubscriptions && type == SubscriptionChange.ADDED) {
                 if (!allowSharedSubscribers) {

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/transport/network/mina/MinaNetworkHandler.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/transport/network/mina/MinaNetworkHandler.java
@@ -39,7 +39,7 @@ import org.wso2.andes.transport.network.NetworkConnection;
 
 public class MinaNetworkHandler extends IoHandlerAdapter
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MinaNetworkHandler.class);
+    private static final Logger log = LoggerFactory.getLogger(MinaNetworkHandler.class);
 
     private ProtocolEngineFactory _factory;
     private SSLContextFactory _sslFactory = null;
@@ -48,7 +48,7 @@ public class MinaNetworkHandler extends IoHandlerAdapter
     static
     {
         boolean directBuffers = Boolean.getBoolean("amqj.enableDirectBuffers");
-        LOGGER.debug("Using " + (directBuffers ? "direct" : "heap") + " buffers");
+        log.debug("Using " + (directBuffers ? "direct" : "heap") + " buffers");
         ByteBuffer.setUseDirectBuffers(directBuffers);
 
         //override the MINA defaults to prevent use of the PooledByteBufferAllocator
@@ -85,20 +85,20 @@ public class MinaNetworkHandler extends IoHandlerAdapter
         ProtocolEngine engine = (ProtocolEngine) ioSession.getAttachment();
         if(engine != null)
         {
-            LOGGER.error("Exception caught by Mina", throwable);
+            log.error("Exception caught by Mina", throwable);
             engine.exception(throwable);
         }
         else
         {
-            LOGGER.error("Exception caught by Mina but without protocol engine to handle it", throwable);
+            log.error("Exception caught by Mina but without protocol engine to handle it", throwable);
         }
     }
 
     public void sessionCreated(IoSession ioSession) throws Exception
     {
-        if(LOGGER.isDebugEnabled())
+        if(log.isDebugEnabled())
         {
-            LOGGER.debug("Created session: " + ioSession.getRemoteAddress());
+            log.debug("Created session: " + ioSession.getRemoteAddress());
         }
 
         SessionUtil.initialize(ioSession);
@@ -127,9 +127,9 @@ public class MinaNetworkHandler extends IoHandlerAdapter
 
     public void sessionClosed(IoSession ioSession) throws Exception
     {
-        if(LOGGER.isDebugEnabled())
+        if(log.isDebugEnabled())
         {
-            LOGGER.debug("closed: " + ioSession.getRemoteAddress());
+            log.debug("closed: " + ioSession.getRemoteAddress());
         }
 
         ProtocolEngine engine = (ProtocolEngine) ioSession.getAttachment();
@@ -139,7 +139,7 @@ public class MinaNetworkHandler extends IoHandlerAdapter
         }
         else
         {
-            LOGGER.error("Unable to close ProtocolEngine as none was present");
+            log.error("Unable to close ProtocolEngine as none was present");
         }
     }
 


### PR DESCRIPTION
Handling exceptions occurring during server shutdown. Utilize Carbon ShutdownEventListener to close any isolated worker threads (e.g. SlotManager).

Handle HazelcastInstanceNotActiveException 