### PR TITLE
Fix for MB-1066

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/ClusterManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/ClusterManager.java
@@ -107,6 +107,9 @@ public class ClusterManager {
         String deletedNodeId = hazelcastAgent.getIdOfNode(node);
 
         SlotManagerClusterMode.getInstance().setRemovedNode(deletedNodeId);
+        if(AndesContext.getInstance().getClusteringAgent().isCoordinator()) {
+            SlotManagerClusterMode.getInstance().recoverSlots();
+        }
         //refresh global queue sync ID
         reAssignNodeSyncId();
 


### PR DESCRIPTION
If coordinator is not on the killed node then the coordinator
should try to recover any un submitted slots from the killed node.