### PR TITLE
[MB-703] - Deactivating durable subscription when node is killed.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesSubscription.java
@@ -114,6 +114,12 @@ public interface AndesSubscription {
     public boolean hasExternalSubscriptions();
 
     /**
+     * Sets whether the subscriptions is active or not.
+     * @param hasExternalSubscription true if subscription is active, false otherwise.
+     */
+    public void setHasExternalSubscriptions(boolean hasExternalSubscription);
+
+    /**
      * Set the subscription type to indicate to which protocol this subscription belongs to.
      * @param subscriptionType The subscription type
      */

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/ClusterManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/ClusterManager.java
@@ -118,6 +118,12 @@ public class ClusterManager {
             }
         }
 
+        // Deactivate durable subscriptions belonging to the node
+        ClusterResourceHolder.getInstance().getSubscriptionManager().
+                deactivateClusterDurableSubscriptionsForNodeID(AndesContext.getInstance().getClusteringAgent()
+                                .isCoordinator(),
+                        hazelcastAgent.getIdOfNode(node));
+
         //update thrift coordinator server details
         //  setThriftCoordinatorServerDetails();
     }
@@ -196,8 +202,7 @@ public class ClusterManager {
 
             log.info("Initializing Standalone Mode. Current Node ID:" + this.nodeId);
 
-            andesContextStore.storeNodeDetails(nodeId, (String) AndesConfigurationManager.readValue
-                    (AndesConfiguration.TRANSPORTS_BIND_ADDRESS));
+            andesContextStore.storeNodeDetails(nodeId, (String) AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_BIND_ADDRESS));
         } catch (UnknownHostException e) {
             throw new AndesException("Unable to get the localhost address.", e);
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/SubscriptionManagementInformationMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/SubscriptionManagementInformationMBean.java
@@ -31,19 +31,32 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Class to Handle data for all subscription related UIs
+ * Class to handle data for all subscription related UI functions.
  */
 public class SubscriptionManagementInformationMBean extends AMQManagedObject implements SubscriptionManagementInformation {
 
+    private static final String ALL_WILDCARD = "*";
+
+    /**
+     * Instantiates the MBeans related to subscriptions.
+     *
+     * @throws NotCompliantMBeanException
+     */
     public SubscriptionManagementInformationMBean() throws NotCompliantMBeanException {
         super(SubscriptionManagementInformation.class, SubscriptionManagementInformation.TYPE);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getObjectInstanceName() {
         return SubscriptionManagementInformation.TYPE;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String[] getAllQueueSubscriptions( String isDurable, String isActive) {
         try {
@@ -58,10 +71,10 @@ public class SubscriptionManagementInformationMBean extends AMQManagedObject imp
                 for (AndesSubscription s : subscriptions) {
                     Long pendingMessageCount = MessagingEngine.getInstance().getMessageCountOfQueue(queue);
 
-                    if (!isDurable.equals("*") && (Boolean.parseBoolean(isDurable) != s.isDurable())) {
+                    if (!isDurable.equals(ALL_WILDCARD) && (Boolean.parseBoolean(isDurable) != s.isDurable())) {
                         continue;
                     }
-                    if (!isActive.equals("*") && (Boolean.parseBoolean(isActive) != s.hasExternalSubscriptions())) {
+                    if (!isActive.equals(ALL_WILDCARD) && (Boolean.parseBoolean(isActive) != s.hasExternalSubscriptions())) {
                         continue;
                     }
 
@@ -75,19 +88,15 @@ public class SubscriptionManagementInformationMBean extends AMQManagedObject imp
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String[] getAllTopicSubscriptions(String isDurable, String isActive) {
         try {
-            boolean isDurableTopic;
-            if("false".equals(isDurable)){
-                isDurableTopic = false;
-            } else {
-                isDurableTopic = true;
-            }
             List<String> allSubscriptionsForTopics = new ArrayList<String>();
 
-            List<String> allTopics = AndesContext.getInstance().getSubscriptionStore().getTopics
-                    ();
+            List<String> allTopics = AndesContext.getInstance().getSubscriptionStore().getTopics();
 
             for (String topic : allTopics) {
 
@@ -99,10 +108,10 @@ public class SubscriptionManagementInformationMBean extends AMQManagedObject imp
 
                     Long pendingMessageCount = MessagingEngine.getInstance().getMessageCountOfQueue(s.getTargetQueue());
 
-                    if (!isDurable.equals("*") && (Boolean.parseBoolean(isDurable) != s.isDurable())) {
+                    if (!isDurable.equals(ALL_WILDCARD) && (Boolean.parseBoolean(isDurable) != s.isDurable())) {
                         continue;
                     }
-                    if (!isActive.equals("*") && (Boolean.parseBoolean(isActive) != s.hasExternalSubscriptions())) {
+                    if (!isActive.equals(ALL_WILDCARD) && (Boolean.parseBoolean(isActive) != s.hasExternalSubscriptions())) {
                         continue;
                     } if(!s.isBoundToTopic()){
                         continue;
@@ -118,6 +127,9 @@ public class SubscriptionManagementInformationMBean extends AMQManagedObject imp
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int getMessageCount(String subscribedNode, String msgPattern ,String destinationName) {
         try {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/SubscriptionManagementInformationMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/SubscriptionManagementInformationMBean.java
@@ -87,7 +87,7 @@ public class SubscriptionManagementInformationMBean extends AMQManagedObject imp
             List<String> allSubscriptionsForTopics = new ArrayList<String>();
 
             List<String> allTopics = AndesContext.getInstance().getSubscriptionStore().getTopics
-                    (isDurableTopic);
+                    ();
 
             for (String topic : allTopics) {
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/BasicSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/BasicSubscription.java
@@ -293,7 +293,7 @@ public class BasicSubscription implements AndesSubscription {
      */
     @Override
     public void setHasExternalSubscriptions(boolean hasExternalSubscription) {
-        hasExternalSubscriptions = hasExternalSubscription;
+        this.hasExternalSubscriptions = hasExternalSubscription;
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/BasicSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/BasicSubscription.java
@@ -158,6 +158,7 @@ public class BasicSubscription implements AndesSubscription {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void setSubscriptionType(SubscriptionType subscriptionType) {
         this.subscriptionType = subscriptionType;
     }
@@ -165,10 +166,14 @@ public class BasicSubscription implements AndesSubscription {
     /**
      * {@inheritDoc}
      */
+    @Override
     public SubscriptionType getSubscriptionType() {
         return subscriptionType;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getSubscriptionID() {
         return subscriptionID;
@@ -179,88 +184,143 @@ public class BasicSubscription implements AndesSubscription {
         return destination;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isBoundToTopic() {
         return isBoundToTopic;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isDurable() {
         return isDurable;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getSubscribedNode() {
         return subscribedNode;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public long getSubscribeTime() {
         return subscribeTime;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public boolean isExclusive() {
         return isExclusive;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setExclusive(boolean isExclusive) {
         this.isExclusive = isExclusive;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String getTargetQueue() {
         return targetQueue;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String getStorageQueueName() {
         return storageQueueName;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getTargetQueueOwner() {
         return targetQueueOwner;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getTargetQueueBoundExchangeName() {
         return targetQueueBoundExchange;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getTargetQueueBoundExchangeType() {
         return targetQueueBoundExchangeType;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Short ifTargetQueueBoundExchangeAutoDeletable() {
         return isTargetQueueBoundExchangeAutoDeletable;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean hasExternalSubscriptions() {
         return hasExternalSubscriptions;
     }
 
-
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public String toString() {
-        StringBuffer buf = new StringBuffer();
-        buf.append("[").append(destination)
-                .append("]ID=").append(subscriptionID)
-                .append("@").append(subscribedNode)
-                .append("/T=").append(subscribeTime)
-                .append("/D=").append(isDurable)
-                .append("/X=").append(isExclusive)
-                .append("/O=").append(targetQueueOwner)
-                .append("/E=").append(targetQueueBoundExchange)
-                .append("/ET=").append(targetQueueBoundExchangeType)
-                .append("/EUD=").append(isTargetQueueBoundExchangeAutoDeletable)
-                .append("/S=").append(hasExternalSubscriptions);
-        return buf.toString();
+    public void setHasExternalSubscriptions(boolean hasExternalSubscription) {
+        hasExternalSubscriptions = hasExternalSubscription;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "[" + destination +
+               "]ID=" + subscriptionID +
+               "@" + subscribedNode +
+               "/T=" + subscribeTime +
+               "/D=" + isDurable +
+               "/X=" + isExclusive +
+               "/O=" + targetQueueOwner
+               + "/E=" + targetQueueBoundExchange +
+               "/ET=" + targetQueueBoundExchangeType +
+               "/EUD=" + isTargetQueueBoundExchangeAutoDeletable +
+               "/S=" + hasExternalSubscriptions;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String encodeAsStr() {
-        StringBuffer buf = new StringBuffer();
-        buf.append("subscriptionID=").append(subscriptionID)
+        StringBuilder builder = new StringBuilder();
+        builder.append("subscriptionID=").append(subscriptionID)
                 .append(",destination=").append(destination)
                 .append(",isBoundToTopic=").append(isBoundToTopic)
                 .append(",isExclusive=").append(isExclusive)
@@ -275,12 +335,15 @@ public class BasicSubscription implements AndesSubscription {
                 .append(",hasExternalSubscriptions=").append(hasExternalSubscriptions);
 
         if (subscriptionType != null) {
-            buf.append(",subscriptionType=").append(subscriptionType);
+            builder.append(",subscriptionType=").append(subscriptionType);
         }
 
-        return buf.toString();
+        return builder.toString();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public boolean equals(Object o) {
         if (o instanceof BasicSubscription) {
             BasicSubscription c = (BasicSubscription) o;
@@ -294,6 +357,9 @@ public class BasicSubscription implements AndesSubscription {
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public int hashCode() {
         return new HashCodeBuilder(17, 31).
                 append(subscriptionID).
@@ -309,11 +375,10 @@ public class BasicSubscription implements AndesSubscription {
     private void setStorageQueueName() {
         if (isBoundToTopic && !isDurable) {  // for normal topic subscriptions
             storageQueueName = AndesUtils.getStorageQueueForDestination(destination, subscribedNode, true);
-        } else if (isBoundToTopic && isDurable) {  //for durable topic subscriptions
+        } else if (isBoundToTopic) {  //for durable topic subscriptions
             storageQueueName = AndesUtils.getStorageQueueForDestination(targetQueue, subscribedNode, false);
         } else { //For queue subscriptions. This is a must. Otherwise queue will not be shared among nodes
             storageQueueName = AndesUtils.getStorageQueueForDestination(targetQueue, subscribedNode, false);
         }
     }
-
 }


### PR DESCRIPTION
The PR contains a fix for durable topics when it comes to fail-over. When a node is killed, the durable subscription is kept active by "hasExternalSubscriber" being true, therefore when the fail-over subscriber attempts to reconnect, it mentions that the subscriber is active.

JIRA - https://wso2.org/jira/browse/MB-703