### PR TITLE
Andes kernel operations converted to blocking calls

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -231,10 +231,11 @@ public class Andes {
      * Shut down Andes.
      * NOTE: This is package specific. We don't need access outside from kernel for this task
      */
-    public void shutDown() {
+    public void shutDown() throws AndesException{
         InboundKernelOpsEvent kernelOpsEvent = new InboundKernelOpsEvent();
         kernelOpsEvent.prepareForShutdownMessagingEngine(messagingEngine);
         inboundEventManager.publishStateEvent(kernelOpsEvent);
+        kernelOpsEvent.waitForTaskCompletion();
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/Broker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/Broker.java
@@ -92,7 +92,7 @@ public class Broker
         }
     }
 
-    public void shutdown()
+    public void shutdown() throws AndesException
     {
         Andes.getInstance().shutDown();
     }

--- a/modules/andes-core/systests/src/main/java/org/wso2/andes/test/utils/InternalBrokerHolder.java
+++ b/modules/andes-core/systests/src/main/java/org/wso2/andes/test/utils/InternalBrokerHolder.java
@@ -21,6 +21,7 @@
 package org.wso2.andes.test.utils;
 
 import org.apache.log4j.Logger;
+import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.server.Broker;
 
 public class InternalBrokerHolder implements BrokerHolder
@@ -42,8 +43,12 @@ public class InternalBrokerHolder implements BrokerHolder
     {
         LOGGER.info("Shutting down Broker instance");
 
-        _broker.shutdown();
-        
+        try {
+            _broker.shutdown();
+        } catch (AndesException e) {
+            LOGGER.error("Error occurred while shutting down", e);
+        }
+
         LOGGER.info("Broker instance shutdown");
     }
 


### PR DESCRIPTION
Kernel operations such as shutdown Andes, shutdown message delivery can be done in a blocking manner with this fix

Jiras 
- https://wso2.org/jira/browse/MB-1021
- https://wso2.org/jira/browse/MB-1020
