### PR TITLE
Enabling Purge Delivery Rule

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagePurgeRule.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagePurgeRule.java
@@ -51,7 +51,7 @@ public class MessagePurgeRule implements DeliveryRule {
                               .getLastPurgedTimestamp();
         if (onflightMessageTracker.getMsgArrivalTime(messageID) <= lastPurgedTimestampOfQueue) {
             log.warn("Message was sent at " + onflightMessageTracker.getMsgArrivalTime(messageID) +
-                     " before last purge event at " + lastPurgedTimestampOfQueue + ". Will be skipped. id= " +
+                     " before last purge event at " + lastPurgedTimestampOfQueue + ". Therefore, it will not be sent. id= " +
                      messageID);
             onflightMessageTracker.setMessageStatus(MessageStatus.PURGED, messageID);
             return false;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/AMQPLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/AMQPLocalSubscription.java
@@ -30,6 +30,7 @@ import org.wso2.andes.kernel.DeliveryRule;
 import org.wso2.andes.kernel.HasInterestRule;
 import org.wso2.andes.kernel.LocalSubscription;
 import org.wso2.andes.kernel.MaximumNumOfDeliveryRule;
+import org.wso2.andes.kernel.MessagePurgeRule;
 import org.wso2.andes.kernel.MessageStatus;
 import org.wso2.andes.kernel.MessagingEngine;
 import org.wso2.andes.kernel.NoLocalRule;
@@ -116,8 +117,8 @@ public class AMQPLocalSubscription extends InboundSubscriptionEvent {
 //        //checking message expiration deliver rule
 //        deliveryRulesList.add(new MessageExpiredRule());
 
-//        //checking message purged delivery rule
-//        deliveryRulesList.add(new MessagePurgeRule());
+        //checking message purged delivery rule
+        deliveryRulesList.add(new MessagePurgeRule());
         //checking has interest delivery rule
         deliveryRulesList.add(new HasInterestRule(amqpSubscription));
         //checking no local delivery rule


### PR DESCRIPTION
As per jira : https://wso2.org/jira/browse/MB-948

If a queue is purged while its messages are in the middle of the delivery logic, a warning like following will be printed and the message will not be delivered, since it had arrived before the purge event.

WARN {org.wso2.andes.kernel.MessagePurgeRule} -  Message was sent at 1437116635408 before last purge event at 1437116635856. Therefore, it will not be sent. id= 37785602728394752