### PR TITLE
Content chunking support for Andes core

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPUtils.java
@@ -196,6 +196,7 @@ public class AMQPUtils {
         metadata.setSlot(amqMessage.getSlot());
         metadata.setExpirationTime(amqMessage.getExpiration());
         metadata.setArrivalTime(amqMessage.getArrivalTime());
+        metadata.setMessageContentLength(amqMetadata.getContentSize());
 
         return metadata;
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -190,7 +190,30 @@ public enum AndesConfiguration implements ConfigurationProperty {
      * is healthy between message store (/Database) and this server instance.
      */
     PERSISTENCE_STORE_HEALTH_CHECK_INTERVAL("persistence/storeHealthCheckInterval", "10", Integer.class),
-            
+
+    /**
+     * Andes core will store message content chunks according to this chunk size. Different database will
+     * have limits and performance gains by tuning this parameter.
+     * <p/>
+     * For instance in MySQL the maximum table column size for content is less than 65534, which is the default
+     * chunk size of AMQP. By changing this parameter to a lesser value we can store large content
+     * chunks converted to smaller content chunks within the DB with this parameter.
+     */
+    PERFORMANCE_TUNING_MAX_CONTENT_CHUNK_SIZE
+            ("performanceTuning/contentHandling/maxContentChunkSize", "65500", Integer.class),
+
+    /**
+     * Within Andes there are content chunk handlers which convert incoming large content chunks
+     * into max content chunk size allowed by Andes core. These handlers run in parallel converting
+     * large content chunks to smaller chunks.
+     * <p/>
+     * If the protocol specific content chunk size is different from the max chunk size allowed by Andes core
+     * and there are significant number of large messages published, then having multiple handlers will
+     * increase performance.
+     */
+    PERFORMANCE_TUNING_CONTENT_CHUNK_HANDLER_COUNT
+            ("performanceTuning/contentHandling/contentChunkHandlerCount", "3", Integer.class),
+
     /**
      * Maximum time interval until which a slot can be retained in memory before updating to the cluster.
      * NOTE : specified in milliseconds.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessage.java
@@ -78,4 +78,12 @@ public class AndesMessage {
         //Messages should be deliverable by default if no rules have been implemented.
         return true;
     }
+
+    /**
+     * Set content chunk list of the message
+     * @param chunkList List of {@link org.wso2.andes.kernel.AndesMessagePart}
+     */
+    public void setChunkList(List<AndesMessagePart> chunkList) {
+        this.contentChunkList = chunkList;
+    }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessageMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessageMetadata.java
@@ -323,6 +323,7 @@ public class AndesMessageMetadata implements Comparable<AndesMessageMetadata> {
             expirationTime = ((MessageMetaData) mdt).getMessageHeader().getExpiration();
             arrivalTime = ((MessageMetaData) mdt).getArrivalTime();
             destination = ((MessageMetaData) mdt).getMessagePublishInfo().getRoutingKey().toString();
+            this.messageContentLength = ((MessageMetaData) mdt).getContentSize();
             isTopic = ((MessageMetaData) mdt).getMessagePublishInfo().getExchange().equals(AMQPUtils.TOPIC_EXCHANGE_NAME);
         }
         //For MQTT Specific Types
@@ -336,16 +337,13 @@ public class AndesMessageMetadata implements Comparable<AndesMessageMetadata> {
 
     }
 
-    public Object getMessageHeader(String header) {
-        ByteBuffer buf = ByteBuffer.wrap(metadata);
-        buf.position(1);
-        buf = buf.slice();
-        MessageMetaDataType type = MessageMetaDataType.values()[metadata[0]];
-        StorableMessageMetaData mdt = type.getFactory()
-                .createMetaData(buf);
-        return ((MessageMetaData) mdt).getMessageHeader().getHeader(header);
-    }
-
+    /**
+     * Create a copy of metadata
+     * @param originalMetadata source metadata that needs to be copied
+     * @param routingKey routing key of the message
+     * @param exchangeName exchange of the message
+     * @return copu of the metadata as a byte array
+     */
     private byte[] createNewMetadata(byte[] originalMetadata, String routingKey, String exchangeName) {
         ByteBuffer buf = ByteBuffer.wrap(originalMetadata);
         buf.position(1);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DisruptorCachedContent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DisruptorCachedContent.java
@@ -37,9 +37,21 @@ public class DisruptorCachedContent implements AndesContent {
      */
     private final int contentLength;
 
-    public DisruptorCachedContent(DeliveryEventData eventDataHolder, int contentLength) {
+    /**
+     * Maximum chunk size allowed within Andes core
+     */
+    private final int maxChunkSize;
+
+    /**
+     * Create a {@link org.wso2.andes.kernel.DisruptorCachedContent} object
+     * @param eventDataHolder {@link org.wso2.andes.kernel.distruptor.delivery.DeliveryEventData}
+     * @param contentLength length of the content to be cached
+     * @param maxChunkSize maximum chunk size of the stored content
+     */
+    public DisruptorCachedContent(DeliveryEventData eventDataHolder, int contentLength, int maxChunkSize) {
         this.eventDataHolder = eventDataHolder;
         this.contentLength = contentLength;
+        this.maxChunkSize = maxChunkSize;
     }
 
     /**
@@ -56,8 +68,8 @@ public class DisruptorCachedContent implements AndesContent {
 
         while (maxRemaining > written) {
             // This is an integer division
-            int chunkNumber = currentBytePosition / AMQPUtils.DEFAULT_CONTENT_CHUNK_SIZE;
-            int chunkStartByteIndex = chunkNumber * AMQPUtils.DEFAULT_CONTENT_CHUNK_SIZE;
+            int chunkNumber = currentBytePosition / maxChunkSize;
+            int chunkStartByteIndex = chunkNumber * maxChunkSize;
             int positionToReadFromChunk = currentBytePosition - chunkStartByteIndex;
 
             AndesMessagePart messagePart = eventDataHolder.getMessagePart(chunkStartByteIndex);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/delivery/DisruptorBasedFlusher.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/delivery/DisruptorBasedFlusher.java
@@ -60,11 +60,13 @@ public class DisruptorBasedFlusher {
                 AndesConfiguration.PERFORMANCE_TUNING_DELIVERY_PARALLEL_DELIVERY_HANDLERS);
         Integer contentSizeToBatch = AndesConfigurationManager.readValue(
                 AndesConfiguration.PERFORMANCE_TUNING_DELIVERY_CONTENT_READ_BATCH_SIZE);
+        int maxContentChunkSize = AndesConfigurationManager.readValue(
+                AndesConfiguration.PERFORMANCE_TUNING_MAX_CONTENT_CHUNK_SIZE);
 
         ThreadFactory namedThreadFactory = new ThreadFactoryBuilder().setNameFormat("DisruptorBasedFlusher-%d").build();
         Executor threadPoolExecutor = Executors.newCachedThreadPool(namedThreadFactory);
 
-        disruptor = new Disruptor<DeliveryEventData>(new DeliveryEventData.DeliveryEventDataFactory(), ringBufferSize,
+        disruptor = new Disruptor<>(new DeliveryEventData.DeliveryEventDataFactory(), ringBufferSize,
                                                      threadPoolExecutor,
                                                      ProducerType.MULTI,
                                                      new BlockingWaitStrategy());
@@ -81,7 +83,7 @@ public class DisruptorBasedFlusher {
             contentReadTaskBatchProcessor[i] = new ConcurrentContentReadTaskBatchProcessor(
                     disruptor.getRingBuffer(),
                     barrier,
-                    new ContentCacheCreator(),
+                    new ContentCacheCreator(maxContentChunkSize),
                     i,
                     parallelContentReaders,
                     contentSizeToBatch);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/ContentChunkHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distruptor/inbound/ContentChunkHandler.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel.distruptor.inbound;
+
+import com.lmax.disruptor.EventHandler;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.AndesMessage;
+import org.wso2.andes.kernel.AndesMessagePart;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class will convert incoming message content chunks into content chunks
+ * that can managed by Andes core. That is, this will change the chunk size.
+ */
+public class ContentChunkHandler implements EventHandler<InboundEventContainer> {
+
+    private static Log log = LogFactory.getLog(ContentChunkHandler.class);
+
+    private final int maxChunkSize;
+
+    /**
+     * Creates a {@link org.wso2.andes.kernel.distruptor.inbound.ContentChunkHandler} object
+     * @param maxChunkSize maximum allowed chunk size to be stored in DB
+     */
+    public ContentChunkHandler(int maxChunkSize) {
+        this.maxChunkSize = maxChunkSize;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onEvent(InboundEventContainer event, long sequence, boolean endOfBatch) throws Exception {
+
+        // If the content is already taken there is no point in further processing
+        // therefore ignore
+        if (!event.availableForContentProcessing()) {
+            return;
+        }
+
+        switch (event.getEventType()) {
+            case MESSAGE_EVENT:
+            case TRANSACTION_ENQUEUE_EVENT:
+                resizeContentChunks(event.messageList, sequence);
+                break;
+            default:
+                if (log.isDebugEnabled()) {
+                    log.debug("Message chunk ignored for event type " + event.getEventType());
+                }
+                break;
+        }
+    }
+
+    /**
+     * Resize the content of the messages provided into chunks that can be stored in DB
+     * @param messageList messages to be processed
+     * @param sequence sequence number of the ring buffer
+     */
+    private void resizeContentChunks(List<AndesMessage> messageList, long sequence) {
+        if (log.isDebugEnabled()) {
+            log.debug("[ " + sequence + " ] Content chunk resize for " + messageList.size() +
+                    " messages ");
+        }
+
+        for (AndesMessage message : messageList) {
+            message.setChunkList(
+                    resizeChunks(message.getContentChunkList(), message.getMetadata().getMessageContentLength())
+            );
+        }
+    }
+
+    /**
+     * This resize content chunks of the provided messages. Resized chunks will have a maximum length of
+     * maxChunkSize
+     * <p/>
+     * Algorithm
+     * <p/>
+     * While iterating through each original content chunk it copies the content to a new data chunk that will
+     * have a maximum length of maxChunkSize.
+     * <p/>
+     * This can handle content with maximum chunk size equal to, less than or greater than the maxChunkSize
+     *
+     * @param partList original content chunk list
+     * @param contentLength total content length
+     * @return list of resized content chunks
+     */
+    public List<AndesMessagePart> resizeChunks(List<AndesMessagePart> partList, int contentLength) {
+        List<AndesMessagePart> chunkList = new ArrayList<>();
+        int written = 0;    // Written bytes to new content chunks
+        int totalRemainingLength = contentLength;
+        byte[] data = null;
+        int startPos = 0;   // Start position of destination data array. (for copying)
+
+        for (AndesMessagePart chunk : partList) {
+
+            // Chunk can be added directly to the new chunk list if there is no remaining data array left
+            // and the following conditions are met
+            //
+            // Chunk is either equal to the the maxChunkSize or the last chunk of the original that is
+            // less than the maxChunkSize.
+            if (data == null && (chunk.getDataLength() == maxChunkSize ||
+                    (chunk.getDataLength() < maxChunkSize && chunk.getDataLength() == totalRemainingLength))) {
+
+                chunk.setOffSet(written);
+                chunkList.add(chunk);
+                written = written + chunk.getDataLength();
+                totalRemainingLength = contentLength - written;
+                continue; // Whole chunk is written. Move to next iteration
+            }
+
+            // When a larger chunk is found, split it to smaller chunks.
+            int chunkStartPos = 0;
+            int chunkRemainingLength = chunk.getDataLength();
+            while (chunkRemainingLength >= maxChunkSize) {
+
+                if (null == data) {
+                    data = new byte[maxChunkSize];
+                    startPos = 0;
+                }
+
+                System.arraycopy(chunk.getData(), chunkStartPos, data, startPos, maxChunkSize - startPos);
+
+                AndesMessagePart newChunk = new AndesMessagePart();
+                newChunk.setMessageID(chunk.getMessageID());
+                newChunk.setDataLength(data.length); // ultimately we write a max chunk here
+                newChunk.setOffSet(written);
+                newChunk.setData(data);
+                chunkList.add(newChunk);
+
+                written = written + data.length;
+                data = null;
+                chunkStartPos = chunkStartPos + (maxChunkSize - startPos);
+                chunkRemainingLength = chunkRemainingLength - (maxChunkSize - startPos) ;
+                startPos = 0;
+                totalRemainingLength = contentLength - written;
+            }
+
+            // This is either original chunks left over part is less than maxChunkSize
+            // or a original chunk it self is less than maxChunkSize
+            while (chunkRemainingLength > 0) {
+                if (null == data) {
+                    int arrayLength;
+                    if (chunkRemainingLength == totalRemainingLength) {
+                        arrayLength = chunkRemainingLength;
+                    } else if (totalRemainingLength >= maxChunkSize) {
+                        arrayLength = maxChunkSize;
+                    } else {
+                        arrayLength = totalRemainingLength;
+                    }
+                    data = new byte[arrayLength];
+                }
+
+                int writeSize;
+                if(chunkRemainingLength <= (data.length - startPos)) {
+                    writeSize = chunkRemainingLength;
+                } else {
+                    writeSize = data.length - startPos;
+                }
+                System.arraycopy(chunk.getData(), chunkStartPos, data, startPos, writeSize);
+                startPos = startPos + writeSize;
+                chunkStartPos = chunkStartPos + writeSize;
+                chunkRemainingLength = chunkRemainingLength - writeSize;
+                if (startPos == data.length) {
+                    AndesMessagePart newChunk = new AndesMessagePart();
+                    newChunk.setMessageID(chunk.getMessageID());
+                    newChunk.setOffSet(written);
+                    newChunk.setDataLength(data.length);
+                    newChunk.setData(data);
+                    chunkList.add(newChunk);
+                    written = written + data.length;
+                    totalRemainingLength = contentLength - written;
+                    data = null;
+                    startPos = 0;
+                }
+            }
+        }
+        return chunkList;
+    }
+}

--- a/modules/andes-core/broker/src/test/java/org/wso2/andes/kernel/distruptor/inbound/ContentChunkHandlerTest.java
+++ b/modules/andes-core/broker/src/test/java/org/wso2/andes/kernel/distruptor/inbound/ContentChunkHandlerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel.distruptor.inbound;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.wso2.andes.kernel.AndesMessagePart;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for {@link org.wso2.andes.kernel.distruptor.inbound.ContentChunkHandlerTest}
+ * This class tests for the functionality of the class for different content chunk sizes
+ */
+@RunWith(Parameterized.class)
+public class ContentChunkHandlerTest {
+
+    private int maxChunkSize;
+    private int originalChunkSize;
+    private int originalChunkCount;
+    private int messageId;
+    private ContentChunkHandler contentChunkHandler;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {65500, 65500, 16, 58}, // same size
+                {65500, 65534, 16, 95}, // original chunk larger than max chunk size
+                {15000, 512, 30, 25 },  // chunk size smaller than max chunk size
+                {65534, 450, 10, 5698}, // total length smaller than max chunk size
+                {800, 252525, 4, 6982}  // original chunk size is a multiple of max chunk size
+        });
+    }
+
+    public ContentChunkHandlerTest(int maxChunkSize, int originalChunkSize, int originalChunkCount, int messageId) {
+        this.maxChunkSize = maxChunkSize;
+        this.originalChunkSize = originalChunkSize;
+        this.originalChunkCount = originalChunkCount;
+        this.messageId = messageId;
+        contentChunkHandler = new ContentChunkHandler(maxChunkSize);
+    }
+
+    /**
+     * Test content resize logic
+     * Content, message id, offset and content length is tested
+     */
+    @Test
+    public void testResizeChunks() {
+
+        List<AndesMessagePart> originalChunks = new ArrayList<>(originalChunkCount);
+
+        StringBuilder contentBuilder = new StringBuilder(originalChunkCount * originalChunkSize);
+
+        int offset = 0;
+        for (int i = 0; i < originalChunkCount; i++) {
+            AndesMessagePart part = new AndesMessagePart();
+            part.setMessageID(messageId);
+
+            StringBuilder contentPartBuilder = new StringBuilder(originalChunkSize);
+            for (int j = 0; j < originalChunkSize; j++) {
+                contentPartBuilder.append((int)(Math.random() * 10)); // Should have a single character.
+            }
+            String contentPart = contentPartBuilder.toString();
+            contentBuilder.append(contentPart);
+
+            part.setData(contentPart.getBytes());
+            part.setOffSet(offset);
+            part.setDataLength(originalChunkSize);
+            originalChunks.add(part);
+            offset = offset + originalChunkSize;
+        }
+
+        String content = contentBuilder.toString();
+
+        List<AndesMessagePart> resultList =
+                contentChunkHandler.resizeChunks(originalChunks, originalChunkSize * originalChunkCount);
+
+        int numOfFullChunks = (originalChunkSize * originalChunkCount) / maxChunkSize;
+        offset = 0;
+        contentBuilder = new StringBuilder(originalChunkCount * originalChunkSize);
+        for (int i = 0; i < numOfFullChunks; i++) {
+            AndesMessagePart messagePart = resultList.get(i);
+            assertEquals("Chunk size mismatch", maxChunkSize, messagePart.getDataLength());
+            assertEquals("Incorrect message id", messageId, messagePart.getMessageID());
+            assertEquals("Incorrect offset", offset, messagePart.getOffSet());
+            contentBuilder.append(new String(messagePart.getData()));
+            offset = offset + maxChunkSize;
+        }
+
+        int remainingLength = (originalChunkSize * originalChunkCount) - (numOfFullChunks * maxChunkSize);
+
+        if (remainingLength != 0) {
+            AndesMessagePart messagePart = resultList.get(numOfFullChunks);
+            assertEquals("Chunk size mismatch", remainingLength, messagePart.getDataLength());
+            assertEquals("Incorrect message id", messageId, messagePart.getMessageID());
+            assertEquals("Incorrect offset", offset, messagePart.getOffSet());
+            contentBuilder.append(new String(messagePart.getData()));
+        }
+
+        assertEquals("Content mismatch", content, contentBuilder.toString());
+    }
+}


### PR DESCRIPTION
There is a new set of handlers added to the inbound disruptor ring to resize content chunks if needed. After that MessagePreProcessor will clone messages if necessary.

This will fix MQTT support for large messages as well. 

Jiras: 
https://wso2.org/jira/browse/MB-972
https://wso2.org/jira/browse/MB-1015
https://wso2.org/jira/browse/MB-1039
https://wso2.org/jira/browse/MB-1071
