### PR TITLE
Fixing message loss during node kill - failover testing

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotManagerClusterMode.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotManagerClusterMode.java
@@ -388,6 +388,10 @@ public class SlotManagerClusterMode {
                 }
             }
             slotAgent.deleteOverlappedSlots(nodeId);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("No slots to return from node " + nodeId + " as member left");
+            }
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/ClusterManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/ClusterManager.java
@@ -119,9 +119,7 @@ public class ClusterManager {
             clearAllPersistedStatesOfDisappearedNode(deletedNodeId);
 
             //Reassign the slot to free slots pool
-            if (AndesContext.getInstance().getClusteringAgent().isCoordinator()) {
-                SlotManagerClusterMode.getInstance().reAssignSlotsWhenMemberLeaves(deletedNodeId);
-            }
+            SlotManagerClusterMode.getInstance().reAssignSlotsWhenMemberLeaves(deletedNodeId);
         }
 
         // Deactivate durable subscriptions belonging to the node

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HazelcastAgent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HazelcastAgent.java
@@ -906,7 +906,7 @@ public class HazelcastAgent implements SlotAgent {
      */
     @Override
     public TreeSet<Slot> getAssignedSlotsByNodeId(String nodeId) throws AndesException {
-        TreeSet<Slot> resultSet = null;
+        TreeSet<Slot> resultSet = new TreeSet<Slot>();
         try {
             HashmapStringTreeSetWrapper wrapper = this.slotAssignmentMap.remove(nodeId);
             HashMap<String, TreeSet<Slot>> queueToSlotMap = null;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/rdbms/RDBMSAgent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/rdbms/RDBMSAgent.java
@@ -228,8 +228,7 @@ public class RDBMSAgent implements SlotAgent {
 	 */
 	@Override
 	public void reAssignSlot(Slot slotToBeReAssigned) throws AndesException {
-		this.setSlotState(slotToBeReAssigned.getStartMessageId(), slotToBeReAssigned.getEndMessageId(),
-							SlotState.RETURNED);
+        andesContextStore.deleteSlotAssignment(slotToBeReAssigned.getStartMessageId(), slotToBeReAssigned.getEndMessageId());
 	}
 
 	/**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -421,7 +421,7 @@ public class RDBMSConstants {
             "UPDATE " + SLOT_TABLE +
                     " SET " +
                     ASSIGNED_NODE_ID + "=NULL, " +
-                    ASSIGNED_QUEUE_NAME + "=NULL " +
+                    ASSIGNED_QUEUE_NAME + "=NULL, " +
                     SLOT_STATE + "=" + SlotState.RETURNED.getCode() +
                     " WHERE " + START_MESSAGE_ID + "=?" +
                     " AND " + END_MESSAGE_ID + "=?";


### PR DESCRIPTION
Fixing RDBMS query to return the slots when a node is killed. Fixing slot return when coordinator itself is killed. Failover happened successfully without message loss. At times several messages came again as acks did not reach sever at the time of killing, which is acceptable. 