### PR TITLE
State event related classes updated

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/AckHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/AckHandler.java
@@ -42,10 +42,10 @@ public class AckHandler implements BatchEventHandler {
     }
 
     @Override
-    public void onEvent(final List<InboundEvent> eventList) throws Exception {
+    public void onEvent(final List<InboundEventContainer> eventList) throws Exception {
         if (log.isTraceEnabled()) {
             StringBuilder messageIDsString = new StringBuilder();
-            for (InboundEvent inboundEvent : eventList) {
+            for (InboundEventContainer inboundEvent : eventList) {
                 messageIDsString.append(inboundEvent.ackData.getMessageID()).append(" , ");
             }
             log.trace(eventList.size() + " messages received : " + messageIDsString);
@@ -67,9 +67,9 @@ public class AckHandler implements BatchEventHandler {
      * all the clients acknowledges)
      * @param eventList inboundEvent list
      */
-    public void ackReceived(final List<InboundEvent> eventList) throws AndesException {
+    public void ackReceived(final List<InboundEventContainer> eventList) throws AndesException {
         List<AndesRemovableMetadata> removableMetadata = new ArrayList<AndesRemovableMetadata>();
-        for (InboundEvent event : eventList) {
+        for (InboundEventContainer event : eventList) {
 
             AndesAckData ack = event.ackData;
             // For topics message is shared. If all acknowledgements are received only we should remove message

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/AndesInboundStateEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/AndesInboundStateEvent.java
@@ -26,65 +26,6 @@ import org.wso2.andes.kernel.AndesException;
 public interface AndesInboundStateEvent {
 
     /**
-     * Supported state events by Andes 
-     */
-    public enum StateEvent {
-        /** Specific client channel close event */
-        CHANNEL_CLOSE_EVENT,
-
-        /** New client connected and client channel is opened event */
-        CHANNEL_OPEN_EVENT,
-
-        /** Stop message delivery in Andes core */
-        STOP_MESSAGE_DELIVERY_EVENT,
-
-        /** Start message delivery in Andes core event */
-        START_MESSAGE_DELIVERY_EVENT,
-
-        /** Shutdown andes broker messaging engine event*/
-        SHUTDOWN_MESSAGING_ENGINE_EVENT,
-
-        /** New local subscription created event */
-        OPEN_SUBSCRIPTION_EVENT,
-
-        /** Close a local subscription event */
-        CLOSE_SUBSCRIPTION_EVENT,
-
-        /** Start expired message deleting task, notification event */
-        START_EXPIRATION_WORKER_EVENT,
-
-        /** Stop expired message deleting task, notification event */
-        STOP_EXPIRATION_WORKER_EVENT,
-
-        /** Queue purging event related event type */
-        QUEUE_PURGE_EVENT,
-        
-        /** Is queue deletable check related event type */
-        IS_QUEUE_DELETABLE_EVENT,
-
-        /** Delete messages event related event type*/
-        DELETE_MESSAGES_EVENT,
-
-        /** Delete the queue from DB related event type */
-        DELETE_QUEUE_EVENT,
-
-        /** Create a queue in Andes related event type */
-        CREATE_QUEUE_EVENT,
-
-        /** Create a binding in Andes related event type */
-        ADD_BINDING_EVENT,
-
-        /** Delete a binding in Andes related event type */
-        REMOVE_BINDING_EVENT, 
-        
-        /** Create exchange in Andes related event type */
-        CREATE_EXCHANGE_EVENT,
-        
-        /** Delete exchange in Andes related event type */
-        DELETE_EXCHANGE_EVENT
-    } 
-    
-    /**
      * Updates Andes internal state according to the inbound event. 
      * Method visibility is package specific. Only StateEventHandler should call this 
      * @throws AndesException
@@ -92,8 +33,9 @@ public interface AndesInboundStateEvent {
     void updateState() throws AndesException;
 
     /**
-     * The state event type handled by the event 
-     * @return StateEvent
+     * Returns a human readable information about the event
+     * @return String
      */
-    StateEvent getEventType();
+    String eventInfo();
+
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/BatchEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/BatchEventHandler.java
@@ -25,5 +25,5 @@ import java.util.List;
  */
 public interface BatchEventHandler {
 
-    void onEvent(final List<InboundEvent> eventList) throws Exception;
+    void onEvent(final List<InboundEventContainer> eventList) throws Exception;
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/ConcurrentBatchEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/ConcurrentBatchEventHandler.java
@@ -33,7 +33,7 @@ import java.util.List;
  * NOTE: Writing a custom batch processor is avoided since it related to implementing disruptor internals related
  * logic which might lead to difficulty in upgrading disruptor versions and getting bug fixes on batch processors 
  */
-public class ConcurrentBatchEventHandler implements EventHandler<InboundEvent> {
+public class ConcurrentBatchEventHandler implements EventHandler<InboundEventContainer> {
 
     private static Log log = LogFactory.getLog(ConcurrentBatchEventHandler.class);
 
@@ -61,12 +61,12 @@ public class ConcurrentBatchEventHandler implements EventHandler<InboundEvent> {
     /**
      * Type of event to do batching
      */
-    private final InboundEvent.Type eventType;
+    private final InboundEventContainer.Type eventType;
 
     /**
      * Events are batched using this until the event handler is called
      */
-    private final List<InboundEvent> eventList;
+    private final List<InboundEventContainer> eventList;
 
     /**
      * Creates an event handler that can be used with a batch processor to do custom batching of inbound
@@ -80,7 +80,7 @@ public class ConcurrentBatchEventHandler implements EventHandler<InboundEvent> {
      * @param eventHandler event handler that does the actual per event, event handling
      */
     public ConcurrentBatchEventHandler(long turn, int groupCount, int batchSize,
-                                       InboundEvent.Type eventType, BatchEventHandler eventHandler) {
+                                       InboundEventContainer.Type eventType, BatchEventHandler eventHandler) {
         
         if (turn >= groupCount) {
             throw new IllegalArgumentException("Turn should be less than groupCount");
@@ -91,7 +91,7 @@ public class ConcurrentBatchEventHandler implements EventHandler<InboundEvent> {
         this.batchSize = batchSize;
         this.eventType = eventType;
         this.eventHandler = eventHandler;
-        eventList = new ArrayList<InboundEvent>(this.batchSize);
+        eventList = new ArrayList<InboundEventContainer>(this.batchSize);
 
     }
 
@@ -101,7 +101,7 @@ public class ConcurrentBatchEventHandler implements EventHandler<InboundEvent> {
      * {@inheritDoc} 
      */
     @Override
-    public void onEvent(InboundEvent event, long sequence, boolean endOfBatch) throws Exception {
+    public void onEvent(InboundEventContainer event, long sequence, boolean endOfBatch) throws Exception {
         long currentTurn;
         
         

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundAndesChannelEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundAndesChannelEvent.java
@@ -25,20 +25,32 @@ import org.wso2.andes.kernel.OnflightMessageTracker;
 
 import java.util.UUID;
 
-import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.StateEvent.CHANNEL_CLOSE_EVENT;
-import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.StateEvent.CHANNEL_OPEN_EVENT;
-
 /**
  * Andes channel related events are published to Disruptor as InboundAndesChannelEvent
  */
 public class InboundAndesChannelEvent implements AndesInboundStateEvent {
 
     private static Log log = LogFactory.getLog(InboundAndesChannelEvent.class);
-    
+
+    /**
+     * Supported state events
+     */
+    public enum EventType {
+        /**
+         * Specific client channel close event
+         */
+        CHANNEL_CLOSE_EVENT,
+
+        /**
+         * New client connected and client channel is opened event
+         */
+        CHANNEL_OPEN_EVENT
+    }
+
     /**
      * Channel event type handle by the event object 
      */
-    private StateEvent eventType;
+    private EventType eventType;
 
     /**
      * Channel ID 
@@ -65,21 +77,21 @@ public class InboundAndesChannelEvent implements AndesInboundStateEvent {
     }
 
     @Override
-    public StateEvent getEventType() {
-        return eventType;
+    public String eventInfo() {
+        return eventType.toString();
     }
 
     /**
      * Update event to a channel open event 
      */
     public void prepareForChannelOpen() {
-        eventType = CHANNEL_OPEN_EVENT;
+        eventType = EventType.CHANNEL_OPEN_EVENT;
     }
 
     /**
      * Update event to a channel close event 
      */
     public void prepareForChannelClose() {
-        eventType = CHANNEL_CLOSE_EVENT;
+        eventType = EventType.CHANNEL_CLOSE_EVENT;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundBindingEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundBindingEvent.java
@@ -25,15 +25,24 @@ import org.wso2.andes.kernel.AndesContextInformationManager;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesQueue;
 
-import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.StateEvent.ADD_BINDING_EVENT;
-import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.StateEvent.REMOVE_BINDING_EVENT;
-
 /**
  * Binding related inbound event 
  */
 public class InboundBindingEvent extends AndesBinding implements AndesInboundStateEvent {
 
     private static Log log = LogFactory.getLog(InboundBindingEvent.class);
+
+    /**
+     * Supported state events
+     */
+    private enum EventType {
+
+        /** Create a binding in Andes related event type */
+        ADD_BINDING_EVENT,
+
+        /** Delete a binding in Andes related event type */
+        REMOVE_BINDING_EVENT,
+    }
 
     /**
      * Reference to AndesContextInformationManager for add/remove binding
@@ -43,12 +52,16 @@ public class InboundBindingEvent extends AndesBinding implements AndesInboundSta
     /**
      * Andes binding related event type of this event 
      */
-    private StateEvent eventType;
+    private EventType eventType;
     
     public InboundBindingEvent(String boundExchangeName, AndesQueue boundQueue, String routingKey) {
         super(boundExchangeName, boundQueue, routingKey);
     }
 
+    /**
+     * {@inheritDoc}
+     * @throws AndesException
+     */
     @Override
     public void updateState() throws AndesException {
         switch (eventType) {
@@ -64,9 +77,12 @@ public class InboundBindingEvent extends AndesBinding implements AndesInboundSta
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public StateEvent getEventType() {
-        return eventType;
+    public String eventInfo() {
+        return eventType.toString();
     }
 
     /**
@@ -75,7 +91,7 @@ public class InboundBindingEvent extends AndesBinding implements AndesInboundSta
      */
     public void prepareForAddBindingEvent(AndesContextInformationManager contextInformationManager) {
         this.contextInformationManager = contextInformationManager;
-        eventType = ADD_BINDING_EVENT;
+        eventType = EventType.ADD_BINDING_EVENT;
     }
 
     /**
@@ -84,6 +100,6 @@ public class InboundBindingEvent extends AndesBinding implements AndesInboundSta
      */
     public void prepareForRemoveBinding(AndesContextInformationManager contextInformationManager) {
         this.contextInformationManager = contextInformationManager;
-        eventType = REMOVE_BINDING_EVENT;
+        eventType = EventType.REMOVE_BINDING_EVENT;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundDeleteMessagesEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundDeleteMessagesEvent.java
@@ -26,19 +26,26 @@ import org.wso2.andes.kernel.MessagingEngine;
 
 import java.util.List;
 
-import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.StateEvent.DELETE_MESSAGES_EVENT;
-
 /**
  * Class to hold information about deleting messages event
  */
 public class InboundDeleteMessagesEvent implements AndesInboundStateEvent {
 
     private static Log log = LogFactory.getLog(InboundDeleteMessagesEvent.class);
-    
+
+    /**
+     * Supported state events
+     */
+    private enum EventType {
+
+        /** Delete messages event related event type*/
+        DELETE_MESSAGES_EVENT,
+
+    }
     /**
      * Type of this event
      */
-    private StateEvent eventType;
+    private EventType eventType;
     
     /**
      * List of messages to remove
@@ -66,6 +73,9 @@ public class InboundDeleteMessagesEvent implements AndesInboundStateEvent {
         this.moveToDLC = moveToDLC;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void updateState() throws AndesException {
         switch (eventType) {
@@ -79,16 +89,19 @@ public class InboundDeleteMessagesEvent implements AndesInboundStateEvent {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String eventInfo() {
+        return eventType.toString();
+    }
+
+    /**
      * Prepare to update Andes state with a delete messages event
      * @param messagingEngine MessagingEngine to be used for this event
      */
     public void prepareForDelete(MessagingEngine messagingEngine) {
-        eventType = DELETE_MESSAGES_EVENT;
+        eventType = EventType.DELETE_MESSAGES_EVENT;
         this.messagingEngine = messagingEngine;
-    }
-
-    @Override
-    public StateEvent getEventType() {
-        return eventType;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundEventContainer.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundEventContainer.java
@@ -21,16 +21,17 @@ package org.wso2.andes.kernel.distruptor.inbound;
 import com.lmax.disruptor.EventFactory;
 import org.wso2.andes.kernel.AndesAckData;
 import org.wso2.andes.kernel.AndesChannel;
+import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesMessage;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * All inbound events are published to disruptor ring buffer as an inboundEvent object
+ * All inbound events are published to disruptor ring buffer as an InboundEventContainer object
  * This class specifies the event type and any data that is relevant to that event.
  */
-public class InboundEvent {
+public class InboundEventContainer {
 
     private AndesChannel channel;
 
@@ -77,7 +78,7 @@ public class InboundEvent {
     }
 
     /**
-     * Specific event type of relevant to this InboundEvent
+     * Specific event type of relevant to this InboundEventContainer
      */
     private Type eventType;
 
@@ -96,10 +97,10 @@ public class InboundEvent {
      */
     public AndesAckData ackData;
 
-    public InboundEvent() {
+    public InboundEventContainer() {
         messageList = new ArrayList<AndesMessage>();
         eventType = Type.IGNORE_EVENT;
-        safeZoneLimit = Long.MAX_VALUE;
+        safeZoneLimit = Long.MIN_VALUE;
 
     }
 
@@ -111,8 +112,8 @@ public class InboundEvent {
         this.eventType = eventType;
     }
 
-    public AndesInboundStateEvent getStateEvent() {
-        return stateEvent;
+    public void updateState() throws AndesException {
+        stateEvent.updateState();
     }
 
     public void setStateEvent(AndesInboundStateEvent stateEvent) {
@@ -131,15 +132,27 @@ public class InboundEvent {
     /**
      * Disruptor uses this factory to populate the ring with inboundEvent objects
      */
-    public static class InboundEventFactory implements EventFactory<InboundEvent> {
+    public static class InboundEventFactory implements EventFactory<InboundEventContainer> {
         @Override
-        public InboundEvent newInstance() {
-            return new InboundEvent() {
+        public InboundEventContainer newInstance() {
+            return new InboundEventContainer() {
             };
         }
     }
 
-    public static EventFactory<InboundEvent> getFactory() {
+    /**
+     * Human readable information of the event
+     * @return brief description of the event
+     */
+    public String eventInfo() {
+        if(eventType == Type.STATE_CHANGE_EVENT) {
+            return stateEvent.eventInfo();
+        } else {
+            return eventType.toString();
+        }
+    }
+
+    public static EventFactory<InboundEventContainer> getFactory() {
         return new InboundEventFactory();
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundExchangeEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundExchangeEvent.java
@@ -24,20 +24,24 @@ import org.wso2.andes.kernel.AndesContextInformationManager;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesExchange;
 
-import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.StateEvent.CREATE_EXCHANGE_EVENT;
-import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.StateEvent.DELETE_EXCHANGE_EVENT;
-
 /**
  * Exchange related inbound event 
  */
 public class InboundExchangeEvent extends AndesExchange implements AndesInboundStateEvent {
 
     private static Log log = LogFactory.getLog(InboundExchangeEvent.class);
-    
+
+    private enum EventType {
+
+        CREATE_EXCHANGE_EVENT,
+
+        DELETE_EXCHANGE_EVENT
+    }
+
     /**
      * Event type this event
      */
-    private StateEvent eventType;
+    private EventType eventType;
 
     /**
      * Reference to AndesContextInformationManager to update create/ remove queue state
@@ -80,8 +84,8 @@ public class InboundExchangeEvent extends AndesExchange implements AndesInboundS
     }
 
     @Override
-    public StateEvent getEventType() {
-        return eventType;
+    public String eventInfo() {
+        return eventType.toString();
     }
 
     /**
@@ -89,7 +93,7 @@ public class InboundExchangeEvent extends AndesExchange implements AndesInboundS
      * @param contextInformationManager AndesContextInformationManager
      */
     public void prepareForCreateExchange(AndesContextInformationManager contextInformationManager) {
-        eventType = CREATE_EXCHANGE_EVENT;
+        eventType = EventType.CREATE_EXCHANGE_EVENT;
         this.contextInformationManager = contextInformationManager;
     }
 
@@ -98,7 +102,7 @@ public class InboundExchangeEvent extends AndesExchange implements AndesInboundS
      * @param contextInformationManager AndesContextInformationManager
      */
     public void prepareForDeleteExchange(AndesContextInformationManager contextInformationManager) {
-        eventType = DELETE_EXCHANGE_EVENT;
+        eventType = EventType.DELETE_EXCHANGE_EVENT;
         this.contextInformationManager = contextInformationManager;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundKernelOpsEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundKernelOpsEvent.java
@@ -28,8 +28,6 @@ import org.wso2.andes.kernel.slot.SlotManagerClusterMode;
 import org.wso2.andes.server.ClusterResourceHolder;
 import org.wso2.andes.server.registry.ApplicationRegistry;
 
-import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.StateEvent.*;
-
 /**
  * Handles events related to basic kernel operations.
  * Starting and shutting down tasks etc 
@@ -37,11 +35,29 @@ import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.St
 public class InboundKernelOpsEvent implements AndesInboundStateEvent {
 
     private static Log log = LogFactory.getLog(InboundKernelOpsEvent.class);
-    
+
+    public enum EventType {
+
+        /** Stop message delivery in Andes core */
+        STOP_MESSAGE_DELIVERY_EVENT,
+
+        /** Start message delivery in Andes core event */
+        START_MESSAGE_DELIVERY_EVENT,
+
+        /** Shutdown andes broker messaging engine event*/
+        SHUTDOWN_MESSAGING_ENGINE_EVENT,
+
+        /** Start expired message deleting task, notification event */
+        START_EXPIRATION_WORKER_EVENT,
+
+        /** Stop expired message deleting task, notification event */
+        STOP_EXPIRATION_WORKER_EVENT
+    }
+
     /**
      * Kernel operation event handled by InboundKernelOpsEvent
      */
-    private StateEvent eventType;
+    private EventType eventType;
 
     /**
      * Reference to MessagingEngine to process kernel events
@@ -70,6 +86,11 @@ public class InboundKernelOpsEvent implements AndesInboundStateEvent {
                 log.error("Event type not set properly " + eventType);
                 break;
         }
+    }
+
+    @Override
+    public String eventInfo() {
+        return eventType.toString();
     }
 
     /**
@@ -124,7 +145,7 @@ public class InboundKernelOpsEvent implements AndesInboundStateEvent {
      * @param messagingEngine MessagingEngine
      */
     public void prepareForStartMessageDelivery(MessagingEngine messagingEngine) {
-        eventType = START_MESSAGE_DELIVERY_EVENT;
+        eventType = EventType.START_MESSAGE_DELIVERY_EVENT;
         this.messagingEngine = messagingEngine;
     }
 
@@ -133,7 +154,7 @@ public class InboundKernelOpsEvent implements AndesInboundStateEvent {
      * @param messagingEngine MessagingEngine
      */
     public void prepareForStopMessageDelivery(MessagingEngine messagingEngine) {
-        eventType = STOP_MESSAGE_DELIVERY_EVENT;
+        eventType = EventType.STOP_MESSAGE_DELIVERY_EVENT;
         this.messagingEngine = messagingEngine;
     }
 
@@ -142,7 +163,7 @@ public class InboundKernelOpsEvent implements AndesInboundStateEvent {
      * @param messagingEngine MessagingEngine
      */
     public void prepareForStartMessageExpirationWorker(MessagingEngine messagingEngine) {
-        eventType = START_EXPIRATION_WORKER_EVENT;
+        eventType = EventType.START_EXPIRATION_WORKER_EVENT;
         this.messagingEngine = messagingEngine;
     }
 
@@ -151,7 +172,7 @@ public class InboundKernelOpsEvent implements AndesInboundStateEvent {
      * @param messagingEngine MessagingEngine
      */
     public void prepareForStopMessageExpirationWorker(MessagingEngine messagingEngine) {
-        eventType = STOP_EXPIRATION_WORKER_EVENT;
+        eventType = EventType.STOP_EXPIRATION_WORKER_EVENT;
         this.messagingEngine = messagingEngine;
     }
 
@@ -160,13 +181,8 @@ public class InboundKernelOpsEvent implements AndesInboundStateEvent {
      * @param messagingEngine MessagingEngine
      */
     public void prepareForShutdownMessagingEngine(MessagingEngine messagingEngine) {
-        eventType = SHUTDOWN_MESSAGING_ENGINE_EVENT;
+        eventType = EventType.SHUTDOWN_MESSAGING_ENGINE_EVENT;
         this.messagingEngine = messagingEngine;
-    }
-
-    @Override
-    public StateEvent getEventType() {
-        return eventType;
     }
 
     private void gracefulShutdown() throws AndesException {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundLogExceptionHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundLogExceptionHandler.java
@@ -33,11 +33,11 @@ public class InboundLogExceptionHandler implements ExceptionHandler {
 
     @Override
     public void handleEventException(Throwable throwable, long sequence, Object object) {
-        InboundEvent event = (InboundEvent) object;
+        InboundEventContainer event = (InboundEventContainer) object;
 
         // NOTE: Event type will be set to IGNORE event type if the exception is coming from StateEventHandler
         String eventType;
-        if (event.getEventType() == InboundEvent.Type.IGNORE_EVENT) {
+        if (event.getEventType() == InboundEventContainer.Type.IGNORE_EVENT) {
             eventType = "";
         } else {
             eventType = "Event type: " + event.getEventType().toString();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundQueueEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundQueueEvent.java
@@ -30,11 +30,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.StateEvent.CREATE_QUEUE_EVENT;
-import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.StateEvent.DELETE_QUEUE_EVENT;
-import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.StateEvent.IS_QUEUE_DELETABLE_EVENT;
-import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.StateEvent.QUEUE_PURGE_EVENT;
-
 /**
  * Queue related inbound events are handled through this method
  */
@@ -43,9 +38,35 @@ public class InboundQueueEvent extends AndesQueue implements AndesInboundStateEv
     private static Log log = LogFactory.getLog(InboundQueueEvent.class);
 
     /**
+     * Supported state events
+     */
+    private enum EventType {
+
+        /**
+         * Queue purging event related event type
+         */
+        QUEUE_PURGE_EVENT,
+
+        /**
+         * Is queue deletable check related event type
+         */
+        IS_QUEUE_DELETABLE_EVENT,
+
+        /**
+         * Delete the queue from DB related event type
+         */
+        DELETE_QUEUE_EVENT,
+
+        /**
+         * Create a queue in Andes related event type
+         */
+        CREATE_QUEUE_EVENT,
+    }
+
+    /**
      * Event type this event
      */
-    private StateEvent eventType;
+    private EventType eventType;
 
     /**
      * Reference to AndesContextInformationManager to update create/ remove queue state
@@ -122,6 +143,11 @@ public class InboundQueueEvent extends AndesQueue implements AndesInboundStateEv
         }
     }
 
+    @Override
+    public String eventInfo() {
+        return eventType.toString();
+    }
+
     private void handleIsQueueDeletableEvent() {
         boolean queueDeletable = false;
         try {
@@ -147,19 +173,13 @@ public class InboundQueueEvent extends AndesQueue implements AndesInboundStateEv
         }
     }
 
-
-    @Override
-    public StateEvent getEventType() {
-        return eventType;
-    }
-
     /**
      * Update the event to a create Queue event
      *
      * @param contextInformationManager AndesContextInformationManager
      */
     public void prepareForCreateQueue(AndesContextInformationManager contextInformationManager) {
-        eventType = CREATE_QUEUE_EVENT;
+        eventType = EventType.CREATE_QUEUE_EVENT;
         this.contextInformationManager = contextInformationManager;
     }
 
@@ -169,7 +189,7 @@ public class InboundQueueEvent extends AndesQueue implements AndesInboundStateEv
      * @param contextInformationManager AndesContextInformationManager
      */
     public void prepareForDeleteQueue(AndesContextInformationManager contextInformationManager) {
-        eventType = DELETE_QUEUE_EVENT;
+        eventType = EventType.DELETE_QUEUE_EVENT;
         this.contextInformationManager = contextInformationManager;
     }
 
@@ -180,7 +200,7 @@ public class InboundQueueEvent extends AndesQueue implements AndesInboundStateEv
      * @param isTopic         is the queue is used to store topic messages
      */
     public void purgeQueue(MessagingEngine messagingEngine, boolean isTopic) {
-        eventType = QUEUE_PURGE_EVENT;
+        eventType = EventType.QUEUE_PURGE_EVENT;
         this.isTopic = isTopic;
         this.messagingEngine = messagingEngine;
     }
@@ -210,7 +230,7 @@ public class InboundQueueEvent extends AndesQueue implements AndesInboundStateEv
      * @param contextInformationManager AndesContextInformationManager
      */
     public void prepareForCheckIfQueueDeletable(AndesContextInformationManager contextInformationManager) {
-        eventType = IS_QUEUE_DELETABLE_EVENT;
+        eventType = EventType.IS_QUEUE_DELETABLE_EVENT;
         this.contextInformationManager = contextInformationManager;
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundSubscriptionEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundSubscriptionEvent.java
@@ -29,9 +29,6 @@ import org.wso2.andes.subscription.BasicSubscription;
 
 import java.util.concurrent.ExecutionException;
 
-import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.StateEvent.CLOSE_SUBSCRIPTION_EVENT;
-import static org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent.StateEvent.OPEN_SUBSCRIPTION_EVENT;
-
 /**
  * Class to hold information relevant to open and close subscription
  */
@@ -40,9 +37,26 @@ public abstract class InboundSubscriptionEvent extends BasicSubscription impleme
     private static Log log = LogFactory.getLog(InboundSubscriptionEvent.class);
 
     /**
+     * Supported state events
+     */
+    public enum EventType {
+
+        /**
+         * New local subscription created event
+         */
+        OPEN_SUBSCRIPTION_EVENT,
+
+        /**
+         * Close a local subscription event
+         */
+        CLOSE_SUBSCRIPTION_EVENT,
+
+    }
+
+    /**
      * Type of subscription event
      */
-    private StateEvent eventType;
+    private EventType eventType;
 
     /**
      * Reference to subscription manager to update subscription event 
@@ -119,12 +133,12 @@ public abstract class InboundSubscriptionEvent extends BasicSubscription impleme
     }
 
     public void prepareForNewSubscription(AndesSubscriptionManager subscriptionManager) {
-        eventType = OPEN_SUBSCRIPTION_EVENT;
+        eventType = EventType.OPEN_SUBSCRIPTION_EVENT;
         this.subscriptionManager = subscriptionManager;
     }
     
     public void prepareForCloseSubscription(AndesSubscriptionManager subscriptionManager) {
-        eventType = CLOSE_SUBSCRIPTION_EVENT;
+        eventType = EventType.CLOSE_SUBSCRIPTION_EVENT;
         this.subscriptionManager = subscriptionManager;
     }
     
@@ -145,8 +159,11 @@ public abstract class InboundSubscriptionEvent extends BasicSubscription impleme
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public StateEvent getEventType() {
-        return eventType;
+    public String eventInfo() {
+        return eventType.toString();
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/MessageWriter.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/MessageWriter.java
@@ -48,10 +48,10 @@ public class MessageWriter implements BatchEventHandler {
     }
 
     @Override
-    public void onEvent(final List<InboundEvent> eventList) throws Exception {
+    public void onEvent(final List<InboundEventContainer> eventList) throws Exception {
 
         // For topics there may be multiple messages in one event.
-        for (InboundEvent event : eventList) {
+        for (InboundEventContainer event : eventList) {
             messageList.addAll(event.messageList);
         }
 


### PR DESCRIPTION
- Each state change related implementation class has its own state management.
  Removed state information inheritance from AndesInboundStateEvent
  interface.

- InboundEvent class renamed to InboundEventContainer. This works as a
  container not as an event object