### PR TITLE
Improvement for queue message count in RDBMS message store 

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AMQPConstructStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AMQPConstructStore.java
@@ -31,7 +31,15 @@ import java.util.Map;
  */
 public class AMQPConstructStore {
 
+    /**
+     * Reference to AndesContextStore to manage exchanges/bindings and queues in persistence storage 
+     */
     private AndesContextStore andesContextStore;
+
+    /**
+     * Reference to message store to be used from message count related functionality 
+     */
+    private MessageStore messageStore;
 
     private Map<String, AndesQueue> andesQueues = new HashMap<String, AndesQueue>();
     private Map<String, AndesExchange> andesExchanges = new HashMap<String, AndesExchange>();
@@ -40,8 +48,9 @@ public class AMQPConstructStore {
     private Map<String, Map<String, AndesBinding>> andesBindings = new HashMap<String, Map<String, AndesBinding>>();
 
 
-    public AMQPConstructStore() throws AndesException {
-        andesContextStore = AndesContext.getInstance().getAndesContextStore();
+    public AMQPConstructStore(AndesContextStore contextStore, MessageStore messageStore) throws AndesException {
+        this.andesContextStore = contextStore;
+        this.messageStore = messageStore;
     }
 
     /**
@@ -104,7 +113,7 @@ public class AMQPConstructStore {
         if (isLocal) {
             andesContextStore.storeQueueInformation(queue.queueName, queue.encodeAsString());
             //create a space to keep message counter on this queue
-            andesContextStore.addMessageCounterForQueue(queue.queueName);
+            messageStore.addQueue(queue.queueName);
         }
         andesQueues.put(queue.queueName, queue);
     }
@@ -120,7 +129,7 @@ public class AMQPConstructStore {
         if (isLocal) {
             andesContextStore.deleteQueueInformation(queueName);
             //create the space created to keep message counter on this queue
-            andesContextStore.removeMessageCounterForQueue(queueName);
+            messageStore.removeQueue(queueName);
         }
         andesQueues.remove(queueName);
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextStore.java
@@ -103,7 +103,7 @@ public interface AndesContextStore {
      *
      * @param destinationQueueName name of queue
      */
-    public void addMessageCounterForQueue(String destinationQueueName) throws AndesException;
+    void addMessageCounterForQueue(String destinationQueueName) throws AndesException;
 
     /**
      * Get message count of queue
@@ -111,21 +111,21 @@ public interface AndesContextStore {
      * @param destinationQueueName name of queue
      * @return message count
      */
-    public long getMessageCountForQueue(String destinationQueueName) throws AndesException;
+    long getMessageCountForQueue(String destinationQueueName) throws AndesException;
 
     /**
      * Store level method to reset the message counter of a given queue to 0.
      * @param storageQueueName name of the queue being purged
      * @throws AndesException
      */
-    public void resetMessageCounterForQueue(String storageQueueName) throws AndesException;
+    void resetMessageCounterForQueue(String storageQueueName) throws AndesException;
 
     /**
      * Remove Message counting entry
      *
      * @param destinationQueueName name of queue
      */
-    public void removeMessageCounterForQueue(String destinationQueueName) throws AndesException;
+    void removeMessageCounterForQueue(String destinationQueueName) throws AndesException;
 
 
     /**
@@ -134,7 +134,7 @@ public interface AndesContextStore {
      * @param incrementBy  increment counter by
      * @throws AndesException
      */
-    public void incrementMessageCountForQueue(String destinationQueueName, long incrementBy) throws AndesException;
+    void incrementMessageCountForQueue(String destinationQueueName, long incrementBy) throws AndesException;
 
 
     /**
@@ -144,7 +144,7 @@ public interface AndesContextStore {
      * @param decrementBy          decrement counter by
      * @throws AndesException
      */
-    public void decrementMessageCountForQueue(String destinationQueueName, long decrementBy) throws AndesException;
+    void decrementMessageCountForQueue(String destinationQueueName, long decrementBy) throws AndesException;
 
     /**
      * Store exchange information (amqp)

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageCountFlusher.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageCountFlusher.java
@@ -43,17 +43,17 @@ public class MessageCountFlusher implements Runnable {
     private int messageCountFlushNumberGap;
 
     /**
-     * Reference for AndesContextStore
+     * Used to increment and decrement message counts
      */
-    private AndesContextStore contextStore;
+    private MessageStore messageStore;
 
     /**
      * Creates a message count flusher object to store message counts in store
-     * @param contextStore AndesContextStore
+     * @param messageStore MessageStore
      * @param messageCountFlushNumberGap batch size of the count update for a given queue.
      */
-    public MessageCountFlusher(AndesContextStore contextStore, int messageCountFlushNumberGap) {
-        this.contextStore = contextStore;
+    public MessageCountFlusher(MessageStore messageStore, int messageCountFlushNumberGap) {
+        this.messageStore = messageStore;
         this.messageCountFlushNumberGap = messageCountFlushNumberGap;
         messageCountDifferenceMap = new ConcurrentHashMap<String, AtomicInteger>();
     }
@@ -141,12 +141,12 @@ public class MessageCountFlusher implements Runnable {
                 if(log.isDebugEnabled()) {
                     log.debug("Increment store count by " + count + " for queue " + queueName);
                 }
-                contextStore.incrementMessageCountForQueue(queueName, count);
+                messageStore.incrementMessageCountForQueue(queueName, count);
             } else if (count < 0) {
                 if(log.isDebugEnabled()) {
                     log.debug("Decrement store count by " + count + " for queue " + queueName);
                 }
-                contextStore.incrementMessageCountForQueue(queueName, count);
+                messageStore.incrementMessageCountForQueue(queueName, count);
             }
         } catch (AndesException e) {
             // On error add back the count. Since the operation didn't run correctly. Next call to this method might

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
@@ -36,8 +36,8 @@ public interface MessageStore {
      * @return DurableStoreConnection object created to make the connection to store
      * @throws AndesException
      */
-    public DurableStoreConnection initializeMessageStore(ConfigurationProperties
-                                                                 connectionProperties)
+    public DurableStoreConnection initializeMessageStore(AndesContextStore contextStore,
+                                                         ConfigurationProperties connectionProperties)
             throws AndesException;
 
     /**
@@ -230,6 +230,58 @@ public interface MessageStore {
      * @throws AndesException
      */
     public List<Long> getMessageIDsAddressedToQueue(String storageQueueName) throws AndesException;
+
+    /**
+     * Add message counting entry for queue. queue count is initialised to zero. The counter for
+     * created queue can then be incremented and decremented.
+     * @see this.removeMessageCounterForQueue this.incrementMessageCountForQueue,
+     * this.decrementMessageCountForQueue
+     *
+     * @param storageQueueName name of queue
+     */
+    public void addQueue(String storageQueueName) throws AndesException;
+
+    /**
+     * Get message count of queue
+     *
+     * @param storageQueueName name of queue
+     * @return message count
+     */
+    public long getMessageCountForQueue(String storageQueueName) throws AndesException;
+
+    /**
+     * Store level method to reset the message counter of a given queue to 0.
+     * @param storageQueueName name of the queue being purged
+     * @throws AndesException
+     */
+    public void resetMessageCounterForQueue(String storageQueueName) throws AndesException;
+
+    /**
+     * Remove Message counting entry
+     *
+     * @param storageQueueName name of the queue actually stored in DB
+     */
+    public void removeQueue(String storageQueueName) throws AndesException;
+
+
+    /**
+     * Increment message counter for a queue by a given incrementBy value
+     * @param storageQueueName      name of the queue actually stored in DB
+     * @param incrementBy           increment counter by
+     * @throws AndesException
+     */
+    public void incrementMessageCountForQueue(String storageQueueName, long incrementBy) throws AndesException;
+
+
+    /**
+     * Decrement message counter for a queue
+     *
+     * @param storageQueueName      name of the queue actually stored in DB
+     * @param decrementBy           decrement counter by
+     * @throws AndesException
+     */
+    public void decrementMessageCountForQueue(String storageQueueName, long decrementBy) throws AndesException;
+
 
     /**
      * close the message store

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQBrokerManagerMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQBrokerManagerMBean.java
@@ -249,7 +249,7 @@ public class AMQBrokerManagerMBean extends AMQManagedObject implements ManagedBr
         {
             if (queue != null)
             {
-                //ClusterResourceHolder.getInstance().getCassandraMessageStore().addMessageCounterForQueue(queueName);
+                //ClusterResourceHolder.getInstance().getCassandraMessageStore().addQueue(queueName);
                 throw new JMException("The queue \"" + queueName + "\" already exists.");
             }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cassandra/CQLBasedAndesContextStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cassandra/CQLBasedAndesContextStoreImpl.java
@@ -21,7 +21,6 @@ package org.wso2.andes.store.cassandra;
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.datastax.driver.core.exceptions.QueryExecutionException;
-import com.datastax.driver.core.querybuilder.Assignment;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.schemabuilder.SchemaBuilder;
 import org.wso2.andes.configuration.util.ConfigurationProperties;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -106,6 +106,13 @@ public class RDBMSConstants {
                     RDBMSConstants.QUEUE_NAME + ") " +
                     " VALUES (?)";
 
+    protected static final String PS_ALIAS_FOR_COUNT = "count";
+
+    protected static final String PS_SELECT_QUEUE_MESSAGE_COUNT =
+            "SELECT COUNT(" + QUEUE_ID + ") AS " + PS_ALIAS_FOR_COUNT +
+                    " FROM " + METADATA_TABLE +
+                    " WHERE " + QUEUE_ID + "=?";
+
     protected static final String PS_SELECT_METADATA =
             "SELECT " + METADATA +
                     " FROM " + METADATA_TABLE +

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/h2/H2MemMessageStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/h2/H2MemMessageStoreImpl.java
@@ -21,6 +21,7 @@ package org.wso2.andes.store.rdbms.h2;
 import org.apache.log4j.Logger;
 import org.wso2.andes.configuration.util.ConfigurationProperties;
 import org.wso2.andes.kernel.AndesContext;
+import org.wso2.andes.kernel.AndesContextStore;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.DurableStoreConnection;
 import org.wso2.andes.store.rdbms.RDBMSConnection;
@@ -91,12 +92,14 @@ public class H2MemMessageStoreImpl extends RDBMSMessageStoreImpl {
      * NOTE: connectionProperties are ignored to minimise error in pointing the in memory store
      * to a wrong message store
      *
-     * @param connectionProperties IGNORED
+     * @param contextStore AndesContextStore
+     * @param connectionProperties ConfigurationProperties
      * @return DurableStoreConnection
      * @throws AndesException
      */
     @Override
-    public DurableStoreConnection initializeMessageStore(ConfigurationProperties connectionProperties)
+    public DurableStoreConnection initializeMessageStore(AndesContextStore contextStore, 
+                                                         ConfigurationProperties connectionProperties)
             throws AndesException {
 
         // in memory mode should only run in single node mode
@@ -105,8 +108,8 @@ public class H2MemMessageStoreImpl extends RDBMSMessageStoreImpl {
         }
 
         // use the initialisation logic of JDBC MessageStore
-        DurableStoreConnection durableStoreConnection = super.initializeMessageStore(RDBMSConnection
-                .getInMemoryConnectionProperties());
+        DurableStoreConnection durableStoreConnection = super.initializeMessageStore(
+                contextStore, RDBMSConnection.getInMemoryConnectionProperties());
 
         // Additionally create in memory database tables
         createTables();

--- a/modules/andes-core/broker/src/test/java/org/wso2/andes/store/rdbms/RDBMSMessageStoreImplTest.java
+++ b/modules/andes-core/broker/src/test/java/org/wso2/andes/store/rdbms/RDBMSMessageStoreImplTest.java
@@ -22,10 +22,13 @@ import junit.framework.Assert;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.*;
 import org.wso2.andes.configuration.util.ConfigurationProperties;
+import org.wso2.andes.kernel.AndesContext;
+import org.wso2.andes.kernel.AndesContextStore;
 import org.wso2.andes.kernel.AndesMessageMetadata;
 import org.wso2.andes.kernel.AndesMessagePart;
 import org.wso2.andes.kernel.AndesRemovableMetadata;
 import org.wso2.andes.kernel.MessageStore;
+import org.wso2.andes.store.rdbms.h2.H2MemAndesContextStoreImpl;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
@@ -65,10 +68,12 @@ public class RDBMSMessageStoreImplTest {
     public void setUp() throws Exception {
         createTables();
         messageStore = new RDBMSMessageStoreImpl();
+        AndesContextStore contextStore = new H2MemAndesContextStoreImpl();
         ConfigurationProperties connectionProperties = new ConfigurationProperties();
         connectionProperties.addProperty(RDBMSConstants.PROP_JNDI_LOOKUP_NAME,
                                             RDBMSConstants.H2_MEM_JNDI_LOOKUP_NAME);
-        messageStore.initializeMessageStore(connectionProperties);
+        contextStore.init(connectionProperties);
+        messageStore.initializeMessageStore(contextStore, connectionProperties);
     }
 
     @After


### PR DESCRIPTION
Message count is directly taken from the DB instead of using the `AndesContextStore` message counters when using RDBMS message store

For Cassandra we need counters to keep track of message counts. This is done in `AndesContextStore`. But for RDBMS we can retieve message counts directly through and SQL query without counting separatly through `AndesContextStore`.

JIRA: https://wso2.org/jira/browse/MB-979