### PR TITLE
Transaction support for Andes

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAMQPBridge.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAMQPBridge.java
@@ -24,13 +24,13 @@ import org.wso2.andes.AMQException;
 import org.wso2.andes.AMQInternalException;
 import org.wso2.andes.exchange.ExchangeDefaults;
 import org.wso2.andes.framing.AMQShortString;
-import org.wso2.andes.framing.FieldTable;
 import org.wso2.andes.framing.abstraction.ContentChunk;
 import org.wso2.andes.kernel.*;
 import org.wso2.andes.kernel.distruptor.inbound.InboundBindingEvent;
 import org.wso2.andes.kernel.distruptor.inbound.InboundExchangeEvent;
 import org.wso2.andes.kernel.distruptor.inbound.InboundQueueEvent;
 import org.wso2.andes.kernel.distruptor.inbound.InboundSubscriptionEvent;
+import org.wso2.andes.kernel.distruptor.inbound.InboundTransactionEvent;
 import org.wso2.andes.kernel.distruptor.inbound.PubAckHandler;
 import org.wso2.andes.protocol.AMQConstant;
 import org.wso2.andes.server.AMQChannel;
@@ -39,20 +39,22 @@ import org.wso2.andes.server.exchange.Exchange;
 import org.wso2.andes.server.message.AMQMessage;
 import org.wso2.andes.server.queue.AMQQueue;
 import org.wso2.andes.server.queue.IncomingMessage;
-import org.wso2.andes.server.stats.PerformanceCounter;
 import org.wso2.andes.server.store.StorableMessageMetaData;
 import org.wso2.andes.server.subscription.Subscription;
 import org.wso2.andes.server.subscription.SubscriptionImpl;
-import org.wso2.andes.server.virtualhost.VirtualHost;
 
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
+/**
+ * Class is not instantiable from outside. This is a used as a bridge between Qpid and
+ * Andes. And the class doesn't store any state information hence the methods are made static
+ */
 public class QpidAMQPBridge {
 
     private static Log log = LogFactory.getLog(QpidAMQPBridge.class);
-    private static QpidAMQPBridge qpidAMQPBridge = null;
+
     /**
      * Following used by a performance counter
      */
@@ -62,37 +64,31 @@ public class QpidAMQPBridge {
     /**
      * Ignore pub acknowledgements in AMQP. AMQP doesn't have pub acks
      */
-    private PubAckHandler pubAckHandler;
+    private static PubAckHandler pubAckHandler;
 
     static {
-        qpidAMQPBridge = new QpidAMQPBridge();
-    }
-    /**
-     * get QpidAMQPBridge instance
-     *
-     * @return QpidAMQPBridge instance
-     */
-    public static QpidAMQPBridge getInstance() {
-        return qpidAMQPBridge;
+        pubAckHandler = new DisablePubAckImpl();
     }
 
     /**
-     * Create a QpidAMQPBridge instance with disabled publisher ack implementation
+     * Class is not instantiable from outside. This is a used as a bridge between Qpid and
+     * Andes. And the class doesn't store any state information
      */
     private QpidAMQPBridge() {
-        pubAckHandler = new DisablePubAckImpl();
     }
 
     /**
      * message metadata received from AMQP transport.
      * This should happen after all content chunks are received
      *
-     * @param incomingMessage message coming in
-     * @param channelID       id of the channel
-     * @param andesChannel    AndesChannel
+     * @param incomingMessage  message coming in
+     * @param channelID        id of the channel
+     * @param andesChannel     AndesChannel
+     * @param transactionEvent not null if this is a message in a transaction, null otherwise
      * @throws AMQException
      */
-    public void messageReceived(IncomingMessage incomingMessage, UUID channelID, AndesChannel andesChannel) throws AMQException {
+    public static void messageReceived(IncomingMessage incomingMessage, UUID channelID,
+                                AndesChannel andesChannel, InboundTransactionEvent transactionEvent) throws AMQException {
 
         long receivedTime = System.currentTimeMillis();
         try {
@@ -127,11 +123,12 @@ public class QpidAMQPBridge {
             }
 
             // Handover message to Andes
-            Andes.getInstance().messageReceived(andesMessage, andesChannel, pubAckHandler);
-
-            if(log.isDebugEnabled()) {
-                PerformanceCounter.recordMessageReceived(queue, incomingMessage.getReceivedChunkCount());
+            if(null == transactionEvent) { // not a transaction
+                Andes.getInstance().messageReceived(andesMessage, andesChannel, pubAckHandler);
+            } else { // transaction event
+                transactionEvent.enqueue(andesMessage, andesChannel);
             }
+
         } catch (AndesException e) {
             throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error while storing incoming message metadata", e);
         }
@@ -153,7 +150,7 @@ public class QpidAMQPBridge {
      * @return StorableMessageMetaData
      * @throws AMQException
      */
-    public StorableMessageMetaData getMessageMetaData(long messageID) throws AMQException {
+    public static StorableMessageMetaData getMessageMetaData(long messageID) throws AMQException {
         StorableMessageMetaData metaData;
         try {
             metaData = AMQPUtils.convertAndesMetadataToAMQMetadata
@@ -172,7 +169,7 @@ public class QpidAMQPBridge {
      * @param offsetInMessage chunk offset
      * @param src             Bytebuffer with content bytes
      */
-    public AndesMessagePart messageContentChunkReceived(long messageID, int offsetInMessage, ByteBuffer src) {
+    public static AndesMessagePart messageContentChunkReceived(long messageID, int offsetInMessage, ByteBuffer src) {
 
         if (log.isDebugEnabled()) {
             log.debug("Content Part Received id " + messageID + ", offset " + offsetInMessage);
@@ -199,7 +196,7 @@ public class QpidAMQPBridge {
      * @return written content length
      * @throws AMQException
      */
-    public int getMessageContentChunk(long messageID, int offsetInMessage, ByteBuffer dst) throws AMQException {
+    public static int getMessageContentChunk(long messageID, int offsetInMessage, ByteBuffer dst) throws AMQException {
         int contentLenWritten;
         try {
             contentLenWritten = AMQPUtils.getMessageContentChunkConvertedCorrectly(messageID, offsetInMessage, dst);
@@ -210,7 +207,7 @@ public class QpidAMQPBridge {
         return contentLenWritten;
     }
 
-    public void ackReceived(UUID channelID, long messageID, String routingKey, boolean isTopic)
+    public static void ackReceived(UUID channelID, long messageID, String routingKey, boolean isTopic)
             throws AMQException {
         try {
             if (log.isDebugEnabled()) {
@@ -237,7 +234,7 @@ public class QpidAMQPBridge {
         }
     }
 
-    public void rejectMessage(AMQMessage message, AMQChannel channel) throws AMQException {
+    public static void rejectMessage(AMQMessage message, AMQChannel channel) throws AMQException {
         try {
             AndesMessageMetadata rejectedMessage = AMQPUtils.convertAMQMessageToAndesMetadata(message, channel.getId());
             log.debug("AMQP BRIDGE: rejected message id= " + rejectedMessage.getMessageID() + " channel = " + rejectedMessage.getChannelId());
@@ -255,7 +252,7 @@ public class QpidAMQPBridge {
      * @param queue        qpid queue
      * @throws AMQException
      */
-    public void createAMQPSubscription(Subscription subscription, AMQQueue queue) throws AMQException {
+    public static void createAMQPSubscription(Subscription subscription, AMQQueue queue) throws AMQException {
         try {
             if (log.isDebugEnabled()) {
                 log.debug("AMQP BRIDGE: create AMQP Subscription subID " + subscription.getSubscriptionID() + " from queue "
@@ -289,7 +286,7 @@ public class QpidAMQPBridge {
      * @param subscription qpid subscription
      * @throws AndesException
      */
-    public void closeAMQPSubscription(AMQQueue queue, Subscription subscription) throws AndesException {
+    public static void closeAMQPSubscription(AMQQueue queue, Subscription subscription) throws AndesException {
         if (log.isDebugEnabled()) {
             log.debug("AMQP BRIDGE: close AMQP Subscription subID " + subscription.getSubscriptionID() + " from queue " +
                     queue.getName());
@@ -307,7 +304,7 @@ public class QpidAMQPBridge {
      * @param exchange qpid exchange
      * @throws AMQException
      */
-    public void createExchange(Exchange exchange) throws AMQException {
+    public static void createExchange(Exchange exchange) throws AMQException {
         if (log.isDebugEnabled()) {
             log.debug("AMQP BRIDGE: create Exchange" + exchange.getName());
         }
@@ -326,7 +323,7 @@ public class QpidAMQPBridge {
      * @param exchange qpid exchange
      * @throws AMQException
      */
-    public void deleteExchange(Exchange exchange) throws AMQException {
+    public static void deleteExchange(Exchange exchange) throws AMQException {
         if (log.isDebugEnabled()) {
             log.debug("AMQP BRIDGE: delete Exchange " + exchange.getName());
         }
@@ -344,7 +341,7 @@ public class QpidAMQPBridge {
      * @param queue qpid queue
      * @throws AMQException
      */
-    public void createQueue(AMQQueue queue) throws AMQException {
+    public static void createQueue(AMQQueue queue) throws AMQException {
         if (log.isDebugEnabled()) {
             log.debug("AMQP BRIDGE: create queue: " + queue.getName());
         }
@@ -362,7 +359,7 @@ public class QpidAMQPBridge {
      * @param queue qpid queue
      * @throws AMQException
      */
-    public void deleteQueue(AMQQueue queue) throws AMQException {
+    public static void deleteQueue(AMQQueue queue) throws AMQException {
         if (log.isDebugEnabled()) {
             log.debug("AMQP BRIDGE:  delete queue : " + queue.getName());
         }
@@ -382,11 +379,10 @@ public class QpidAMQPBridge {
      * @param exchange   qpid exchange
      * @param routingKey routing key
      * @param queue      qpid queue
-     * @param args       qpid queue arguments
      * @throws AMQInternalException
      */
-    public void createBinding(Exchange exchange, AMQShortString routingKey,
-                              AMQQueue queue, FieldTable args) throws AMQInternalException {
+    public static void createBinding(Exchange exchange, AMQShortString routingKey,
+                              AMQQueue queue) throws AMQInternalException {
 
         // We ignore default exchange events. Andes doesn't honor creation of AMQ default exchange bindings
         if (exchange.getNameShortString().equals(ExchangeDefaults.DEFAULT_EXCHANGE_NAME)) {
@@ -416,10 +412,9 @@ public class QpidAMQPBridge {
      * remove binding from andes kernel
      *
      * @param binding           qpid binding
-     * @param virtualHost virtualhost binding belongs
      * @throws AndesException
      */
-    public void removeBinding(Binding binding, VirtualHost virtualHost) throws AndesException {
+    public static void removeBinding(Binding binding) throws AndesException {
 
         Exchange exchange = binding.getExchange();
 
@@ -447,7 +442,7 @@ public class QpidAMQPBridge {
      * @param subscription subscription
      * @throws AndesException
      */
-    private void addLocalSubscriptionsForAllBindingsOfQueue(AMQQueue queue, Subscription subscription) throws AndesException, SubscriptionAlreadyExistsException {
+    private static void addLocalSubscriptionsForAllBindingsOfQueue(AMQQueue queue, Subscription subscription) throws AndesException, SubscriptionAlreadyExistsException {
 
         List<Binding> bindingList = queue.getBindings();
         if (bindingList != null && !bindingList.isEmpty()) {
@@ -486,7 +481,7 @@ public class QpidAMQPBridge {
      * @param subscription subscription to remove
      * @throws AndesException
      */
-    private void closeLocalSubscriptionsForAllBindingsOfQueue(AMQQueue queue, Subscription subscription) throws AndesException {
+    private static void closeLocalSubscriptionsForAllBindingsOfQueue(AMQQueue queue, Subscription subscription) throws AndesException {
         List<Binding> bindingList = queue.getBindings();
         if (bindingList != null && !bindingList.isEmpty()) {
             Set<AndesBinding> uniqueBindings = new HashSet<AndesBinding>();
@@ -512,7 +507,7 @@ public class QpidAMQPBridge {
      *
      * @param channelID id of the closed channel
      */
-    public void channelIsClosing(UUID channelID) {
+    public static void channelIsClosing(UUID channelID) {
         Andes.getInstance().clientConnectionClosed(channelID);
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
@@ -48,7 +48,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Class is not instantiable from outside. This is a used as a bridge between Qpid and
+ * Class is not instantiable from outside. This is used as a bridge between Qpid and
  * Andes. And the class doesn't store any state information hence the methods are made static
  */
 public class QpidAndesBridge {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
@@ -51,9 +51,9 @@ import java.util.concurrent.atomic.AtomicLong;
  * Class is not instantiable from outside. This is a used as a bridge between Qpid and
  * Andes. And the class doesn't store any state information hence the methods are made static
  */
-public class QpidAMQPBridge {
+public class QpidAndesBridge {
 
-    private static Log log = LogFactory.getLog(QpidAMQPBridge.class);
+    private static Log log = LogFactory.getLog(QpidAndesBridge.class);
 
     /**
      * Following used by a performance counter
@@ -74,7 +74,7 @@ public class QpidAMQPBridge {
      * Class is not instantiable from outside. This is a used as a bridge between Qpid and
      * Andes. And the class doesn't store any state information
      */
-    private QpidAMQPBridge() {
+    private QpidAndesBridge() {
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -333,6 +333,19 @@ public enum AndesConfiguration implements ConfigurationProperty {
             ("performanceTuning/messageCounter/countUpdateBatchSize", "100", Integer.class),
 
     /**
+     * Number of connections reserved at a given time for transactional DB tasks. Transaction will hold on to
+     * a DB connection until a transaction is committed, rolled back or closed.
+     */
+    DB_CONNECTION_POOL_SIZE_FOR_TRANSACTIONS
+            ("transaction/dbConnectionPoolSize", "10", Integer.class),
+
+    /**
+     * Maximum batch size (Messages) for a transaction. Exceeding this limit will result in a failure in the subsequent
+     * commit request. Default is set to 10MB. Limit is calculated considering the payload of messages
+     */
+    MAX_TRANSACTION_BATCH_SIZE ("transaction/maxBatchSizeInBytes", "10000000", Integer.class),
+
+    /**
      * The number of messages to be handled in a single operation related to browser subscriptions.
      */
     MANAGEMENT_CONSOLE_MESSAGE_BATCH_SIZE_FOR_BROWSER_SUBSCRIPTIONS("managementConsole" +

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -28,6 +28,7 @@ import org.wso2.andes.kernel.distruptor.inbound.InboundExchangeEvent;
 import org.wso2.andes.kernel.distruptor.inbound.InboundKernelOpsEvent;
 import org.wso2.andes.kernel.distruptor.inbound.InboundQueueEvent;
 import org.wso2.andes.kernel.distruptor.inbound.InboundSubscriptionEvent;
+import org.wso2.andes.kernel.distruptor.inbound.InboundTransactionEvent;
 import org.wso2.andes.kernel.distruptor.inbound.PubAckHandler;
 import org.wso2.andes.server.registry.ApplicationRegistry;
 import org.wso2.andes.subscription.SubscriptionStore;
@@ -119,9 +120,9 @@ public class Andes {
         this.contextInformationManager = contextInformationManager;
         this.messagingEngine = messagingEngine;
         this.subscriptionManager = subscriptionManager;
-        
+
         inboundEventManager = InboundEventManagerFactory.createEventManager(subscriptionStore, messagingEngine);
-        
+
         log.info("Andes API initialised.");
     }
 
@@ -534,6 +535,17 @@ public class Andes {
         inboundEventManager.publishStateEvent(queueEvent);
         
         return queueEvent.IsQueueDeletable();
+    }
+
+    /**
+     * Get a new transaction object. This object handles the lifecycle of transactional message publishing.
+     * Once the transactional session is closed this object needs to be closed as well.
+     *
+     * @return InboundTransactionEvent
+     * @throws AndesException
+     */
+    public InboundTransactionEvent newTransaction() throws AndesException {
+        return new InboundTransactionEvent(messagingEngine.newTransaction(), inboundEventManager);
     }
 
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesChannel.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesChannel.java
@@ -18,6 +18,7 @@
 
 package org.wso2.andes.kernel;
 
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -154,7 +155,6 @@ public class AndesChannel {
         unblockLocalChannel();
     }
 
-    
     /**
      * Invoked when error based global flow control is enabled.
      */
@@ -255,5 +255,18 @@ public class AndesChannel {
                 unblockLocalChannel();
             }
         }
+    }
+
+    /**
+     * Get total number of content chunks present in provided message list
+     * @param messages AndesMessage list
+     * @return total message chunks
+     */
+    public static int getTotalChunkCount(List<AndesMessage> messages) {
+        int count = 0;
+        for (AndesMessage message : messages) {
+            count = count + message.getContentChunkList().size();
+        }
+        return count;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DisablePubAckImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DisablePubAckImpl.java
@@ -3,7 +3,11 @@ package org.wso2.andes.kernel;
 import org.wso2.andes.kernel.distruptor.inbound.PubAckHandler;
 
 /**
- * Drops any request to send publisher acknowledgements.
+ * This Implementation of ack handler drops any ack or nack received
+ * from Andes.
+ *
+ * For instance AMQP 0.91 doesn't support publisher acknowledgements. For that use
+ * case publisher acknowledgements can be dropped using this handler
  */
 public class DisablePubAckImpl implements PubAckHandler{
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/InboundEventManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/InboundEventManager.java
@@ -19,6 +19,7 @@
 package org.wso2.andes.kernel;
 
 import org.wso2.andes.kernel.distruptor.inbound.AndesInboundStateEvent;
+import org.wso2.andes.kernel.distruptor.inbound.InboundTransactionEvent;
 import org.wso2.andes.kernel.distruptor.inbound.PubAckHandler;
 
 import java.util.List;
@@ -90,4 +91,23 @@ public interface InboundEventManager {
      * Stop disruptor. This wait until disruptor process pending events in ring buffer.
      */
     public void stop();
+
+    /**
+     * Schedule adding a transaction message after pre processing. This doesn't commit the message to DB
+     *
+     * @param transactionEvent InboundTransactionEvent that is relevant to the message
+     * @param message AndesMessage to be added to the transaction
+     * @param channel AndesChannel
+     */
+    public void processTransactionEnqueue(InboundTransactionEvent transactionEvent, AndesMessage message,
+                                          AndesChannel channel);
+
+    /**
+     * Schedule transaction commit or rollback. Calling this InboundTransactionEvent internal state
+     * should be updated to appropriate event (commit, rollback, close)
+     *
+     * @param transactionEvent InboundTransactionEvent that needs to be committed
+     */
+    public void requestTransactionOperation(InboundTransactionEvent transactionEvent);
+
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
@@ -33,6 +33,39 @@ import java.util.Map;
 public interface MessageStore extends HealthAwareStore{
 
     /**
+     * Message store transaction related class. This class should be used only for a single transaction
+     */
+    public interface AndesTransaction {
+
+        /**
+         * Add message to the transaction object. Need to specifically commit to publish the message.
+         * @param message AndesMessage
+         * @throws AndesException
+         */
+        public void enqueue(AndesMessage message) throws AndesException;
+
+        /**
+         * Commit all enqueued messages. Calling this will publish the messages and persist them in DB.
+         * After this, committed messages will be delivered to subscribers
+         * @throws AndesException
+         */
+        public void commit() throws AndesException;
+
+        /**
+         * All the enqueued messages will be cleared and won't be persisted. All the resources tied to
+         * the transaction object will be released.
+         * @throws AndesException
+         */
+        public void rollback() throws AndesException;
+
+        /**
+         * releases all resources tied to the transaction object.
+         * @throws AndesException
+         */
+        void close() throws AndesException;
+    }
+
+    /**
      * Initialise the MessageStore and returns the DurableStoreConnection used by store
      * @param connectionProperties ConfigurationProperties to be used to create the connection
      * @return DurableStoreConnection object created to make the connection to store
@@ -329,5 +362,11 @@ public interface MessageStore extends HealthAwareStore{
      * close the message store
      */
     public void close();
+
+    /**
+     * For a new Transaction this new transaction object need to be created.
+     * AndesTransaction is then used to do transactional storage of items
+     */
+    public AndesTransaction newTransaction() throws AndesException;
 
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -765,4 +765,21 @@ public class MessagingEngine {
         return new RetainedContent(retainedContentParts, contentSize, messageID);
     }
 
+
+    /**
+     * For transaction based message publishing AndesTransaction should be used
+     *
+     * For each transaction a new Transaction object need to be created and then
+     * publish messages through that
+     *
+     * To persist the messages need to specifically commit the published messages
+     * using the AndesTransaction#commit method. There is also the option to rollback
+     * changes as well using AndesTransaction#rollback
+     *
+     * @return AndesTransaction
+     * @throws AndesException
+     */
+    public MessageStore.AndesTransaction newTransaction() throws AndesException {
+        return messageStore.newTransaction();
+    }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundEventContainer.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundEventContainer.java
@@ -65,6 +65,11 @@ public class InboundEventContainer {
      */
     public PubAckHandler pubAckHandler;
 
+    /**
+     * Andes Transaction related event. Used to handle Andes transactions
+     */
+    public InboundTransactionEvent transactionEvent;
+
     public AndesChannel getChannel() {
         return channel;
     }
@@ -80,6 +85,7 @@ public class InboundEventContainer {
     public long getSafeZoneLimit() {
         return safeZoneLimit;
     }
+
     /**
      * For storing retained messages for topic
      */
@@ -92,6 +98,13 @@ public class InboundEventContainer {
 
         /** Message receive event */
         MESSAGE_EVENT,
+
+        /** Adding a message to transaction event.
+         * This represents batching messages before committing */
+        TRANSACTION_ENQUEUE_EVENT,
+
+        /** Event related to a transaction object */
+        TRANSACTION_EVENT,
 
         /** Message acknowledgement receive event */
         ACKNOWLEDGEMENT_EVENT,
@@ -123,7 +136,16 @@ public class InboundEventContainer {
     }
 
     public void updateState() throws AndesException {
-        stateEvent.updateState();
+        switch (eventType) {
+            case STATE_CHANGE_EVENT:
+                stateEvent.updateState();
+                break;
+            case TRANSACTION_EVENT:
+                transactionEvent.updateState();
+                break;
+            default:
+                break;
+        }
     }
 
     public void setStateEvent(AndesInboundStateEvent stateEvent) {
@@ -140,7 +162,9 @@ public class InboundEventContainer {
         stateEvent = null;
         eventType = Type.IGNORE_EVENT;
         pubAckHandler = null;
+        transactionEvent = null;
     }
+
     /**
      * Disruptor uses this factory to populate the ring with inboundEvent objects
      */

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundTransactionEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/InboundTransactionEvent.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel.distruptor.inbound;
+
+import com.google.common.util.concurrent.SettableFuture;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.AndesChannel;
+import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.kernel.AndesMessage;
+import org.wso2.andes.kernel.AndesMessageMetadata;
+import org.wso2.andes.kernel.InboundEventManager;
+import org.wso2.andes.kernel.MessageStore;
+import org.wso2.andes.kernel.slot.SlotMessageCounter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * This is the Andes transaction event related class. This event object handles
+ * the life cycle of a single transaction coming from the protocol to Andes.
+ */
+public class InboundTransactionEvent {
+
+    private static Log log = LogFactory.getLog(InboundTransactionEvent.class);
+
+    private final MessageStore.AndesTransaction transaction;
+    private final InboundEventManager eventManager;
+    private EventType eventType;
+    private SettableFuture<Boolean> taskCompleted;
+    private final List<AndesMessageMetadata> metadataList;
+
+    /**
+     * Supported state events
+     */
+    private enum EventType {
+
+        /** Transaction commit related event type */
+        TX_COMMIT_EVENT,
+
+        /** Transaction rollback related event type */
+        TX_ROLLBACK_EVENT,
+
+        /** Transaction message enqueue related event type */
+        TX_ENQUEUE_EVENT,
+
+        /** close the current transaction and release all resources */
+        TX_CLOSE_EVENT
+    }
+
+    /**
+     * Transaction object to do a transaction
+     * @param transaction AndesTransaction
+     * @param eventManager InboundEventManager
+     */
+    public InboundTransactionEvent(MessageStore.AndesTransaction transaction, InboundEventManager eventManager) {
+        this.transaction = transaction;
+        this.eventManager = eventManager;
+        metadataList = new ArrayList<AndesMessageMetadata>();
+        taskCompleted = SettableFuture.create();
+    }
+
+    /**
+     * This will commit the batched transacted message to the persistence storage using Andes
+     * underlying event manager.
+     *
+     * This is a blocking call
+     * @throws AndesException
+     */
+    public void commit() throws AndesException {
+        if (log.isDebugEnabled()) {
+            log.debug("Prepare for commit");
+        }
+
+        eventType = EventType.TX_COMMIT_EVENT;
+        taskCompleted = SettableFuture.create();
+
+        // Publish to event manager for processing
+        eventManager.requestTransactionOperation(this);
+        // Make the call blocking
+        waitForCompletion();
+    }
+
+    /**
+     * This will rollback the transaction. This is done using Andes underlying event manager
+     * This is a blocking call.
+     *
+     * @throws AndesException
+     */
+    public void rollback() throws AndesException {
+        if (log.isDebugEnabled()) {
+            log.debug("Prepare for rollback");
+        }
+
+        eventType = EventType.TX_ROLLBACK_EVENT;
+        taskCompleted = SettableFuture.create();
+
+        // Publish to event manager for processing
+        eventManager.requestTransactionOperation(this);
+        // Make the call blocking
+        waitForCompletion();
+    }
+
+    /**
+     * Add a message to a transaction. Added messages will be persisted in DB only when
+     * commit is invoked. Underlying event manager will add the message to the the transaction
+     *
+     * This is a asynchronous call
+     * @param message AndesMessage
+     * @param channel AndesChannel
+     */
+    public void enqueue(AndesMessage message, AndesChannel channel) {
+        eventType = EventType.TX_ENQUEUE_EVENT;
+        eventManager.processTransactionEnqueue(this, message, channel);
+    }
+
+    /**
+     * Release all resources used by transaction object. This should be called when the transactional session is
+     * closed. This is to prevent unwanted resource usage (DB connections etc) after closing
+     * a transactional session.
+     *
+     * @throws AndesException
+     */
+    public void close() throws AndesException {
+        eventType = EventType.TX_CLOSE_EVENT;
+        taskCompleted = SettableFuture.create();
+        eventManager.requestTransactionOperation(this);
+        waitForCompletion();
+    }
+
+    /**
+     * Update internal state of the transaction according to the prepared event of the transaction
+     * This method is call by the state event handler.
+     */
+    void updateState() {
+        switch (eventType) {
+            case TX_COMMIT_EVENT:
+                commitTransactionToDB();
+                break;
+            case TX_ROLLBACK_EVENT:
+                rollbackTransactionFromDB();
+                break;
+            case TX_CLOSE_EVENT:
+                closeTransactionFromDB();
+                break;
+            default:
+                log.debug("Event " + eventType + " ignored.");
+                break;
+        }
+    }
+
+    private void closeTransactionFromDB() {
+        try {
+            transaction.close();
+            metadataList.clear();
+            taskCompleted.set(true);
+        } catch (Throwable t) {
+            // Exception is passed to the the caller of get method of settable future
+            taskCompleted.setException(t);
+            metadataList.clear();
+        }
+    }
+
+    /**
+     * This is only a package specific method only called from Andes underlying event manager.
+     *
+     * @param message AndesMessage
+     * @throws AndesException
+     */
+    void enqueuePreProcessedMessage(AndesMessage message) throws AndesException {
+        transaction.enqueue(message);
+        metadataList.add(message.getMetadata());
+        if (log.isDebugEnabled()) {
+            log.debug("Enqueue message with message id " + message.getMetadata().getMessageID() + " for transaction ");
+        }
+    }
+
+    private void commitTransactionToDB() {
+        try {
+            transaction.commit();
+
+            // update slot information for transaction related messages
+            for(AndesMessageMetadata metadata: metadataList){
+                SlotMessageCounter.getInstance().recordMetadataCountInSlot(metadata);
+            }
+            metadataList.clear();
+            taskCompleted.set(true);
+        } catch (Throwable t) {
+            // Exception is passed to the the caller of get method of settable future
+            taskCompleted.setException(t);
+            metadataList.clear();
+        }
+    }
+
+    private void rollbackTransactionFromDB() {
+        try {
+            transaction.rollback();
+            metadataList.clear();
+            taskCompleted.set(true);
+        } catch (Throwable t) {
+            taskCompleted.setException(t);
+        }
+    }
+
+    private Boolean waitForCompletion() throws AndesException {
+        try {
+            return taskCompleted.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            throw new AndesException("Error occurred while processing transaction event " + eventType, e);
+        }
+        return false;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/MessageWriter.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/MessageWriter.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesMessage;
 import org.wso2.andes.kernel.MessagingEngine;
 import org.wso2.andes.kernel.distruptor.BatchEventHandler;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotMessageCounter.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotMessageCounter.java
@@ -117,20 +117,28 @@ public class SlotMessageCounter {
     public void recordMetaDataCountInSlot(List<AndesMessage> messageList) {
         //If metadata list is null this method is called from time out thread
         for (AndesMessage message : messageList) {
-            String storageQueueName = message.getMetadata().getStorageQueueName();
-            //If this is the first message to that queue
-            Slot currentSlot;
-            currentSlot = updateQueueToSlotMap(message.getMetadata());
-            if (currentSlot.getMessageCount() >= slotWindowSize) {
-                try {
-                    submitSlot(storageQueueName);
-                } catch (AndesException e) {
+            recordMetadataCountInSlot(message.getMetadata());
+        }
+    }
+
+    /**
+     * Add a new message to the count for the current slot related to a particular queue
+     * @param metadata AndesMessageMetadata
+     */
+    public void recordMetadataCountInSlot(AndesMessageMetadata metadata) {
+        String storageQueueName = metadata.getStorageQueueName();
+        //If this is the first message to that queue
+        Slot currentSlot;
+        currentSlot = updateQueueToSlotMap(metadata);
+        if (currentSlot.getMessageCount() >= slotWindowSize) {
+            try {
+                submitSlot(storageQueueName);
+            } catch (AndesException e) {
                     /*
                     We do not do anything here since this operation will be run by timeout thread also
                      */
-                    log.error("Error occurred while connecting to the thrift coordinator " + e
-                            .getMessage(), e);
-                }
+                log.error("Error occurred while connecting to the thrift coordinator " + e
+                        .getMessage(), e);
             }
         }
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/InMemoryConnector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/InMemoryConnector.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.andes.mqtt.connectors;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.kernel.AndesException;
@@ -26,7 +27,6 @@ import org.wso2.andes.kernel.distruptor.inbound.PubAckHandler;
 import org.wso2.andes.mqtt.MQTTException;
 import org.wso2.andes.mqtt.utils.MQTTUtils;
 import org.wso2.andes.mqtt.MQTTopicManager;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.nio.ByteBuffer;
 import java.util.*;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQBrokerManagerMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQBrokerManagerMBean.java
@@ -27,13 +27,9 @@ import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
 import org.wso2.andes.AMQException;
-import org.wso2.andes.amqp.AMQPUtils;
-import org.wso2.andes.amqp.QpidAMQPBridge;
+import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.framing.AMQShortString;
-import org.wso2.andes.kernel.AndesContext;
-import org.wso2.andes.kernel.MessagingEngine;
 import org.wso2.andes.server.logging.LogMessage;
-import org.wso2.andes.subscription.SubscriptionStore;
 import org.wso2.andes.management.common.mbeans.ManagedBroker;
 import org.wso2.andes.management.common.mbeans.ManagedQueue;
 import org.wso2.andes.management.common.mbeans.annotations.MBeanConstructor;
@@ -182,7 +178,7 @@ public class AMQBrokerManagerMBean extends AMQManagedObject implements ManagedBr
                         _durableConfig.createExchange(exchange);
 
                         //tell Andes kernel to create Exchange
-                        QpidAMQPBridge.createExchange(exchange);
+                        QpidAndesBridge.createExchange(exchange);
                     }
                 }
                 else
@@ -266,7 +262,7 @@ public class AMQBrokerManagerMBean extends AMQManagedObject implements ManagedBr
                 _durableConfig.createQueue(queue);
 
                 //tell Andes kernel to create queue
-                QpidAMQPBridge.createQueue(queue);
+                QpidAndesBridge.createQueue(queue);
             }
 
         }
@@ -313,7 +309,7 @@ public class AMQBrokerManagerMBean extends AMQManagedObject implements ManagedBr
                 }
 
                 //tell Andes kernel to remove queue
-                QpidAMQPBridge.deleteQueue(queue);
+                QpidAndesBridge.deleteQueue(queue);
             } else {
                 _logActor.message( new LogMessage()
                 {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQBrokerManagerMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQBrokerManagerMBean.java
@@ -182,7 +182,7 @@ public class AMQBrokerManagerMBean extends AMQManagedObject implements ManagedBr
                         _durableConfig.createExchange(exchange);
 
                         //tell Andes kernel to create Exchange
-                        QpidAMQPBridge.getInstance().createExchange(exchange);
+                        QpidAMQPBridge.createExchange(exchange);
                     }
                 }
                 else
@@ -266,7 +266,7 @@ public class AMQBrokerManagerMBean extends AMQManagedObject implements ManagedBr
                 _durableConfig.createQueue(queue);
 
                 //tell Andes kernel to create queue
-                QpidAMQPBridge.getInstance().createQueue(queue);
+                QpidAMQPBridge.createQueue(queue);
             }
 
         }
@@ -313,7 +313,7 @@ public class AMQBrokerManagerMBean extends AMQManagedObject implements ManagedBr
                 }
 
                 //tell Andes kernel to remove queue
-                QpidAMQPBridge.getInstance().deleteQueue(queue);
+                QpidAMQPBridge.deleteQueue(queue);
             } else {
                 _logActor.message( new LogMessage()
                 {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
@@ -21,7 +21,7 @@ import org.apache.log4j.Logger;
 import org.wso2.andes.AMQException;
 import org.wso2.andes.AMQSecurityException;
 import org.wso2.andes.amqp.AMQPUtils;
-import org.wso2.andes.amqp.QpidAMQPBridge;
+import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.configuration.qpid.ConfigStore;
 import org.wso2.andes.configuration.qpid.ConfiguredObject;
 import org.wso2.andes.configuration.qpid.ConnectionConfig;
@@ -419,7 +419,7 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
                      * adding metadata and message to global queue
                      * happen here
                      */
-                     QpidAMQPBridge.messageReceived(incomingMessage, getId(), andesChannel, andesTransactionEvent);
+                     QpidAndesBridge.messageReceived(incomingMessage, getId(), andesChannel);
 
                 } catch (Throwable e) {
                     _logger.error("Error processing completed messages, Close the session " + getSessionName(), e);
@@ -530,7 +530,7 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
         try {
             //tell Andes Kernel to register a subscription
             queue.registerSubscription(subscription, exclusive);
-            QpidAMQPBridge.createAMQPSubscription(subscription, queue);
+            QpidAndesBridge.createAMQPSubscription(subscription, queue);
         } catch (AMQException e) {
             _tag2SubscriptionMap.remove(tag);
             throw e;
@@ -625,7 +625,7 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
 
         forgetMessages4Channel();
 
-        QpidAMQPBridge.channelIsClosing(this.getId());
+        QpidAndesBridge.channelIsClosing(this.getId());
         Andes.getInstance().deleteChannel(andesChannel);
 
         if (_managedObject != null) {
@@ -931,7 +931,7 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
                                                                .getExchange()
                                                                .equals(AMQPUtils
                                                                                .TOPIC_EXCHANGE_NAME);
-            QpidAMQPBridge.ackReceived(this.getId(), entry.getMessage().getMessageNumber(),
+            QpidAndesBridge.ackReceived(this.getId(), entry.getMessage().getMessageNumber(),
                     entry.getMessage().getRoutingKey(),
                     isTopic);
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
@@ -419,11 +419,10 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
                      * adding metadata and message to global queue
                      * happen here
                      */
-
-                    QpidAMQPBridge.getInstance().messageReceived(incomingMessage, this.getId(), andesChannel);
+                     QpidAMQPBridge.messageReceived(incomingMessage, getId(), andesChannel, andesTransactionEvent);
 
                 } catch (Throwable e) {
-                    _logger.error("Error processing completed messages, we will close this session", e);
+                    _logger.error("Error processing completed messages, Close the session " + getSessionName(), e);
                     // We mark the session as closed due to error
                     if (_session instanceof AMQProtocolEngine) {
                         ((AMQProtocolEngine) _session).closeProtocolSession();
@@ -531,7 +530,7 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
         try {
             //tell Andes Kernel to register a subscription
             queue.registerSubscription(subscription, exclusive);
-            QpidAMQPBridge.getInstance().createAMQPSubscription(subscription, queue);
+            QpidAMQPBridge.createAMQPSubscription(subscription, queue);
         } catch (AMQException e) {
             _tag2SubscriptionMap.remove(tag);
             throw e;
@@ -626,7 +625,7 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
 
         forgetMessages4Channel();
 
-        QpidAMQPBridge.getInstance().channelIsClosing(this.getId());
+        QpidAMQPBridge.channelIsClosing(this.getId());
         Andes.getInstance().deleteChannel(andesChannel);
 
         if (_managedObject != null) {
@@ -932,10 +931,9 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
                                                                .getExchange()
                                                                .equals(AMQPUtils
                                                                                .TOPIC_EXCHANGE_NAME);
-            QpidAMQPBridge.getInstance()
-                          .ackReceived(this.getId(), entry.getMessage().getMessageNumber(),
-                                       entry.getMessage().getRoutingKey(),
-                                       isTopic);
+            QpidAMQPBridge.ackReceived(this.getId(), entry.getMessage().getMessageNumber(),
+                    entry.getMessage().getRoutingKey(),
+                    isTopic);
         }
 
         updateTransactionalActivity();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
@@ -41,6 +41,7 @@ import org.wso2.andes.kernel.AndesChannel;
 import org.wso2.andes.kernel.AndesContext;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.FlowControlListener;
+import org.wso2.andes.kernel.distruptor.inbound.InboundTransactionEvent;
 import org.wso2.andes.server.queue.AMQQueue;
 import org.wso2.andes.server.queue.BaseQueue;
 import org.wso2.andes.server.queue.DLCQueueUtils;
@@ -124,7 +125,7 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
      */
     private AtomicLong _deliveryTag = new AtomicLong(0);
 
-    /** A channel has a default queue (the last declared) that is used when no queue name is explictily set */
+    /** A channel has a default queue (the last declared) that is used when no queue name is explicitly set */
     private AMQQueue _defaultQueue;
 
     /** This tag is unique per subscription to a queue. The server returns this in response to a basic.consume request. */
@@ -150,6 +151,17 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
     private final AtomicBoolean _suspended = new AtomicBoolean(false);
 
     private ServerTransaction _transaction;
+
+    /**
+     * This transaction object handles incoming transactional messages (not acknowledgments)
+     * to Andes core
+     */
+    private InboundTransactionEvent andesTransactionEvent;
+
+    /**
+     * This specifies the beginning of a transaction initiated by a select command
+     */
+    private boolean beginTransaction;
 
     private final AtomicLong _txnStarts = new AtomicLong(0);
     private final AtomicLong _txnCommits = new AtomicLong(0);
@@ -197,6 +209,7 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
 
         // message tracking related to this channel is initialised
         Andes.getInstance().clientConnectionCreated(_id);
+        beginTransaction = false;
         andesChannel = Andes.getInstance().createChannel(new FlowControlListener() {
             @Override
             public void block() {
@@ -227,10 +240,10 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
     }
 
     /** Sets this channel to be part of a local transaction */
-    public void setLocalTransactional()
-    {
+    public void setLocalTransactional() throws AMQException {
         _transaction = new LocalTransaction(_messageStore);
         _txnStarts.incrementAndGet();
+        beginTransaction = true;
     }
 
     public boolean isTransactional()
@@ -339,19 +352,6 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
 
             routeCurrentMessage();
 
-            _transaction.addPostTransactionAction(new ServerTransaction.Action()
-            {
-
-                public void postCommit()
-                {
-                }
-
-                public void onRollback()
-                {
-                    handle.remove();
-                }
-            });
-
             deliverCurrentMessageIfComplete();
         }
     }
@@ -412,14 +412,18 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
                 final IncomingMessage incomingMessage = _currentMessage;
 
                 try {
-                    /**
+                    /*
                      * All we have to do is to write content, metadata,
                      * and add the message id to the global queue
                      * Content are already added to the same work queue
                      * adding metadata and message to global queue
                      * happen here
                      */
-                     QpidAndesBridge.messageReceived(incomingMessage, getId(), andesChannel);
+                    if (beginTransaction) {
+                        andesTransactionEvent = Andes.getInstance().newTransaction();
+                        beginTransaction = false;
+                    }
+                    QpidAndesBridge.messageReceived(incomingMessage, getId(), andesChannel, andesTransactionEvent);
 
                 } catch (Throwable e) {
                     _logger.error("Error processing completed messages, Close the session " + getSessionName(), e);
@@ -601,36 +605,42 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
      */
     public void close() throws AMQException
     {
-        if(!_closing.compareAndSet(false, true))
-        {
+        if(!_closing.compareAndSet(false, true)) {
             //Channel is already closing
+            _logger.debug("Channel " + _channelId + " is already closing. Hence dropping close request.");
             return;
         }
 
-        CurrentActor.get().message(_logSubject, ChannelMessages.CLOSE());
+        try {
+            CurrentActor.get().message(_logSubject, ChannelMessages.CLOSE());
 
-        unsubscribeAllConsumers();
-        _transaction.rollback();
+            unsubscribeAllConsumers();
+            _transaction.rollback();
 
-        try
-        {
-            requeue();
+
+            if (null != andesTransactionEvent) {
+                andesTransactionEvent.close();
+            }
+
+            try {
+                requeue();
+            } catch (AMQException e) {
+                _logger.error("Caught AMQException whilst attempting to reque:" + e);
+            }
+
+            getConfigStore().removeConfiguredObject(this);
+
+            forgetMessages4Channel();
+            if (_managedObject != null) {
+                _managedObject.unregister();
+            }
+        } catch (AndesException e) {
+            throw new AMQException("Exception occurred while closing channel " + _channelId, e);
+        } finally {
+            QpidAndesBridge.channelIsClosing(this.getId());
+            Andes.getInstance().deleteChannel(andesChannel);
         }
-        catch (AMQException e)
-        {
-            _logger.error("Caught AMQException whilst attempting to reque:" + e);
-        }
 
-        getConfigStore().removeConfiguredObject(this);
-
-        forgetMessages4Channel();
-
-        QpidAndesBridge.channelIsClosing(this.getId());
-        Andes.getInstance().deleteChannel(andesChannel);
-
-        if (_managedObject != null) {
-            _managedObject.unregister();
-        }
     }
 
     private void unsubscribeAllConsumers() throws AMQException
@@ -1043,7 +1053,14 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
         }
 
         _transaction.commit();
-
+        if(null != andesTransactionEvent) {
+            try {
+                andesTransactionEvent.commit();
+            } catch (AndesException e) {
+                throw new AMQException(AMQConstant.INTERNAL_ERROR,
+                        "Error occurred while committing transaction.", e);
+            }
+        }
         _txnCommits.incrementAndGet();
         _txnStarts.incrementAndGet();
         decrementOutstandingTxnsIfNecessary();
@@ -1070,6 +1087,14 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
         {
             sub.getSendLock();
             sub.releaseSendLock();
+        }
+
+        if(null != andesTransactionEvent) {
+            try {
+                andesTransactionEvent.rollback();
+            } catch (AndesException e) {
+                throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error occurred while rollback ", e);
+            }
         }
 
         try

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/binding/BindingFactory.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/binding/BindingFactory.java
@@ -176,7 +176,7 @@ public class BindingFactory {
 
                 if(isLocal) {
                     //tell Andes kernel to create binding
-                    QpidAMQPBridge.getInstance().createBinding(exchange, new AMQShortString(bindingKey), queue, FieldTable.convertToFieldTable(arguments));
+                    QpidAMQPBridge.createBinding(exchange, new AMQShortString(bindingKey), queue);
                 }
             }
 
@@ -245,7 +245,7 @@ public class BindingFactory {
                 if (binding.isDurable()) {
                     if(isLocal) {
                         //inform andes kernel to remove binding.
-                        QpidAMQPBridge.getInstance().removeBinding(binding, getVirtualHost());
+                        QpidAMQPBridge.removeBinding(binding);
                     }
                     _configSource.getDurableConfigurationStore().unbindQueue(exchange,
                             new AMQShortString(bindingKey),

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/binding/BindingFactory.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/binding/BindingFactory.java
@@ -22,7 +22,7 @@ import org.wso2.andes.AMQException;
 import org.wso2.andes.AMQInternalException;
 import org.wso2.andes.AMQSecurityException;
 import org.wso2.andes.amqp.AMQPUtils;
-import org.wso2.andes.amqp.QpidAMQPBridge;
+import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.configuration.qpid.BindingConfig;
 import org.wso2.andes.configuration.qpid.BindingConfigType;
 import org.wso2.andes.configuration.qpid.ConfigStore;
@@ -176,7 +176,7 @@ public class BindingFactory {
 
                 if(isLocal) {
                     //tell Andes kernel to create binding
-                    QpidAMQPBridge.createBinding(exchange, new AMQShortString(bindingKey), queue);
+                    QpidAndesBridge.createBinding(exchange, new AMQShortString(bindingKey), queue);
                 }
             }
 
@@ -245,7 +245,7 @@ public class BindingFactory {
                 if (binding.isDurable()) {
                     if(isLocal) {
                         //inform andes kernel to remove binding.
-                        QpidAMQPBridge.removeBinding(binding);
+                        QpidAndesBridge.removeBinding(binding);
                     }
                     _configSource.getDurableConfigurationStore().unbindQueue(exchange,
                             new AMQShortString(bindingKey),

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/exchange/DefaultExchangeRegistry.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/exchange/DefaultExchangeRegistry.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentMap;
 import org.apache.log4j.Logger;
 import org.wso2.andes.AMQException;
 import org.wso2.andes.AMQSecurityException;
-import org.wso2.andes.amqp.QpidAMQPBridge;
+import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.framing.AMQShortString;
 import org.wso2.andes.server.queue.IncomingMessage;
 import org.wso2.andes.server.store.DurableConfigurationStore;
@@ -102,7 +102,7 @@ public class DefaultExchangeRegistry implements ExchangeRegistry
                 getDurableConfigurationStore().removeExchange(e);
 
                 //tell Andes Kernel to remove exchange
-                QpidAMQPBridge.deleteExchange(e);
+                QpidAndesBridge.deleteExchange(e);
             }
             e.close();
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/exchange/DefaultExchangeRegistry.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/exchange/DefaultExchangeRegistry.java
@@ -102,7 +102,7 @@ public class DefaultExchangeRegistry implements ExchangeRegistry
                 getDurableConfigurationStore().removeExchange(e);
 
                 //tell Andes Kernel to remove exchange
-                QpidAMQPBridge.getInstance().deleteExchange(e);
+                QpidAMQPBridge.deleteExchange(e);
             }
             e.close();
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/exchange/ExchangeInitialiser.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/exchange/ExchangeInitialiser.java
@@ -18,7 +18,7 @@
 package org.wso2.andes.server.exchange;
 
 import org.wso2.andes.AMQException;
-import org.wso2.andes.amqp.QpidAMQPBridge;
+import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.exchange.ExchangeDefaults;
 import org.wso2.andes.framing.AMQShortString;
 import org.wso2.andes.server.store.DurableConfigurationStore;
@@ -48,7 +48,7 @@ public class ExchangeInitialiser
                 store.createExchange(exchange);
 
                 //tell Andes kernel to create Exchange
-                QpidAMQPBridge.createExchange(exchange);
+                QpidAndesBridge.createExchange(exchange);
             }
         }
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/exchange/ExchangeInitialiser.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/exchange/ExchangeInitialiser.java
@@ -48,7 +48,7 @@ public class ExchangeInitialiser
                 store.createExchange(exchange);
 
                 //tell Andes kernel to create Exchange
-                QpidAMQPBridge.getInstance().createExchange(exchange);
+                QpidAMQPBridge.createExchange(exchange);
             }
         }
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRejectMethodHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRejectMethodHandler.java
@@ -18,7 +18,7 @@
 package org.wso2.andes.server.handler;
 
 import org.wso2.andes.AMQException;
-import org.wso2.andes.amqp.QpidAMQPBridge;
+import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.framing.BasicRejectBody;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.MessagingEngine;
@@ -110,7 +110,7 @@ public class BasicRejectMethodHandler implements StateAwareMethodListener<BasicR
                  * Inform kernel that message has been rejected by AMQP transport
                  */
                 try {
-                    QpidAMQPBridge.rejectMessage((AMQMessage) message.getMessage(), channel);
+                    QpidAndesBridge.rejectMessage((AMQMessage) message.getMessage(), channel);
                 } catch (AMQException e) {
                     _logger.error("Error while rejecting message by kernel" , e);
                     throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error while rejecting message by kernel", e);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRejectMethodHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRejectMethodHandler.java
@@ -110,7 +110,7 @@ public class BasicRejectMethodHandler implements StateAwareMethodListener<BasicR
                  * Inform kernel that message has been rejected by AMQP transport
                  */
                 try {
-                    QpidAMQPBridge.getInstance().rejectMessage((AMQMessage) message.getMessage(), channel);
+                    QpidAMQPBridge.rejectMessage((AMQMessage) message.getMessage(), channel);
                 } catch (AMQException e) {
                     _logger.error("Error while rejecting message by kernel" , e);
                     throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error while rejecting message by kernel", e);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/ExchangeDeclareHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/ExchangeDeclareHandler.java
@@ -86,7 +86,7 @@ public class ExchangeDeclareHandler implements StateAwareMethodListener<Exchange
                             virtualHost.getDurableConfigurationStore().createExchange(exchange);
 
                             //tell Andes kernel to create Exchange
-                            QpidAMQPBridge.getInstance().createExchange(exchange);
+                            QpidAMQPBridge.createExchange(exchange);
                         }
                     }
                     catch(AMQUnknownExchangeType e)

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/ExchangeDeclareHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/ExchangeDeclareHandler.java
@@ -21,7 +21,7 @@ import org.apache.log4j.Logger;
 import org.wso2.andes.AMQConnectionException;
 import org.wso2.andes.AMQException;
 import org.wso2.andes.AMQUnknownExchangeType;
-import org.wso2.andes.amqp.QpidAMQPBridge;
+import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.framing.AMQMethodBody;
 import org.wso2.andes.framing.ExchangeDeclareBody;
 import org.wso2.andes.framing.MethodRegistry;
@@ -86,7 +86,7 @@ public class ExchangeDeclareHandler implements StateAwareMethodListener<Exchange
                             virtualHost.getDurableConfigurationStore().createExchange(exchange);
 
                             //tell Andes kernel to create Exchange
-                            QpidAMQPBridge.createExchange(exchange);
+                            QpidAndesBridge.createExchange(exchange);
                         }
                     }
                     catch(AMQUnknownExchangeType e)

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeclareHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeclareHandler.java
@@ -19,7 +19,7 @@ package org.wso2.andes.server.handler;
 
 import org.apache.log4j.Logger;
 import org.wso2.andes.AMQException;
-import org.wso2.andes.amqp.QpidAMQPBridge;
+import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.framing.AMQShortString;
 import org.wso2.andes.framing.MethodRegistry;
 import org.wso2.andes.framing.QueueDeclareBody;
@@ -40,7 +40,6 @@ import org.wso2.andes.server.store.DurableConfigurationStore;
 import org.wso2.andes.server.virtualhost.VirtualHost;
 
 import java.util.Collections;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.wso2.andes.amqp.AMQPUtils.generateQueueName;
@@ -112,7 +111,7 @@ public class QueueDeclareHandler implements StateAwareMethodListener<QueueDeclar
                         store.createQueue(queue, body.getArguments());
 
                         //Tell Andes kernel to create queue
-                        QpidAMQPBridge.createQueue(queue);
+                        QpidAndesBridge.createQueue(queue);
                     }
                     if(body.getAutoDelete())
                     {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeclareHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeclareHandler.java
@@ -112,7 +112,7 @@ public class QueueDeclareHandler implements StateAwareMethodListener<QueueDeclar
                         store.createQueue(queue, body.getArguments());
 
                         //Tell Andes kernel to create queue
-                        QpidAMQPBridge.getInstance().createQueue(queue);
+                        QpidAMQPBridge.createQueue(queue);
                     }
                     if(body.getAutoDelete())
                     {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeleteHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeleteHandler.java
@@ -125,7 +125,7 @@ public class QueueDeleteHandler implements StateAwareMethodListener<QueueDeleteB
                         store.removeQueue(queue);
 
                         //tell Andes Kernel to remove queue
-                        QpidAMQPBridge.getInstance().deleteQueue(queue);
+                        QpidAMQPBridge.deleteQueue(queue);
 
                     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeleteHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeleteHandler.java
@@ -20,7 +20,7 @@ package org.wso2.andes.server.handler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.andes.AMQException;
-import org.wso2.andes.amqp.QpidAMQPBridge;
+import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.framing.MethodRegistry;
 import org.wso2.andes.framing.QueueDeleteBody;
 import org.wso2.andes.framing.QueueDeleteOkBody;
@@ -125,7 +125,7 @@ public class QueueDeleteHandler implements StateAwareMethodListener<QueueDeleteB
                         store.removeQueue(queue);
 
                         //tell Andes Kernel to remove queue
-                        QpidAMQPBridge.deleteQueue(queue);
+                        QpidAndesBridge.deleteQueue(queue);
 
                     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/SimpleAMQQueue.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/SimpleAMQQueue.java
@@ -982,7 +982,7 @@ public class SimpleAMQQueue implements AMQQueue, Subscription.StateListener
                 if (newState == Subscription.State.CLOSED) {
 
                     //Tell Andes Kernel to close the subscription
-                    QpidAMQPBridge.getInstance().closeAMQPSubscription(sub.getQueue(), sub);
+                    QpidAMQPBridge.closeAMQPSubscription(sub.getQueue(), sub);
                 }
 
             } catch (AndesException e) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/SimpleAMQQueue.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/SimpleAMQQueue.java
@@ -20,7 +20,7 @@ package org.wso2.andes.server.queue;
 import org.apache.log4j.Logger;
 import org.wso2.andes.AMQException;
 import org.wso2.andes.AMQSecurityException;
-import org.wso2.andes.amqp.QpidAMQPBridge;
+import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
 import org.wso2.andes.configuration.qpid.*;
@@ -982,7 +982,7 @@ public class SimpleAMQQueue implements AMQQueue, Subscription.StateListener
                 if (newState == Subscription.State.CLOSED) {
 
                     //Tell Andes Kernel to close the subscription
-                    QpidAMQPBridge.closeAMQPSubscription(sub.getQueue(), sub);
+                    QpidAndesBridge.closeAMQPSubscription(sub.getQueue(), sub);
                 }
 
             } catch (AndesException e) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/transport/ServerSessionDelegate.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/transport/ServerSessionDelegate.java
@@ -19,7 +19,7 @@ package org.wso2.andes.server.transport;
 
 import org.wso2.andes.AMQException;
 import org.wso2.andes.AMQUnknownExchangeType;
-import org.wso2.andes.amqp.QpidAMQPBridge;
+import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.framing.AMQShortString;
 import org.wso2.andes.framing.FieldTable;
 import org.wso2.andes.server.ClusterResourceHolder;
@@ -453,7 +453,7 @@ public class ServerSessionDelegate extends SessionDelegate
                         store.createExchange(exchange);
 
                         //tell Andes kernel to create Exchange
-                        QpidAMQPBridge.createExchange(exchange);
+                        QpidAndesBridge.createExchange(exchange);
                     }
 
                     exchangeRegistry.registerExchange(exchange);
@@ -568,7 +568,7 @@ public class ServerSessionDelegate extends SessionDelegate
                     store.removeExchange(exchange);
 
                     //tell Andes Kernel to remove exchange
-                    QpidAMQPBridge.deleteExchange(exchange);
+                    QpidAndesBridge.deleteExchange(exchange);
                 }
             }
         }
@@ -915,14 +915,14 @@ public class ServerSessionDelegate extends SessionDelegate
                                 store.createQueue(queue, ftArgs);
 
                                 //Tell Andes kernel to create queue
-                                QpidAMQPBridge.createQueue(queue);
+                                QpidAndesBridge.createQueue(queue);
                             }
                             else
                             {
                                 store.createQueue(queue);
 
                                 //tell andes kernel to create queue
-                                QpidAMQPBridge.createQueue(queue);
+                                QpidAndesBridge.createQueue(queue);
 
                             }
                         }
@@ -1080,7 +1080,7 @@ public class ServerSessionDelegate extends SessionDelegate
                                 store.removeQueue(queue);
 
                                 //tell Andes Kernel to remove queue
-                                QpidAMQPBridge.deleteQueue(queue);
+                                QpidAndesBridge.deleteQueue(queue);
 
                             }
                         }  else {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/transport/ServerSessionDelegate.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/transport/ServerSessionDelegate.java
@@ -453,7 +453,7 @@ public class ServerSessionDelegate extends SessionDelegate
                         store.createExchange(exchange);
 
                         //tell Andes kernel to create Exchange
-                        QpidAMQPBridge.getInstance().createExchange(exchange);
+                        QpidAMQPBridge.createExchange(exchange);
                     }
 
                     exchangeRegistry.registerExchange(exchange);
@@ -568,7 +568,7 @@ public class ServerSessionDelegate extends SessionDelegate
                     store.removeExchange(exchange);
 
                     //tell Andes Kernel to remove exchange
-                    QpidAMQPBridge.getInstance().deleteExchange(exchange);
+                    QpidAMQPBridge.deleteExchange(exchange);
                 }
             }
         }
@@ -915,14 +915,14 @@ public class ServerSessionDelegate extends SessionDelegate
                                 store.createQueue(queue, ftArgs);
 
                                 //Tell Andes kernel to create queue
-                                QpidAMQPBridge.getInstance().createQueue(queue);
+                                QpidAMQPBridge.createQueue(queue);
                             }
                             else
                             {
                                 store.createQueue(queue);
 
                                 //tell andes kernel to create queue
-                                QpidAMQPBridge.getInstance().createQueue(queue);
+                                QpidAMQPBridge.createQueue(queue);
 
                             }
                         }
@@ -1080,7 +1080,7 @@ public class ServerSessionDelegate extends SessionDelegate
                                 store.removeQueue(queue);
 
                                 //tell Andes Kernel to remove queue
-                                QpidAMQPBridge.getInstance().deleteQueue(queue);
+                                QpidAMQPBridge.deleteQueue(queue);
 
                             }
                         }  else {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/txn/LocalTransaction.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/txn/LocalTransaction.java
@@ -296,7 +296,7 @@ public class LocalTransaction implements ServerTransaction
     private void resetDetails()
     {
         _transaction = null;
-	_postTransactionActions.clear();
+        _postTransactionActions.clear();
         _txnStartTime = 0L;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/virtualhost/VirtualHostImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/virtualhost/VirtualHostImpl.java
@@ -411,7 +411,7 @@ public class VirtualHostImpl implements VirtualHost {
                 durableConfigurationStore.createExchange(newExchange);
 
                 //tell Andes kernel to create Exchange
-                QpidAMQPBridge.getInstance().createExchange(newExchange);
+                QpidAMQPBridge.createExchange(newExchange);
             }
         }
     }
@@ -423,7 +423,7 @@ public class VirtualHostImpl implements VirtualHost {
             getDurableConfigurationStore().createQueue(queue);
 
             //tell Andes kernel to create queue
-            QpidAMQPBridge.getInstance().createQueue(queue);
+            QpidAMQPBridge.createQueue(queue);
         }
 
         String exchangeName = queueConfiguration.getExchange();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/virtualhost/VirtualHostImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/virtualhost/VirtualHostImpl.java
@@ -22,7 +22,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.log4j.Logger;
 import org.wso2.andes.AMQException;
 import org.wso2.andes.AMQStoreException;
-import org.wso2.andes.amqp.QpidAMQPBridge;
+import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.configuration.qpid.*;
 import org.wso2.andes.framing.AMQShortString;
 import org.wso2.andes.framing.FieldTable;
@@ -411,7 +411,7 @@ public class VirtualHostImpl implements VirtualHost {
                 durableConfigurationStore.createExchange(newExchange);
 
                 //tell Andes kernel to create Exchange
-                QpidAMQPBridge.createExchange(newExchange);
+                QpidAndesBridge.createExchange(newExchange);
             }
         }
     }
@@ -423,7 +423,7 @@ public class VirtualHostImpl implements VirtualHost {
             getDurableConfigurationStore().createQueue(queue);
 
             //tell Andes kernel to create queue
-            QpidAMQPBridge.createQueue(queue);
+            QpidAndesBridge.createQueue(queue);
         }
 
         String exchangeName = queueConfiguration.getExchange();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
@@ -484,6 +484,14 @@ public class FailureObservingMessageStore implements MessageStore {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AndesTransaction newTransaction() throws AndesException {
+        return wrappedInstance.newTransaction();
+    }
+
+    /**
      * {@inheritDoc}.
      * <p>
      * Alters the behavior where

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/StoredAMQPMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/StoredAMQPMessage.java
@@ -21,7 +21,7 @@ package org.wso2.andes.store;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.AMQException;
-import org.wso2.andes.amqp.QpidAMQPBridge;
+import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.slot.Slot;
 import org.wso2.andes.server.store.StorableMessageMetaData;
@@ -57,7 +57,7 @@ public class StoredAMQPMessage implements StoredMessage {
     public StorableMessageMetaData getMetaData() {
         if (metaData == null) {
             try {
-                QpidAMQPBridge.getMessageMetaData(_messageId);
+                QpidAndesBridge.getMessageMetaData(_messageId);
             } catch (AMQException e) {
                 log.error("Error while getting message metaData for message ID " + _messageId);
             }
@@ -91,7 +91,7 @@ public class StoredAMQPMessage implements StoredMessage {
 //     */
 //    private void addContentInPersistentMode(final int offsetInMessage, ByteBuffer src) {
 //
-//        QpidAMQPBridge.getInstance().messageContentChunkReceived(_messageId,offsetInMessage,src);
+//        QpidAndesBridge.getInstance().messageContentChunkReceived(_messageId,offsetInMessage,src);
 //    }
 
     @Override
@@ -101,7 +101,7 @@ public class StoredAMQPMessage implements StoredMessage {
     public int getContent(int offsetInMessage, ByteBuffer dst) {
         int c = 0;
         try {
-            c = QpidAMQPBridge.getMessageContentChunk(_messageId, offsetInMessage, dst);
+            c = QpidAndesBridge.getMessageContentChunk(_messageId, offsetInMessage, dst);
         } catch (AMQException e) {
            log.error("Error while getting message content chunk messageID=" + _messageId + " offset=" + offsetInMessage,e);
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/StoredAMQPMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/StoredAMQPMessage.java
@@ -57,7 +57,7 @@ public class StoredAMQPMessage implements StoredMessage {
     public StorableMessageMetaData getMetaData() {
         if (metaData == null) {
             try {
-                QpidAMQPBridge.getInstance().getMessageMetaData(_messageId);
+                QpidAMQPBridge.getMessageMetaData(_messageId);
             } catch (AMQException e) {
                 log.error("Error while getting message metaData for message ID " + _messageId);
             }
@@ -101,7 +101,7 @@ public class StoredAMQPMessage implements StoredMessage {
     public int getContent(int offsetInMessage, ByteBuffer dst) {
         int c = 0;
         try {
-            c = QpidAMQPBridge.getInstance().getMessageContentChunk(_messageId, offsetInMessage, dst);
+            c = QpidAMQPBridge.getMessageContentChunk(_messageId, offsetInMessage, dst);
         } catch (AMQException e) {
            log.error("Error while getting message content chunk messageID=" + _messageId + " offset=" + offsetInMessage,e);
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cassandra/CQLBasedMessageStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cassandra/CQLBasedMessageStoreImpl.java
@@ -34,6 +34,18 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.log4j.Logger;
+import com.datastax.driver.core.BatchStatement;
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import com.datastax.driver.core.exceptions.QueryExecutionException;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.datastax.driver.core.schemabuilder.SchemaBuilder;
+import org.apache.commons.lang.NotImplementedException;
 import org.wso2.andes.configuration.util.ConfigurationProperties;
 import org.wso2.andes.kernel.AndesContextStore;
 import org.wso2.andes.kernel.AndesException;
@@ -47,18 +59,6 @@ import org.wso2.andes.matrics.DataAccessMatrixManager;
 import org.wso2.andes.matrics.MatrixConstants;
 import org.wso2.andes.store.AndesStoreUnavailableException;
 import org.wso2.carbon.metrics.manager.Timer.Context;
-
-import com.datastax.driver.core.BatchStatement;
-import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.Row;
-import com.datastax.driver.core.Session;
-import com.datastax.driver.core.Statement;
-import com.datastax.driver.core.exceptions.NoHostAvailableException;
-import com.datastax.driver.core.exceptions.QueryExecutionException;
-import com.datastax.driver.core.querybuilder.QueryBuilder;
-import com.datastax.driver.core.schemabuilder.SchemaBuilder;
 
 /**
  * CQL 3 based Cassandra MessageStore implementation. This is intended to support Cassandra 2.xx series upwards.
@@ -222,7 +222,6 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
         } finally {
             context.stop();
         }
-
     }
 
     /**
@@ -263,7 +262,6 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
         } finally {
             context.stop();
         }
-
     }
 
     /**
@@ -301,8 +299,6 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
             context.stop();
 
         }
-
-
     }
 
     /**
@@ -361,8 +357,6 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
         } finally {
             context.stop();
         }
-
-
     }
 
     /**
@@ -385,7 +379,6 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
         } finally {
             context.stop();
         }
-
     }
 
     /**
@@ -490,7 +483,6 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
 
         addMetaDataToQueue(targetQueueName, metadataList.get(0));
         deleteMessageMetadataFromQueue(currentQueueName, removableMetadataList);
-
     }
 
     /**
@@ -520,7 +512,6 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
         } finally {
             context.stop();
         }
-
     }
 
     /**
@@ -557,8 +548,6 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
         } finally {
             context.stop();
         }
-
-
     }
 
     /**
@@ -592,8 +581,6 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
         } finally {
             context.stop();
         }
-
-
     }
 
     /**
@@ -627,8 +614,6 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
         } finally {
             context.stop();
         }
-
-
     }
 
     /**
@@ -669,7 +654,6 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
         } finally {
             context.stop();
         }
-
     }
 
     /**
@@ -754,7 +738,6 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
                 removableMetadataList.clear();
             }
         }
-
         return removedMessageCount;
     }
 
@@ -832,6 +815,11 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
     @Override
     public void close() {
         cqlConnection.close();
+    }
+
+    @Override
+    public AndesTransaction newTransaction() throws AndesException {
+        throw new NotImplementedException("Transactions not supported by " + this.getClass());
     }
 
     /**
@@ -920,7 +908,4 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
                                                                   " retain feature will be implemented " +
                                                                   "in next iteration");
     }
-
-
-
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cassandra/HectorBasedMessageStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cassandra/HectorBasedMessageStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005-2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -23,6 +23,7 @@ import me.prettyprint.hector.api.Cluster;
 import me.prettyprint.hector.api.Keyspace;
 import me.prettyprint.hector.api.factory.HFactory;
 import me.prettyprint.hector.api.mutation.Mutator;
+import org.apache.commons.lang.NotImplementedException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -717,6 +718,14 @@ public class HectorBasedMessageStoreImpl implements MessageStore {
     @Override
     public void close() {
         hectorConnection.close();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AndesTransaction newTransaction() throws AndesException {
+        throw new NotImplementedException("Transactions not supported with Hector API");
     }
 
     /**


### PR DESCRIPTION
By using `InboundTransactionEvent`, protocol specific message publishing transactions
can be integrated to Andes core.

For a transactional session an `InboundTransactionEvent` object needs to be created.
This object handles the life-cycle of the transactional session for message publishing.
That is adding messages for publishing, commit added messages or rollback.
