### PR TITLE
Large content view issue fixed

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPUtils.java
@@ -63,7 +63,10 @@ public class AMQPUtils {
 
     public static String DEFAULT_EXCHANGE_NAME = "<<default>>";
 
-    public static final int DEFAULT_CONTENT_CHUNK_SIZE = 65534;
+    /**
+     * Max chunk size of the stored content in Andes;
+     */
+    public static int DEFAULT_CONTENT_CHUNK_SIZE;
 
     private static Log log = LogFactory.getLog(AMQPUtils.class);
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/Broker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/Broker.java
@@ -21,6 +21,7 @@ package org.wso2.andes.server;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.logging.Log;
 import org.wso2.andes.AMQException;
+import org.wso2.andes.amqp.AMQPUtils;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
 import org.wso2.andes.configuration.qpid.ServerConfiguration;
@@ -320,6 +321,9 @@ public class Broker
              * Boot andes kernel
              */
             AndesKernelBoot.bootAndesKernel();
+
+            AMQPUtils.DEFAULT_CONTENT_CHUNK_SIZE = AndesConfigurationManager.readValue(
+                    AndesConfiguration.PERFORMANCE_TUNING_MAX_CONTENT_CHUNK_SIZE);
         } catch (ConfigurationException ce) {
             throw new AndesException("Unable to create configuration files based application registry", ce);
         } catch (AMQException amqe) {


### PR DESCRIPTION
Queue browser delivery worker content reading logic had a hard-coded constant value for max content chunk size. Updated this to reflect Andes max content chunk size.

Jira: https://wso2.org/jira/browse/MB-1100