### PR TITLE
Initial commit for broker.xml to support ciphertool and to move amqp/mqtt ssl configurations into broker.xml

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/server/Server.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/server/Server.java
@@ -52,9 +52,9 @@ public class Server {
 
         Properties mqttProperties = new Properties();
 
-        mqttProperties.put("port",AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_MQTT_PORT));
+        mqttProperties.put("port",AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_MQTT_DEFAULT_CONNECTION_PORT));
 
-        mqttProperties.put("sslPort",AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_MQTT_SSL_PORT));
+        mqttProperties.put("sslPort",AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_MQTT_SSL_CONNECTION_PORT));
 
         mqttProperties.put("host",AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_MQTT_BIND_ADDRESS));
         

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/AndesConfigurationManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/AndesConfigurationManager.java
@@ -17,6 +17,9 @@
  */
 package org.wso2.andes.configuration;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -29,18 +32,36 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMNode;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
+import org.apache.axiom.om.impl.llom.OMElementImpl;
+import org.apache.axiom.om.xpath.AXIOMXPath;
 import org.apache.commons.configuration.CompositeConfiguration;
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.XMLConfiguration;
 import org.apache.commons.configuration.tree.xpath.XPathExpressionEngine;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jaxen.JaxenException;
+import org.w3c.dom.Document;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
 import org.wso2.andes.configuration.util.ConfigurationProperty;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.carbon.utils.ServerConstants;
+import org.wso2.securevault.SecretResolver;
+import org.wso2.securevault.SecretResolverFactory;
+import org.wso2.securevault.secret.SecretLoadingModule;
+import org.wso2.securevault.secret.SingleSecretCallback;
+
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLStreamException;
 
 /**
  * This class acts as a singleton access point for all config parameters used within MB.
@@ -60,13 +81,15 @@ public class AndesConfigurationManager {
     private static final String LIST_TYPE = "LIST_";
 
     /**
+     * Namespace and attribute used by secure vault to identify encrypted properties.
+     */
+    private static final QName SECURE_VAULT_QNAME = new QName("http://org.wso2.securevault/configuration","secretAlias");
+
+    /**
      * Common Error states
      */
     private static final String GENERIC_CONFIGURATION_PARSE_ERROR = "Error occurred when trying to parse " +
             "configuration value {0}.";
-
-    private static final String NO_CHILD_FOR_INDEX_IN_PROPERTY = "There was no child at the given index {0} for the " +
-            "parent property {1}.";
 
     private static final String NO_CHILD_FOR_KEY_IN_PROPERTY = "There was no child at the given key {0} for the " +
             "parent property {1}.";
@@ -95,6 +118,8 @@ public class AndesConfigurationManager {
      */
     private static CompositeConfiguration compositeConfiguration;
 
+    private static ConcurrentHashMap<String,String> cipherValueMap;
+
     /**
      * Decisive configurations coming from carbon.xml that affect the MB configs. e.g port Offset
      * These are injected as custom logic when reading the configurations.
@@ -108,46 +133,33 @@ public class AndesConfigurationManager {
      * @throws AndesException
      */
     public static void initialize(int portOffset) throws AndesException {
+
+        String brokerConfigFilePath = ROOT_CONFIG_FILE_PATH + ROOT_CONFIG_FILE_NAME;
+        log.info("Main andes configuration located at : " + brokerConfigFilePath);
+
         try {
 
             compositeConfiguration = new CompositeConfiguration();
-
             compositeConfiguration.setDelimiterParsingDisabled(true);
-            
-            log.info("Main andes configuration located at : " + ROOT_CONFIG_FILE_PATH + ROOT_CONFIG_FILE_NAME);
 
-            
             XMLConfiguration rootConfiguration = new XMLConfiguration();
             rootConfiguration.setDelimiterParsingDisabled(true);
-            rootConfiguration.setFileName(ROOT_CONFIG_FILE_PATH + ROOT_CONFIG_FILE_NAME);
+            rootConfiguration.setFileName(brokerConfigFilePath);
             rootConfiguration.setExpressionEngine(new XPathExpressionEngine());
             rootConfiguration.load();
             compositeConfiguration.addConfiguration(rootConfiguration);
-            // Load and combine other configurations linked to broker.xml
-            String[] linkedConfigurations = compositeConfiguration.getStringArray("links/link");
 
-            for (String linkedConfigurationPath : linkedConfigurations) {
+            //Decrypt and maintain secure vault property values in a map for cross-reference.
+            decryptConfigurationFromFile(brokerConfigFilePath);
 
-                log.info("Linked configuration file path : " + ROOT_CONFIG_FILE_PATH + linkedConfigurationPath);
-
-                XMLConfiguration linkedConfiguration = new XMLConfiguration();
-                linkedConfiguration.setDelimiterParsingDisabled(false);
-                linkedConfiguration.setFileName(ROOT_CONFIG_FILE_PATH + linkedConfigurationPath);
-                linkedConfiguration.setExpressionEngine(new XPathExpressionEngine());
-                linkedConfiguration.load();
-                compositeConfiguration.addConfiguration(linkedConfiguration);
-            }
-
-            // derive certain special properties that are not simply specified in
-            // the configuration files.
+            // Derive certain special properties that are not simply specified in the configuration files.
             addDerivedProperties();
 
             // set carbonPortOffset coming from carbon
             AndesConfigurationManager.carbonPortOffset = portOffset;
 
         } catch (ConfigurationException e) {
-            String error = "Error occurred when trying to construct configurations from file at path : " +
-                    ROOT_CONFIG_FILE_PATH + ROOT_CONFIG_FILE_NAME;
+            String error = "Error occurred when trying to construct configurations from file at path : " + brokerConfigFilePath;
             log.error(error, e);
             throw new AndesException(error, e);
 
@@ -155,8 +167,21 @@ public class AndesConfigurationManager {
             String error = "Error occurred when trying to derive the bind address for messaging from configurations.";
             log.error(error, e);
             throw new AndesException(error, e);
+        } catch (FileNotFoundException e) {
+            String error = "Error occurred when trying to read the configuration file : " + brokerConfigFilePath ;
+            log.error(error, e);
+            throw new AndesException(error, e);
+        } catch (JaxenException e) {
+            String error = "Error occurred when trying to process cipher text in file : " + brokerConfigFilePath;
+            log.error(error, e);
+            throw new AndesException(error, e);
+        } catch (XMLStreamException e) {
+            String error = "Error occurred when trying to process cipher text in file : " + brokerConfigFilePath;
+            log.error(error, e);
+            throw new AndesException(error, e);
         }
     }
+
 
     /**
      * The sole method exposed to everyone accessing configurations. We can use the relevant
@@ -166,7 +191,6 @@ public class AndesConfigurationManager {
      * @param <T>                   Expected data type of the property
      * @param configurationProperty relevant enum value (e.g.- config.enums.AndesConfiguration)
      * @return Value of config in the expected data type.
-     * @throws org.wso2.andes.kernel.AndesException
      */
     public static <T> T readValue(ConfigurationProperty configurationProperty) {
 
@@ -175,16 +199,12 @@ public class AndesConfigurationManager {
             return (T) readPortValue(configurationProperty);
         }
 
-        String valueInFile = compositeConfiguration.getString(configurationProperty.get()
-                .getKeyInFile());
-
         try {
             // The cast to T is unavoidable. Even though the function returns the same data type,
             // compiler doesn't know about it. We could add the data type as a parameter,
             // but that only complicates the method call.
             return (T) deriveValidConfigurationValue(configurationProperty.get().getKeyInFile(),
-                    configurationProperty.get().getDataType(), configurationProperty.get().getDefaultValue(),
-                    valueInFile);
+                    configurationProperty.get().getDataType(), configurationProperty.get().getDefaultValue());
         } catch (ConfigurationException e) {
 
             log.error(e); // Since the descriptive message is wrapped in exception itself
@@ -194,7 +214,7 @@ public class AndesConfigurationManager {
             // small mistake.
             try {
                 return (T) deriveValidConfigurationValue(configurationProperty.get().getKeyInFile(),
-                        configurationProperty.get().getDataType(), configurationProperty.get().getDefaultValue(), null);
+                        configurationProperty.get().getDataType(), configurationProperty.get().getDefaultValue());
             } catch (ConfigurationException e1) {
                 // It is highly unlikely that this will throw an exception (if defined default values are also invalid).
                 // But if it does, the method will return null.
@@ -203,40 +223,6 @@ public class AndesConfigurationManager {
                 log.error(e); // Since the descriptive message is wrapped in exception itself
                 return null;
             }
-        }
-    }
-
-    /**
-     * Using this method, you can access a singular property of a child.
-     * <p/>
-     * example,
-     * <p/>
-     * <users>
-     * <user userName="testuser1" password="password1" />
-     * <user userName="testuser2" password="password2" />
-     * </users> scenario.
-     *
-     * @param configurationProperty relevant enum value (e.g.- above scenario -> config
-     *                              .enums.AndesConfiguration.TRANSPORTS_MQTT_PASSWORD)
-     * @param index                 index of the child of whom you seek the property (e.g. above scenario -> 1)
-     */
-    public static <T> T readValueOfChildByIndex(AndesConfiguration configurationProperty, int index) {
-
-        String constructedKey = configurationProperty.get().getKeyInFile().replace("{i}", String.valueOf(index));
-
-        String valueInFile = compositeConfiguration.getString(constructedKey);
-
-        // The cast to T is unavoidable. Even though the function returns the same data type,
-        // compiler doesn't know about it. We could add the data type as a parameter,
-        // but that only complicates the method call.
-        try {
-            return (T) deriveValidConfigurationValue(configurationProperty.get().getKeyInFile(),
-                    configurationProperty.get().getDataType(),
-                    configurationProperty.get().getDefaultValue(), valueInFile);
-        } catch (ConfigurationException e) {
-            // This means that there is no child by the given index for the parent property.
-            log.error(MessageFormat.format(NO_CHILD_FOR_INDEX_IN_PROPERTY, index, configurationProperty), e);
-            return null;
         }
     }
 
@@ -259,15 +245,13 @@ public class AndesConfigurationManager {
         String constructedKey = configurationProperty.get().getKeyInFile().replace("{key}",
                 key);
 
-        String valueInFile = compositeConfiguration.getString(constructedKey);
-
         // The cast to T is unavoidable. Even though the function returns the same data type,
         // compiler doesn't know about it. We could add the data type as a parameter,
         // but that only complicates the method call.
         try {
-            return (T) deriveValidConfigurationValue(configurationProperty.get().getKeyInFile(),
+            return (T) deriveValidConfigurationValue(constructedKey,
                     configurationProperty.get().getDataType(),
-                    configurationProperty.get().getDefaultValue(), valueInFile);
+                    configurationProperty.get().getDefaultValue());
         } catch (ConfigurationException e) {
             // This means that there is no child by the given key for the parent property.
             log.error(MessageFormat.format(NO_CHILD_FOR_KEY_IN_PROPERTY, key, configurationProperty), e);
@@ -301,18 +285,18 @@ public class AndesConfigurationManager {
      * @param dataType     Expected data type of the property
      * @param defaultValue This parameter should NEVER be null since we assign a default value to
      *                     every config property.
-     * @param readValue    Value read from the config file
      * @param <T>          Expected data type of the property
      * @return Value of config in the expected data type.
      * @throws ConfigurationException
      */
-    private static <T> T deriveValidConfigurationValue(String key, Class<T> dataType,
-                                                       String defaultValue,
-                                                       String readValue) throws ConfigurationException {
+    public static <T> T deriveValidConfigurationValue(String key, Class<T> dataType,
+                                                       String defaultValue) throws ConfigurationException {
 
         if (log.isDebugEnabled()) {
             log.debug("Reading andes configuration value " + key);
         }
+
+        String readValue = compositeConfiguration.getString(key);
 
         String validValue = defaultValue;
 
@@ -320,7 +304,7 @@ public class AndesConfigurationManager {
             log.warn("Error when trying to read property : " + key + ". Switching to " + "default value : " +
                     defaultValue);
         } else {
-            validValue = readValue;
+            validValue = overrideWithDecryptedValue(key,readValue);
         }
 
         if (log.isDebugEnabled()) {
@@ -340,6 +324,12 @@ public class AndesConfigurationManager {
             } else if (dataType.isEnum()) {
                 // this will indirectly forces programmer to define enum values in upper case
                 return (T) Enum.valueOf((Class<? extends Enum>) dataType, validValue.toUpperCase(Locale.ENGLISH));
+
+            } else if (dataType.getPackage().getName().equals("org.wso2.andes.configuration.modules")) {
+                // Custom data structures defined within this package only need to root Xpath to extract the other
+                // required child properties to construct the config object.
+                return dataType.getConstructor(String.class).newInstance(key);
+
             } else {
                 return dataType.getConstructor(String.class).newInstance(validValue);
             }
@@ -397,11 +387,9 @@ public class AndesConfigurationManager {
         }
 
         try {
-            String valueInFile = compositeConfiguration.getString(configurationProperty.get().getKeyInFile());
-
             Integer portFromConfiguration = (Integer) deriveValidConfigurationValue(configurationProperty.get()
                             .getKeyInFile(), configurationProperty.get().getDataType(),
-                    configurationProperty.get().getDefaultValue(), valueInFile);
+                    configurationProperty.get().getDefaultValue());
 
             return portFromConfiguration + carbonPortOffset;
 
@@ -411,6 +399,70 @@ public class AndesConfigurationManager {
             //recover and return default port with offset value.
             return Integer.parseInt(configurationProperty.get().getDefaultValue()) + carbonPortOffset;
         }
+    }
+
+    /**
+     * Decrypt properties with secure vault and maintain on a separate hashmap for cross-reference.
+     * @param filePath File path to the configuration file in question
+     * @throws FileNotFoundException
+     * @throws JaxenException
+     * @throws XMLStreamException
+     */
+    private static void decryptConfigurationFromFile(String filePath) throws FileNotFoundException, JaxenException, XMLStreamException {
+
+        cipherValueMap = new ConcurrentHashMap<String, String>();
+
+        StAXOMBuilder stAXOMBuilder = new StAXOMBuilder(new FileInputStream(new File(filePath)));
+        OMElement dom = stAXOMBuilder.getDocumentElement();
+
+        //Initialize the SecretResolver providing the configuration element.
+        SecretResolver secretResolver = SecretResolverFactory.create(dom, false);
+
+        AXIOMXPath xpathExpression = new AXIOMXPath ("//*[@*[local-name() = 'secretAlias']]");
+        List nodeList = xpathExpression.selectNodes(dom);
+
+        for (Object o : nodeList) {
+
+            String secretAlias = ((OMElement)o).getAttributeValue(SECURE_VAULT_QNAME);
+            String decryptedValue = "";
+
+            if (secretResolver != null && secretResolver.isInitialized()) {
+                if (secretResolver.isTokenProtected(secretAlias)) {
+                    decryptedValue = secretResolver.resolve(secretAlias);
+                }
+            } else {
+                log.warn("Error while trying to decipher secure property with secretAlias : " + secretAlias);
+            }
+
+            cipherValueMap.put(secretAlias,decryptedValue);
+        }
+
+    }
+
+    /**
+     * If the property is contained in the cipherValueMap, replace the raw value with that value.
+     * @param keyInFile xpath expression used to extract the value from file.
+     * @param rawValue The value read from the file without any processing.
+     * @return the decrypted value if the property was encrypted with ciphertool.
+     */
+    private static String overrideWithDecryptedValue(String keyInFile, String rawValue) {
+
+        if (keyInFile.contains("@")) {
+            if (log.isDebugEnabled()) {
+                log.debug("Ciphertool does not operate on xml attributes or lists. ( input key : " + keyInFile + " )");
+            }
+        }
+
+        if (StringUtils.isBlank(keyInFile)) {
+
+            String secretAlias = keyInFile.replaceAll("/",".");
+
+            if (cipherValueMap.containsKey(secretAlias)) {
+                return cipherValueMap.get(secretAlias);
+            }
+        }
+
+        return rawValue;
     }
 
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/AndesConfigurationManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/AndesConfigurationManager.java
@@ -463,7 +463,7 @@ public class AndesConfigurationManager {
             }
         }
 
-        if (StringUtils.isBlank(keyInFile)) {
+        if (!StringUtils.isBlank(keyInFile)) {
 
             // The alias is inferred from the xpath of the property.
             // If the xpath = "transports/amqp/sslConnection/keyStore/password",

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -18,6 +18,7 @@
 
 package org.wso2.andes.configuration.enums;
 
+import org.wso2.andes.configuration.modules.JKSStore;
 import org.wso2.andes.configuration.util.ConfigurationProperty;
 import org.wso2.andes.configuration.util.ImmutableMetaProperties;
 import org.wso2.andes.configuration.util.MetaProperties;
@@ -75,14 +76,34 @@ public enum AndesConfiguration implements ConfigurationProperty {
     TRANSPORTS_AMQP_ENABLED("transports/amqp/@enabled", "true", Boolean.class),
 
     /**
-     * The port used to listen for amqp messages/commands by the MB server.
+     * The port used to listen for non-secure amqp messages/commands by the MB server.
      */
-    TRANSPORTS_AMQP_PORT("transports/amqp/port", "5672", Integer.class),
+    TRANSPORTS_AMQP_DEFAULT_CONNECTION_PORT("transports/amqp/defaultConnection/@port", "5672", Integer.class),
 
     /**
-     * The SSL port used to listen for amqp messages/commands by the MB server.
+     * Enable/disable the default, non-secure AMQP connection.
      */
-    TRANSPORTS_AMQP_SSL_PORT("transports/amqp/sslPort", "8672", Integer.class),
+    TRANSPORTS_AMQP_DEFAULT_CONNECTION_ENABLED("transports/amqp/defaultConnection/@enabled", "true", Boolean.class),
+
+    /**
+     * Enable/disable the secure AMQP connection.
+     */
+    TRANSPORTS_AMQP_SSL_CONNECTION_ENABLED("transports/amqp/sslConnection/@enabled", "true", Boolean.class),
+
+    /**
+     * The port used to listen for secure amqp messages/commands by the MB server.
+     */
+    TRANSPORTS_AMQP_SSL_CONNECTION_PORT("transports/amqp/sslConnection/@port", "8672", Integer.class),
+
+    /**
+     * The key store used for AMQP SSL connection.
+     */
+    TRANSPORTS_AMQP_SSL_CONNECTION_KEYSTORE("transports/amqp/sslConnection/keyStore", "", JKSStore.class),
+
+    /**
+     * The trust store used for AMQP SSL connection.
+     */
+    TRANSPORTS_AMQP_SSL_CONNECTION_TRUSTSTORE("transports/amqp/sslConnection/trustStore", "", JKSStore.class),
 
     /**
      * By default, expired messages are sent to the Dead Letter Channel for later revival/reference. But,
@@ -114,12 +135,32 @@ public enum AndesConfiguration implements ConfigurationProperty {
     /**
      * The port used to listen for mqtt messages/commands by the MB server.
      */
-    TRANSPORTS_MQTT_PORT("transports/mqtt/port", "1883", Integer.class),
+    TRANSPORTS_MQTT_DEFAULT_CONNECTION_PORT("transports/mqtt/defaultConnection/@port", "1883", Integer.class),
+
+    /**
+     * Enable/disable the default, non-secure MQTT connection.
+     */
+    TRANSPORTS_MQTT_DEFAULT_CONNECTION_ENABLED("transports/mqtt/defaultConnection/@enabled", "true", Boolean.class),
 
     /**
      * The SSL port used to listen for mqtt messages/commands by the MB server.
      */
-    TRANSPORTS_MQTT_SSL_PORT("transports/mqtt/sslPort", "1884", Integer.class),
+    TRANSPORTS_MQTT_SSL_CONNECTION_PORT("transports/mqtt/sslConnection/@port", "8883", Integer.class),
+
+    /**
+     * Enable/disable the secure MQTT connection.
+     */
+    TRANSPORTS_MQTT_SSL_CONNECTION_ENABLED("transports/mqtt/sslConnection/@enabled", "true", Boolean.class),
+
+    /**
+     * The key store used for MQTT SSL connection.
+     */
+    TRANSPORTS_MQTT_SSL_CONNECTION_KEYSTORE("transports/mqtt/sslConnection/keyStore", "", JKSStore.class),
+
+    /**
+     * The trust store used for MQTT SSL connection.
+     */
+    TRANSPORTS_MQTT_SSL_CONNECTION_TRUSTSTORE("transports/mqtt/sslConnection/trustStore", "", JKSStore.class),
 
     /**
      * Ring buffer size of MQTT inbound event Disruptor. Default is set to 32768 (1024 * 32)

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/modules/JKSStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/modules/JKSStore.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.configuration.modules;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.wso2.andes.configuration.AndesConfigurationManager;
+
+import java.io.File;
+
+/**
+ * Common class used to maintain and parse JKS stores specified in broker.xml.
+ */
+public class JKSStore {
+
+    private final String DEFAULT_STORE_LOCATION = "repository" + File.separator + "resources" + File.separator +
+            "security" + File.separator + "wso2carbon.jks";
+    private final String DEFAULT_STORE_PASSWORD = "wso2carbon";
+
+    private final String relativeXPathForLocation = "/location";
+    private final String relativeXPathForPassword = "/password";
+
+    private String storeLocation;
+    private String password;
+
+    public String getStoreLocation() {
+        return storeLocation;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public JKSStore(String rootXPath) throws ConfigurationException {
+
+        String locationXPath = rootXPath + relativeXPathForLocation;
+        String passwordXPath = rootXPath + relativeXPathForPassword;
+
+        storeLocation = AndesConfigurationManager.deriveValidConfigurationValue(locationXPath, String.class,
+                DEFAULT_STORE_LOCATION);
+        password = AndesConfigurationManager.deriveValidConfigurationValue(passwordXPath, String.class,
+                DEFAULT_STORE_PASSWORD);
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/modules/JKSStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/modules/JKSStore.java
@@ -25,17 +25,41 @@ import java.io.File;
 
 /**
  * Common class used to maintain and parse JKS stores specified in broker.xml.
+ * <p/>
+ * This is an example for modularizing configurations for re-usability. Since JKS stores are used for both AMQP and
+ * MQTT, the following config block is used repeatedly within the broker.xml :
+ * <p/>
+ * <keyStore>
+ * <location>repository/resources/security/wso2carbon.jks</location>
+ * <password>wso2carbon</password>
+ * </keyStore>
+ * <p/>
+ * So this class is used to parse this block into a common data structure.
+ * Refer usages of the class in AndesConfiguration for more information.
  */
 public class JKSStore {
 
+    /**
+     * Default values
+     */
     private final String DEFAULT_STORE_LOCATION = "repository" + File.separator + "resources" + File.separator +
             "security" + File.separator + "wso2carbon.jks";
     private final String DEFAULT_STORE_PASSWORD = "wso2carbon";
 
+    /**
+     * Relative xpaths which are appended to the input root XPath at constructor.
+     */
     private final String relativeXPathForLocation = "/location";
     private final String relativeXPathForPassword = "/password";
 
+    /**
+     * Physical location of the JKS store, relative to PRODUCT_HOME
+     */
     private String storeLocation;
+
+    /**
+     * password of the JKS store.
+     */
     private String password;
 
     public String getStoreLocation() {
@@ -51,6 +75,8 @@ public class JKSStore {
         String locationXPath = rootXPath + relativeXPathForLocation;
         String passwordXPath = rootXPath + relativeXPathForPassword;
 
+        // After deriving the full xpaths, the AndesConfigurationManager is used to extract the values for each
+        // property.
         storeLocation = AndesConfigurationManager.deriveValidConfigurationValue(locationXPath, String.class,
                 DEFAULT_STORE_LOCATION);
         password = AndesConfigurationManager.deriveValidConfigurationValue(passwordXPath, String.class,

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/qpid/ServerConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/qpid/ServerConfiguration.java
@@ -23,6 +23,7 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.log4j.Logger;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
+import org.wso2.andes.configuration.modules.JKSStore;
 import org.wso2.andes.configuration.qpid.plugins.ConfigurationPlugin;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.server.registry.ApplicationRegistry;
@@ -511,7 +512,7 @@ public class ServerConfiguration extends ConfigurationPlugin implements SignalHa
      * @return Port
      */
     public List getPorts() {
-        Integer port = AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_PORT);
+        Integer port = AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_DEFAULT_CONNECTION_PORT);
 
         return Collections.singletonList(port);
     }
@@ -558,11 +559,12 @@ public class ServerConfiguration extends ConfigurationPlugin implements SignalHa
     }
 
     public boolean getEnableSSL() {
-        return getBooleanValue("connector.ssl.enabled");
+        return (Boolean)AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_SSL_CONNECTION_ENABLED);
     }
 
     public boolean getSSLOnly() {
-        return getBooleanValue("connector.ssl.sslOnly");
+        return (Boolean)AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_SSL_CONNECTION_ENABLED) &&
+                !(Boolean)AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_DEFAULT_CONNECTION_ENABLED);
     }
 
     /**
@@ -571,17 +573,17 @@ public class ServerConfiguration extends ConfigurationPlugin implements SignalHa
      * @return SSL Port List
      */
     public List getSSLPorts() {
-        Integer sslPort = AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_SSL_PORT);
+        Integer sslPort = AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_SSL_CONNECTION_PORT);
 
         return Collections.singletonList(sslPort);
     }
 
     public String getKeystorePath() {
-        return getStringValue("connector.ssl.keystorePath", "repository/resources/security/wso2carbon.jks");
+        return ((JKSStore)AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_SSL_CONNECTION_KEYSTORE)).getStoreLocation();
     }
 
     public String getKeystorePassword() {
-        return getStringValue("connector.ssl.keystorePassword", "wso2carbon");
+        return ((JKSStore)AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_SSL_CONNECTION_KEYSTORE)).getPassword();
     }
 
     public String getCertType() {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/util/MetaProperties.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/util/MetaProperties.java
@@ -41,7 +41,7 @@ public interface MetaProperties {
     Class<?> getDataType();
 
     /**
-     * @return Name of the property (e.g. TRANSPORTS_AMQP_PORT)
+     * @return Name of the property (e.g. TRANSPORTS_AMQP_DEFAULT_CONNECTION_PORT)
      */
     String getName();
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/Broker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/Broker.java
@@ -24,6 +24,7 @@ import org.wso2.andes.AMQException;
 import org.wso2.andes.amqp.AMQPUtils;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
+import org.wso2.andes.configuration.modules.JKSStore;
 import org.wso2.andes.configuration.qpid.ServerConfiguration;
 import org.wso2.andes.configuration.qpid.ServerNetworkTransportConfiguration;
 import org.wso2.andes.configuration.qpid.management.ConfigurationManagementMBean;
@@ -224,11 +225,10 @@ public class Broker
                 }
 
                 if (serverConfig.getEnableSSL()) {
-                    String keystorePath = serverConfig.getKeystorePath();
-                    String keystorePassword = serverConfig.getKeystorePassword();
+                    JKSStore keyStore = AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_SSL_CONNECTION_KEYSTORE);
                     String certType = serverConfig.getCertType();
                     SSLContextFactory sslFactory =
-                            new SSLContextFactory(keystorePath, keystorePassword, certType);
+                            new SSLContextFactory(keyStore.getStoreLocation(), keyStore.getPassword(), certType);
 
                     for(int sslPort : sslPorts)
                     {


### PR DESCRIPTION
This is with reference to jiras : 

https://wso2.org/jira/browse/MB-924 
https://wso2.org/jira/browse/MB-1160

At server startup, AndesConfigurationManager will scan for any encrypted properties within broker.xml and add their decrypted values to a static hashmap. Whenever a property is read, this map will be cross referenced to find the decrypted value. This approach is used because cipher tool is dependent on using an AXIOM xml parser. 

A common data structure is used to parse AMQP / MQTT JKS store configurations into the server. Refer JKSStore.java

AMQP SSL configurations are now parsed through AndesConfiguration instead of ServerConfiguration (QPID code.)

This is dependent on : https://github.com/wso2/carbon-business-messaging/pull/100