### PR TITLE
Re-arranging onflight message tracker

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ConcurrentTrackingList.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ConcurrentTrackingList.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+import java.util.LinkedList;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Concurrent List like implementation.
+ * This implementation will create thread safe LinkedList.
+ * Two threads won't be able to execute same operation simultaneously
+ * with this LinkedList.
+ *
+ * @param <T> Type of list items
+ *
+ */
+public class ConcurrentTrackingList<T> {
+    private final LinkedList<T> dataList;
+    private final ReentrantReadWriteLock lock;
+
+    public ConcurrentTrackingList() {
+        dataList = new LinkedList<T>();
+        lock = new ReentrantReadWriteLock();
+    }
+
+    /**
+     * Returns true if this list contains the specified element.
+     *
+     * @param item
+     *         Ite, whose presence in this list is to be tested
+     * @return true if this list contains the specified element
+     */
+    public boolean contains(T item) {
+        try {
+            lock.readLock().lock();
+            return dataList.contains(item);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Appends the specified element to the end of this list.
+     *
+     * @param item
+     *         Item to be appended to this list
+     */
+    public void add(T item) {
+        try {
+            lock.writeLock().lock();
+            dataList.add(item);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Removes the first occurrence of the specified element from this list, if it is present.
+     * If this list does not contain the element, it is unchanged.
+     *
+     * @param item
+     *         Item to be removed from this list, if present
+     */
+    public void remove(T item) {
+        try {
+            lock.writeLock().lock();
+            dataList.remove(item);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/LocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/LocalSubscription.java
@@ -28,5 +28,31 @@ public interface LocalSubscription extends AndesSubscription {
 
     public UUID getChannelID();
 
+    /**
+     * Check if this subscription has ability to accept messages
+     * If pending ack count is high it does not have ability to accept new messages
+     * @return true if able to accept messages
+     */
+    public boolean hasRoomToAcceptMessages();
+
+    /**
+     * Ack received for subscription. Protocol specific subscribers implement
+     * independent behaviours
+     * @param messageID id of the message
+     */
+    public void ackReceived(long messageID);
+
+    /**
+     * Message rejected by the subscriber. Protocol specific subscribers implement
+     * independent behaviours
+     * @param messageID id of the rejected message
+     */
+    public void msgRejectReceived(long messageID);
+
+    /**
+     * Close subscriber. Here subscriber should release all the resources.
+     */
+    public void close();
+
     public LocalSubscription createQueueToListentoTopic();
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageData.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageData.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+import org.wso2.andes.kernel.slot.Slot;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * This class represents a bean where message delivery statistics are kept
+ */
+public class MessageData {
+
+    public final long msgID;
+
+    public final String destination;
+    /**
+     * timestamp at which the message was taken from store for processing.
+     */
+    public long timestamp;
+    /**
+     * Timestamp after which the message should expire.
+     */
+    public long expirationTime;
+    /**
+     * timestamp at which the message entered the first gates of the broker.
+     */
+    public long arrivalTime;
+    /**
+     * Number of scheduled deliveries. concurrently modified whenever the message is scheduled to be delivered.
+     */
+    public AtomicInteger numberOfScheduledDeliveries;
+    /**
+     * Number of deliveries done of this message in each amq channel.
+     */
+    private Map<UUID, Integer> channelToNumOfDeliveries;
+    /**
+     * State transition of the message
+     */
+    public List<MessageStatus> messageStatus;
+    /**
+     * Parent slot of message.
+     */
+    public Slot slot;
+
+    public MessageData(long msgID, Slot slot, String destination, long timestamp,
+                    long expirationTime, MessageStatus messageStatus,
+                    long arrivalTime) {
+        this.msgID = msgID;
+        this.slot = slot;
+        this.destination = destination;
+        this.timestamp = timestamp;
+        this.expirationTime = expirationTime;
+        this.channelToNumOfDeliveries = new ConcurrentHashMap<UUID, Integer>();
+        this.messageStatus = Collections.synchronizedList(new ArrayList<MessageStatus>());
+        this.messageStatus.add(messageStatus);
+        this.numberOfScheduledDeliveries = new AtomicInteger(0);
+        this.arrivalTime = arrivalTime;
+    }
+
+    public boolean isExpired() {
+        if (expirationTime != 0L) {
+            long now = System.currentTimeMillis();
+            return (now > expirationTime);
+        } else {
+            return false;
+        }
+    }
+
+    public void addMessageStatus(MessageStatus status) {
+        messageStatus.add(status);
+    }
+
+    public String getStatusHistory() {
+        String history = "";
+        for (MessageStatus status : messageStatus) {
+            history = history + status + ">>";
+        }
+        return history;
+    }
+
+    public MessageStatus getLatestState() {
+        MessageStatus latest = null;
+        if (messageStatus.size() > 0) {
+            latest = messageStatus.get(messageStatus.size() - 1);
+        }
+        return latest;
+    }
+
+    public boolean isRedelivered(UUID channelID) {
+        Integer numOfDeliveries = channelToNumOfDeliveries.get(channelID);
+        return numOfDeliveries > 1;
+    }
+
+    public int incrementDeliveryCount(UUID channelID) {
+        Integer numOfDeliveries = channelToNumOfDeliveries.get(channelID);
+        if (numOfDeliveries == null) {
+            numOfDeliveries = 0;
+        }
+        numOfDeliveries++;
+        channelToNumOfDeliveries.put(channelID, numOfDeliveries);
+        return numOfDeliveries;
+    }
+
+    public Set<UUID> getAllDeliveredChannels() {
+        return channelToNumOfDeliveries.keySet();
+    }
+
+    public int decrementDeliveryCount(UUID channelID) {
+        Integer numOfDeliveries = channelToNumOfDeliveries.get(channelID);
+        numOfDeliveries--;
+        if (numOfDeliveries > 0) {
+            channelToNumOfDeliveries.put(channelID, numOfDeliveries);
+        } else {
+            channelToNumOfDeliveries.remove(channelID);
+        }
+        return numOfDeliveries;
+    }
+
+    public int getNumOfDeliveires4Channel(UUID channelID) {
+         /* Since sometimes Broker tries to send stored messages when it initialised a subscription
+            so then it returns null value for that subscription's channel's amount of deliveries,
+            Since we need to the evaluate the rules before we send message, therefore we have to ignore the null value,
+            then we have to check the number of deliveries for the particular channel */
+        if (null != channelToNumOfDeliveries.get(channelID)) {
+            return channelToNumOfDeliveries.get(channelID);
+        } else {
+            return 0;
+        }
+    }
+
+    public boolean allAcksReceived() {
+        return channelToNumOfDeliveries.isEmpty();
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -231,7 +231,7 @@ public class MessagingEngine {
         OnflightMessageTracker.getInstance().handleFailure(metadata);
         LocalSubscription subToResend = subscriptionStore.getLocalSubscriptionForChannelId(metadata.getChannelId());
         if (subToResend != null) {
-            OnflightMessageTracker.getInstance().decrementNonAckedMessageCount(metadata.getChannelId());
+            subToResend.msgRejectReceived(metadata.messageID);
             reQueueMessage(metadata, subToResend);
         } else {
             log.warn("Cannot handle reject. Subscription not found for channel " + metadata.getChannelId()

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/AckHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/AckHandler.java
@@ -21,16 +21,13 @@ package org.wso2.andes.kernel.disruptor.inbound;
 import com.google.common.util.concurrent.SettableFuture;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.andes.kernel.AndesAckData;
-import org.wso2.andes.kernel.AndesException;
-import org.wso2.andes.kernel.AndesRemovableMetadata;
-import org.wso2.andes.kernel.MessagingEngine;
-import org.wso2.andes.kernel.OnflightMessageTracker;
+import org.wso2.andes.kernel.*;
 import org.wso2.andes.kernel.disruptor.BatchEventHandler;
 import org.wso2.andes.store.AndesTranactionRollbackException;
 import org.wso2.andes.store.FailureObservingStoreManager;
 import org.wso2.andes.store.HealthAwareStore;
 import org.wso2.andes.store.StoreHealthListener;
+import org.wso2.andes.subscription.SubscriptionStore;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -110,7 +107,9 @@ public class AckHandler implements BatchEventHandler, StoreHealthListener {
                         ack.getMsgStorageDestination()));
             }
 
-            OnflightMessageTracker.getInstance().decrementNonAckedMessageCount(ack.getChannelID());
+            LocalSubscription subscription = AndesContext.getInstance().getSubscriptionStore()
+                    .getLocalSubscriptionForChannelId(ack.getChannelID());
+            subscription.ackReceived(ack.getMessageID());
             event.clear();
         }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundAndesChannelEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundAndesChannelEvent.java
@@ -20,7 +20,9 @@ package org.wso2.andes.kernel.disruptor.inbound;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.AndesContext;
 import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.kernel.LocalSubscription;
 import org.wso2.andes.kernel.OnflightMessageTracker;
 
 import java.util.UUID;
@@ -65,10 +67,8 @@ public class InboundAndesChannelEvent implements AndesInboundStateEvent {
     public void updateState() throws AndesException {
         switch (eventType) {
             case CHANNEL_OPEN_EVENT:
-                OnflightMessageTracker.getInstance().addNewChannelForTracking(channelID);
                 break;
             case CHANNEL_CLOSE_EVENT:
-                OnflightMessageTracker.getInstance().releaseAllMessagesOfChannelFromTracking(channelID);
                 break;
             default:
                 log.error("Event type not set properly " + eventType);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/SubscriptionImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/SubscriptionImpl.java
@@ -257,16 +257,6 @@ public abstract class SubscriptionImpl implements Subscription, FlowCreditManage
                  */
                 recordMessageDelivery(entry, deliveryTag);
 
-                long messageID = entry.getMessage().getMessageNumber();
-                OnflightMessageTracker messageTracker = OnflightMessageTracker.getInstance();
-
-                boolean isRedelivered = messageTracker.checkAndRegisterSent(messageID, getChannel().getId());
-
-                //set redelivery header
-                if (isRedelivered) {
-                    entry.setRedelivered();
-                }
-
                 //no point of trying to deliver if channel is closed ReQueue the message to
                 // be resent
                 // when channel is available
@@ -289,7 +279,7 @@ public abstract class SubscriptionImpl implements Subscription, FlowCreditManage
                 }
 
                 if (log.isDebugEnabled()) {
-                    log.debug("sent message : " + messageID + " JMSMessageId " + ": " +
+                    log.debug("sent message : " + entry.getMessageHeader().getMessageId() + " JMSMessageId " + ": " +
                               entry.getMessageHeader().getMessageId() + " channel=" + getChannel().getChannelId());
 
                 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionStore.java
@@ -641,6 +641,7 @@ public class SubscriptionStore {
      * @throws AndesException
      */
     private LocalSubscription removeLocalSubscription(AndesSubscription subscription) throws AndesException {
+        ((LocalSubscription)subscription).close();
         String destination = getDestination(subscription);
         String subscriptionID = subscription.getSubscriptionID();
         LocalSubscription subscriptionToRemove = null;


### PR DESCRIPTION
1. removing sending tracker from onflight message tracker
2. removing un-ack message counting from Onflight message tracker.
3. Fix OOM issue of topics - when there are slow topic subscribers broker goes OOM as Queue entries are accumulated in transport level. Fix is to flow control topic messages. Messages to slow subscribers who are stuck at the moment will be lost.  
