### PR TITLE
[WIP] MQTT 3.1.1 Upgrade 

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/commons/Constants.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/commons/Constants.java
@@ -1,5 +1,6 @@
 package org.dna.mqtt.commons;
 
+
 /**
  * Contains some useful constants.
  */
@@ -7,4 +8,12 @@ public class Constants {
     public static final int PORT = 1883;
     public static final String HOST = "0.0.0.0";
     public static final int DEFAULT_CONNECT_TIMEOUT = 10;
+    public static final String PORT_PROPERTY_NAME = "port";
+    public static final String HOST_PROPERTY_NAME = "host";
+    public static final String WEB_SOCKET_PORT_PROPERTY_NAME = "websocket_port";
+    public static final String WSS_PORT_PROPERTY_NAME = "secure_websocket_port";
+    public static final String SSL_PORT_PROPERTY_NAME = "sslPort";
+    public static final String JKS_PATH_PROPERTY_NAME = "jks_path";
+    public static final String KEY_STORE_PASSWORD_PROPERTY_NAME = "key_store_password";
+    public static final String KEY_MANAGER_PASSWORD_PROPERTY_NAME = "key_manager_password";
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/messaging/spi/impl/ProtocolProcessor.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/messaging/spi/impl/ProtocolProcessor.java
@@ -158,19 +158,6 @@ public class ProtocolProcessor implements EventHandler<ValueEvent>, PubAckHandle
             return;
         }
 
-        //handle user authentication
-        if (msg.isUserFlag()) {
-            String pwd = null;
-            if (msg.isPasswordFlag()) {
-                pwd = msg.getPassword();
-            }
-            if (!m_authenticator.checkValid(msg.getUsername(), pwd)) {
-                failedCredentials(session);
-                return;
-            }
-            session.setAttribute(NettyChannel.ATTR_KEY_USERNAME, msg.getUsername());
-        }
-
         //Server enforces user authentication but user doesn't supply credentials
         // NOTE: this is just a interim solution for a potential security threat.
         if ( isAuthenticationRequired && (! msg.isUserFlag())) {
@@ -765,7 +752,7 @@ public class ProtocolProcessor implements EventHandler<ValueEvent>, PubAckHandle
         for (SubscribeMessage.Couple req : msg.subscriptions()) {
 
             // Authorize subscribe
-            String tenant = MQTTUtils.getTenantFromTopic(req.getTopic());
+            String tenant = MQTTUtils.getTenantFromTopic(req.getTopicFilter());
             if ((!isAuthenticationRequired && !authSubject.isUserFlag())
                 || (authSubject.isUserFlag() && tenant.equals(authSubject.getTenantDomain()))) {
 
@@ -773,7 +760,8 @@ public class ProtocolProcessor implements EventHandler<ValueEvent>, PubAckHandle
             } else {
                 // User flag has to be set at this point, else not authenticated
                 // Log and continue since there is no method to inform the client about permission failure
-                log.error("Client " + clientID + " does not have permission to subscribe to topic : " + req.getTopic());
+                log.error("Client " + clientID + " does not have permission to subscribe to topic : " +
+                        req.getTopicFilter());
 
                 continue;
             }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/ConnAckDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/ConnAckDecoder.java
@@ -1,28 +1,31 @@
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.AttributeMap;
 import org.dna.mqtt.moquette.proto.messages.ConnAckMessage;
 
 import java.util.List;
 
+/**
+ * @author andrea
+ */
 class ConnAckDecoder extends DemuxDecoder {
 
     @Override
-    void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+    void decode(AttributeMap ctx, ByteBuf in, List<Object> out) throws Exception {
         in.resetReaderIndex();
         //Common decoding part
         ConnAckMessage message = new ConnAckMessage();
-        if (!decodeCommonHeader(message, in)) {
+        if (!decodeCommonHeader(message, 0x00, in)) {
             in.resetReaderIndex();
             return;
         }
         //skip reserved byte
         in.skipBytes(1);
-        
+
         //read  return code
         message.setReturnCode(in.readByte());
         out.add(message);
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/ConnAckEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/ConnAckEncoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -5,14 +20,17 @@ import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.ConnAckMessage;
 
-class ConnAckEncoder extends DemuxEncoder<ConnAckMessage>{
+/**
+ * @author andrea
+ */
+class ConnAckEncoder extends DemuxEncoder<ConnAckMessage> {
 
     @Override
     protected void encode(ChannelHandlerContext chc, ConnAckMessage message, ByteBuf out) {
         out.writeByte(AbstractMessage.CONNACK << 4);
         out.writeBytes(Utils.encodeRemainingLength(2));
-        out.writeByte(0);
+        out.writeByte(message.isSessionPresent() ? 0x01 : 0x00);
         out.writeByte(message.getReturnCode());
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/ConnectDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/ConnectDecoder.java
@@ -1,58 +1,136 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.CorruptedFrameException;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import io.netty.util.AttributeMap;
+import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.ConnectMessage;
 
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 
+import static org.dna.mqtt.moquette.parser.netty.Utils.VERSION_3_1;
+import static org.dna.mqtt.moquette.parser.netty.Utils.VERSION_3_1_1;
+
+/**
+ * @author andrea
+ */
 public class ConnectDecoder extends DemuxDecoder {
 
+    static final AttributeKey<Boolean> CONNECT_STATUS = AttributeKey.valueOf("connected");
+
     @Override
-    void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws UnsupportedEncodingException {
+    void decode(AttributeMap ctx, ByteBuf in, List<Object> out) throws UnsupportedEncodingException {
         in.resetReaderIndex();
         //Common decoding part
         ConnectMessage message = new ConnectMessage();
-        if (!decodeCommonHeader(message, in)) {
+        if (!decodeCommonHeader(message, 0x00, in)) {
             in.resetReaderIndex();
             return;
         }
         int remainingLength = message.getRemainingLength();
         int start = in.readerIndex();
 
-        //Connect specific decoding part
-        //ProtocolName 8 bytes
-        if (in.readableBytes() < 12) {
-            in.resetReaderIndex();
-            return;
-        }
-        byte[] encProtoName = new byte[6];
-        in.skipBytes(2); //size, is 0x06
-        in.readBytes(encProtoName);
-        String protoName = new String(encProtoName, "UTF-8");
-        if (!"MQIsdp".equals(protoName)) {
-            in.resetReaderIndex();
-            throw new CorruptedFrameException("Invalid protoName: " + protoName);
-        }
-        message.setProtocolName(protoName);
+        int protocolNameLen = in.readUnsignedShort();
+        byte[] encProtoName;
+        String protoName;
+        Attribute<Integer> versionAttr = ctx.attr(MQTTDecoder.PROTOCOL_VERSION);
+        switch (protocolNameLen) {
+            case 6:
+                //MQTT version 3.1 "MQIsdp"
+                //ProtocolName 8 bytes or 6 bytes
+                if (in.readableBytes() < 10) {
+                    in.resetReaderIndex();
+                    return;
+                }
 
-        //ProtocolVersion 1 byte (value 0x03)
+                encProtoName = new byte[6];
+                in.readBytes(encProtoName);
+                protoName = new String(encProtoName, "UTF-8");
+                if (!"MQIsdp".equals(protoName)) {
+                    in.resetReaderIndex();
+                    throw new CorruptedFrameException("Invalid protoName: " + protoName);
+                }
+                message.setProtocolName(protoName);
+
+                versionAttr.set((int) VERSION_3_1);
+                break;
+            case 4:
+                //MQTT version 3.1.1 "MQTT"
+                //ProtocolName 6 bytes
+                if (in.readableBytes() < 8) {
+                    in.resetReaderIndex();
+                    return;
+                }
+                encProtoName = new byte[4];
+                in.readBytes(encProtoName);
+                protoName = new String(encProtoName, "UTF-8");
+                if (!"MQTT".equals(protoName)) {
+                    in.resetReaderIndex();
+                    throw new CorruptedFrameException("Invalid protoName: " + protoName);
+                }
+                message.setProtocolName(protoName);
+                versionAttr.set((int) VERSION_3_1_1);
+                break;
+            default:
+                //protocol broken
+                throw new CorruptedFrameException("Invalid protoName size: " + protocolNameLen);
+        }
+
+        //ProtocolVersion 1 byte (value 0x03 for 3.1, 0x04 for 3.1.1)
         message.setProcotolVersion(in.readByte());
+        if (message.getProcotolVersion() == VERSION_3_1_1) {
+            //if 3.1.1, check the flags (dup, retain and qos == 0)
+            if (message.isDupFlag() || message.isRetainFlag() || message.getQos() != AbstractMessage.QOSType.MOST_ONE) {
+                throw new CorruptedFrameException("Received a CONNECT with fixed header flags != 0");
+            }
+
+            //check if this is another connect from the same client on the same session
+            Attribute<Boolean> connectAttr = ctx.attr(ConnectDecoder.CONNECT_STATUS);
+            Boolean alreadyConnected = connectAttr.get();
+            if (alreadyConnected == null) {
+                //never set
+                connectAttr.set(true);
+            } else if (alreadyConnected) {
+                throw new CorruptedFrameException("Received a second CONNECT on the same network connection");
+            }
+        }
 
         //Connection flag
         byte connFlags = in.readByte();
-        boolean cleanSession = ((connFlags & 0x02) >> 1) == 1 ? true : false;
-        boolean willFlag = ((connFlags & 0x04) >> 2) == 1 ? true : false;
+        if (message.getProcotolVersion() == VERSION_3_1_1) {
+            if ((connFlags & 0x01) != 0) { //bit(0) of connection flags is != 0
+                throw new CorruptedFrameException("Received a CONNECT with connectionFlags[0(bit)] != 0");
+            }
+        }
+
+        boolean cleanSession = ((connFlags & 0x02) >> 1) == 1;
+        boolean willFlag = ((connFlags & 0x04) >> 2) == 1;
         byte willQos = (byte) ((connFlags & 0x18) >> 3);
         if (willQos > 2) {
             in.resetReaderIndex();
             throw new CorruptedFrameException("Expected will QoS in range 0..2 but found: " + willQos);
         }
-        boolean willRetain = ((connFlags & 0x20) >> 5) == 1 ? true : false;
-        boolean passwordFlag = ((connFlags & 0x40) >> 6) == 1 ? true : false;
-        boolean userFlag = ((connFlags & 0x80) >> 7) == 1 ? true : false;
+        boolean willRetain = ((connFlags & 0x20) >> 5) == 1;
+        boolean passwordFlag = ((connFlags & 0x40) >> 6) == 1;
+        boolean userFlag = ((connFlags & 0x80) >> 7) == 1;
         //a password is true iff user is true.
         if (!userFlag && passwordFlag) {
             in.resetReaderIndex();
@@ -70,7 +148,8 @@ public class ConnectDecoder extends DemuxDecoder {
         int keepAlive = in.readUnsignedShort();
         message.setKeepAlive(keepAlive);
 
-        if (remainingLength == 12) {
+        if ((remainingLength == 12 && message.getProcotolVersion() == VERSION_3_1) ||
+                (remainingLength == 10 && message.getProcotolVersion() == VERSION_3_1_1)) {
             out.add(message);
             return;
         }
@@ -103,7 +182,7 @@ public class ConnectDecoder extends DemuxDecoder {
             message.setWillMessage(willMessage);
         }
 
-        //Compatibility check wieth v3.0, remaining length has precedence over
+        //Compatibility check with v3.0, remaining length has precedence over
         //the user and password flags
         int readed = in.readerIndex() - start;
         if (readed == remainingLength) {
@@ -139,5 +218,5 @@ public class ConnectDecoder extends DemuxDecoder {
 
         out.add(message);
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/ConnectEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/ConnectEncoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -5,6 +20,9 @@ import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.ConnectMessage;
 
+/**
+ * @author andrea
+ */
 public class ConnectEncoder extends DemuxEncoder<ConnectMessage> {
 
     @Override
@@ -68,5 +86,5 @@ public class ConnectEncoder extends DemuxEncoder<ConnectMessage> {
             variableHeaderBuff.release();
         }
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/DemuxDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/DemuxDecoder.java
@@ -1,21 +1,68 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.CorruptedFrameException;
+import io.netty.util.AttributeMap;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 
 import java.util.List;
 
+/**
+ * @author andrea
+ */
 abstract class DemuxDecoder {
-    abstract void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception;
-    
+    abstract void decode(AttributeMap ctx, ByteBuf in, List<Object> out) throws Exception;
+
+    /**
+     * Decodes the first 2 bytes of the MQTT packet.
+     * The first byte contain the packet operation code and the flags,
+     * the second byte and more contains the overall packet length.
+     */
     protected boolean decodeCommonHeader(AbstractMessage message, ByteBuf in) {
+        return genericDecodeCommonHeader(message, null, in);
+    }
+
+    /**
+     * Do the same as the @see#decodeCommonHeader but having a strong validation on the flags values
+     */
+    protected boolean decodeCommonHeader(AbstractMessage message, int expectedFlags, ByteBuf in) {
+        return genericDecodeCommonHeader(message, expectedFlags, in);
+    }
+
+
+    private boolean genericDecodeCommonHeader(AbstractMessage message, Integer expectedFlagsOpt, ByteBuf in) {
         //Common decoding part
         if (in.readableBytes() < 2) {
             return false;
         }
         byte h1 = in.readByte();
         byte messageType = (byte) ((h1 & 0x00F0) >> 4);
+
+        byte flags = (byte) (h1 & 0x0F);
+        if (expectedFlagsOpt != null) {
+            int expectedFlags = expectedFlagsOpt;
+            if ((byte) expectedFlags != flags) {
+                String hexExpected = Integer.toHexString(expectedFlags);
+                String hexReceived = Integer.toHexString(flags);
+                throw new CorruptedFrameException(String.format("Received a message with fixed header flags (%s) != expected (%s)", hexReceived, hexExpected));
+            }
+        }
+
         boolean dupFlag = ((byte) ((h1 & 0x0008) >> 3) == 1);
         byte qosLevel = (byte) ((h1 & 0x0006) >> 1);
         boolean retainFlag = ((byte) (h1 & 0x0001) == 1);
@@ -31,5 +78,4 @@ abstract class DemuxDecoder {
         message.setRemainingLength(remainingLength);
         return true;
     }
-    
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/DemuxEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/DemuxEncoder.java
@@ -1,9 +1,27 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 
+/**
+ * @author andrea
+ */
 abstract class DemuxEncoder<T extends AbstractMessage> {
     abstract protected void encode(ChannelHandlerContext chc, T msg, ByteBuf bb);
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/DisconnectDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/DisconnectDecoder.java
@@ -1,23 +1,41 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.AttributeMap;
 import org.dna.mqtt.moquette.proto.messages.DisconnectMessage;
 
 import java.util.List;
 
+/**
+ * @author andrea
+ */
 class DisconnectDecoder extends DemuxDecoder {
 
     @Override
-    void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+    void decode(AttributeMap ctx, ByteBuf in, List<Object> out) throws Exception {
         //Common decoding part
         in.resetReaderIndex();
         DisconnectMessage message = new DisconnectMessage();
-        if (!decodeCommonHeader(message, in)) {
+        if (!decodeCommonHeader(message, 0x00, in)) {
             in.resetReaderIndex();
             return;
         }
         out.add(message);
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/DisconnectEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/DisconnectEncoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -5,6 +20,10 @@ import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.DisconnectMessage;
 
+/**
+ *
+ * @author andrea
+ */
 public class DisconnectEncoder extends DemuxEncoder<DisconnectMessage> {
 
     @Override

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/MQTTDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/MQTTDecoder.java
@@ -1,34 +1,56 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.CorruptedFrameException;
+import io.netty.util.AttributeKey;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * @author andrea
+ */
 public class MQTTDecoder extends ByteToMessageDecoder {
-    
-    private Map<Byte, DemuxDecoder> m_decoderMap = new HashMap<Byte, DemuxDecoder>();
-    
+
+    //3 = 3.1, 4 = 3.1.1
+    static final AttributeKey<Integer> PROTOCOL_VERSION = AttributeKey.valueOf("version");
+
+    private final Map<Byte, DemuxDecoder> m_decoderMap = new HashMap<>();
+
     public MQTTDecoder() {
-       m_decoderMap.put(AbstractMessage.CONNECT, new ConnectDecoder());
-       m_decoderMap.put(AbstractMessage.CONNACK, new ConnAckDecoder());
-       m_decoderMap.put(AbstractMessage.PUBLISH, new PublishDecoder());
-       m_decoderMap.put(AbstractMessage.PUBACK, new PubAckDecoder());
-       m_decoderMap.put(AbstractMessage.SUBSCRIBE, new SubscribeDecoder());
-       m_decoderMap.put(AbstractMessage.SUBACK, new SubAckDecoder());
-       m_decoderMap.put(AbstractMessage.UNSUBSCRIBE, new UnsubscribeDecoder());
-       m_decoderMap.put(AbstractMessage.DISCONNECT, new DisconnectDecoder());
-       m_decoderMap.put(AbstractMessage.PINGREQ, new PingReqDecoder());
-       m_decoderMap.put(AbstractMessage.PINGRESP, new PingRespDecoder());
-       m_decoderMap.put(AbstractMessage.UNSUBACK, new UnsubAckDecoder());
-       m_decoderMap.put(AbstractMessage.PUBCOMP, new PubCompDecoder());
-       m_decoderMap.put(AbstractMessage.PUBREC, new PubRecDecoder());
-       m_decoderMap.put(AbstractMessage.PUBREL, new PubRelDecoder());
+        m_decoderMap.put(AbstractMessage.CONNECT, new ConnectDecoder());
+        m_decoderMap.put(AbstractMessage.CONNACK, new ConnAckDecoder());
+        m_decoderMap.put(AbstractMessage.PUBLISH, new PublishDecoder());
+        m_decoderMap.put(AbstractMessage.PUBACK, new PubAckDecoder());
+        m_decoderMap.put(AbstractMessage.SUBSCRIBE, new SubscribeDecoder());
+        m_decoderMap.put(AbstractMessage.SUBACK, new SubAckDecoder());
+        m_decoderMap.put(AbstractMessage.UNSUBSCRIBE, new UnsubscribeDecoder());
+        m_decoderMap.put(AbstractMessage.DISCONNECT, new DisconnectDecoder());
+        m_decoderMap.put(AbstractMessage.PINGREQ, new PingReqDecoder());
+        m_decoderMap.put(AbstractMessage.PINGRESP, new PingRespDecoder());
+        m_decoderMap.put(AbstractMessage.UNSUBACK, new UnsubAckDecoder());
+        m_decoderMap.put(AbstractMessage.PUBCOMP, new PubCompDecoder());
+        m_decoderMap.put(AbstractMessage.PUBREC, new PubRecDecoder());
+        m_decoderMap.put(AbstractMessage.PUBREL, new PubRelDecoder());
     }
 
     @Override
@@ -39,9 +61,9 @@ public class MQTTDecoder extends ByteToMessageDecoder {
             return;
         }
         in.resetReaderIndex();
-        
+
         byte messageType = Utils.readMessageType(in);
-        
+
         DemuxDecoder decoder = m_decoderMap.get(messageType);
         if (decoder == null) {
             throw new CorruptedFrameException("Can't find any suitable decoder for message type: " + messageType);

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/MQTTEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/MQTTEncoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -9,27 +24,30 @@ import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @author andrea
+ */
 public class MQTTEncoder extends MessageToByteEncoder<AbstractMessage> {
-    
+
     private Map<Byte, DemuxEncoder> m_encoderMap = new HashMap<Byte, DemuxEncoder>();
-    
+
     public MQTTEncoder() {
-       m_encoderMap.put(AbstractMessage.CONNECT, new ConnectEncoder());
-       m_encoderMap.put(AbstractMessage.CONNACK, new ConnAckEncoder());
-       m_encoderMap.put(AbstractMessage.PUBLISH, new PublishEncoder());
-       m_encoderMap.put(AbstractMessage.PUBACK, new PubAckEncoder());
-       m_encoderMap.put(AbstractMessage.SUBSCRIBE, new SubscribeEncoder());
-       m_encoderMap.put(AbstractMessage.SUBACK, new SubAckEncoder());
-       m_encoderMap.put(AbstractMessage.UNSUBSCRIBE, new UnsubscribeEncoder());
-       m_encoderMap.put(AbstractMessage.DISCONNECT, new DisconnectEncoder());
-       m_encoderMap.put(AbstractMessage.PINGREQ, new PingReqEncoder());
-       m_encoderMap.put(AbstractMessage.PINGRESP, new PingRespEncoder());
-       m_encoderMap.put(AbstractMessage.UNSUBACK, new UnsubAckEncoder());
-       m_encoderMap.put(AbstractMessage.PUBCOMP, new PubCompEncoder());
-       m_encoderMap.put(AbstractMessage.PUBREC, new PubRecEncoder());
-       m_encoderMap.put(AbstractMessage.PUBREL, new PubRelEncoder());
+        m_encoderMap.put(AbstractMessage.CONNECT, new ConnectEncoder());
+        m_encoderMap.put(AbstractMessage.CONNACK, new ConnAckEncoder());
+        m_encoderMap.put(AbstractMessage.PUBLISH, new PublishEncoder());
+        m_encoderMap.put(AbstractMessage.PUBACK, new PubAckEncoder());
+        m_encoderMap.put(AbstractMessage.SUBSCRIBE, new SubscribeEncoder());
+        m_encoderMap.put(AbstractMessage.SUBACK, new SubAckEncoder());
+        m_encoderMap.put(AbstractMessage.UNSUBSCRIBE, new UnsubscribeEncoder());
+        m_encoderMap.put(AbstractMessage.DISCONNECT, new DisconnectEncoder());
+        m_encoderMap.put(AbstractMessage.PINGREQ, new PingReqEncoder());
+        m_encoderMap.put(AbstractMessage.PINGRESP, new PingRespEncoder());
+        m_encoderMap.put(AbstractMessage.UNSUBACK, new UnsubAckEncoder());
+        m_encoderMap.put(AbstractMessage.PUBCOMP, new PubCompEncoder());
+        m_encoderMap.put(AbstractMessage.PUBREC, new PubRecEncoder());
+        m_encoderMap.put(AbstractMessage.PUBREL, new PubRelEncoder());
     }
-    
+
     @Override
     protected void encode(ChannelHandlerContext chc, AbstractMessage msg, ByteBuf bb) throws Exception {
         DemuxEncoder encoder = m_encoderMap.get(msg.getMessageType());

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/MessageIDDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/MessageIDDecoder.java
@@ -1,28 +1,46 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.AttributeMap;
 import org.dna.mqtt.moquette.proto.messages.MessageIDMessage;
 
 import java.util.List;
 
+/**
+ * @author andrea
+ */
 abstract class MessageIDDecoder extends DemuxDecoder {
-    
+
     protected abstract MessageIDMessage createMessage();
 
     @Override
-    void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+    void decode(AttributeMap ctx, ByteBuf in, List<Object> out) throws Exception {
         in.resetReaderIndex();
         //Common decoding part
         MessageIDMessage message = createMessage();
-        if (!decodeCommonHeader(message, in)) {
+        if (!decodeCommonHeader(message, 0x00, in)) {
             in.resetReaderIndex();
             return;
         }
-        
+
         //read  messageIDs
         message.setMessageID(in.readUnsignedShort());
         out.add(message);
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PingReqDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PingReqDecoder.java
@@ -1,19 +1,37 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.AttributeMap;
 import org.dna.mqtt.moquette.proto.messages.PingReqMessage;
 
 import java.util.List;
 
+/**
+ * @author andrea
+ */
 class PingReqDecoder extends DemuxDecoder {
 
     @Override
-    void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+    void decode(AttributeMap ctx, ByteBuf in, List<Object> out) throws Exception {
         //Common decoding part
         in.resetReaderIndex();
         PingReqMessage message = new PingReqMessage();
-        if (!decodeCommonHeader(message, in)) {
+        if (!decodeCommonHeader(message, 0x00, in)) {
             in.resetReaderIndex();
             return;
         }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PingReqEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PingReqEncoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -5,6 +20,10 @@ import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.PingReqMessage;
 
+/**
+ *
+ * @author andrea
+ */
 class PingReqEncoder  extends DemuxEncoder<PingReqMessage> {
 
     @Override

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PingRespDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PingRespDecoder.java
@@ -1,19 +1,38 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.AttributeMap;
 import org.dna.mqtt.moquette.proto.messages.PingRespMessage;
 
 import java.util.List;
 
+/**
+ *
+ * @author andrea
+ */
 class PingRespDecoder extends DemuxDecoder {
 
     @Override
-    void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+    void decode(AttributeMap ctx, ByteBuf in, List<Object> out) throws Exception {
         //Common decoding part
         in.resetReaderIndex();
         PingRespMessage message = new PingRespMessage();
-        if (!decodeCommonHeader(message, in)) {
+        if (!decodeCommonHeader(message, 0x00, in)) {
             in.resetReaderIndex();
             return;
         }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PingRespEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PingRespEncoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -5,6 +20,9 @@ import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.PingRespMessage;
 
+/**
+ * @author andrea
+ */
 class PingRespEncoder extends DemuxEncoder<PingRespMessage> {
 
     @Override

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubAckDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubAckDecoder.java
@@ -1,13 +1,31 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import org.dna.mqtt.moquette.proto.messages.MessageIDMessage;
 import org.dna.mqtt.moquette.proto.messages.PubAckMessage;
 
+/**
+ * @author andrea
+ */
 class PubAckDecoder extends MessageIDDecoder {
 
     @Override
     protected MessageIDMessage createMessage() {
         return new PubAckMessage();
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubAckEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubAckEncoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -5,6 +20,9 @@ import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.PubAckMessage;
 
+/**
+ * @author andrea
+ */
 class PubAckEncoder extends DemuxEncoder<PubAckMessage> {
 
     @Override
@@ -19,5 +37,5 @@ class PubAckEncoder extends DemuxEncoder<PubAckMessage> {
             buff.release();
         }
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubCompDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubCompDecoder.java
@@ -1,9 +1,27 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import org.dna.mqtt.moquette.proto.messages.MessageIDMessage;
 import org.dna.mqtt.moquette.proto.messages.PubCompMessage;
 
 
+/**
+ * @author andrea
+ */
 class PubCompDecoder extends MessageIDDecoder {
 
     @Override

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubCompEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubCompEncoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -5,6 +20,9 @@ import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.PubCompMessage;
 
+/**
+ * @author andrea
+ */
 class PubCompEncoder extends DemuxEncoder<PubCompMessage> {
 
     @Override

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubRecDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubRecDecoder.java
@@ -1,8 +1,26 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import org.dna.mqtt.moquette.proto.messages.MessageIDMessage;
 import org.dna.mqtt.moquette.proto.messages.PubRecMessage;
 
+/**
+ * @author andrea
+ */
 class PubRecDecoder extends MessageIDDecoder {
 
     @Override

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubRecEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubRecEncoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -5,6 +20,10 @@ import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.PubRecMessage;
 
+/**
+ *
+ * @author andrea
+ */
 class PubRecEncoder extends DemuxEncoder<PubRecMessage> {
 
     @Override

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubRelDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubRelDecoder.java
@@ -1,13 +1,47 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.util.AttributeMap;
 import org.dna.mqtt.moquette.proto.messages.MessageIDMessage;
 import org.dna.mqtt.moquette.proto.messages.PubRelMessage;
 
-class PubRelDecoder extends MessageIDDecoder {
+import java.io.UnsupportedEncodingException;
+import java.util.List;
 
+/**
+ *
+ * @author andrea
+ */
+class PubRelDecoder extends DemuxDecoder {
+    
     @Override
-    protected MessageIDMessage createMessage() {
-        return new PubRelMessage();
+    void decode(AttributeMap ctx, ByteBuf in, List<Object> out) throws UnsupportedEncodingException {
+        in.resetReaderIndex();
+        //Common decoding part
+        MessageIDMessage message = new PubRelMessage();
+        if (!decodeCommonHeader(message, 0x02, in)) {
+            in.resetReaderIndex();
+            return;
+        }
+        
+        //read  messageIDs
+        message.setMessageID(in.readUnsignedShort());
+        out.add(message);
     }
 
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubRelEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PubRelEncoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -5,6 +20,9 @@ import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.PubRelMessage;
 
+/**
+ * @author andrea
+ */
 class PubRelEncoder extends DemuxEncoder<PubRelMessage> {
 
     @Override

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PublishDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PublishDecoder.java
@@ -1,37 +1,63 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelHandlerContext;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import io.netty.handler.codec.CorruptedFrameException;
+import io.netty.util.AttributeMap;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.PublishMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
+/**
+ * @author andrea
+ */
 class PublishDecoder extends DemuxDecoder {
 
-    private static Log log = LogFactory.getLog(PublishDecoder.class);
+    private static Logger LOG = LoggerFactory.getLogger(PublishDecoder.class);
 
     @Override
-    void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
-        // log.info("decode invoked with buffer {}", in);
-        if (log.isDebugEnabled()) {
-            log.debug("decode invoked with buffer : " + in);
-        }
+    void decode(AttributeMap ctx, ByteBuf in, List<Object> out) throws Exception {
+        LOG.info("decode invoked with buffer {}", in);
         in.resetReaderIndex();
         int startPos = in.readerIndex();
 
         //Common decoding part
         PublishMessage message = new PublishMessage();
         if (!decodeCommonHeader(message, in)) {
-            if (log.isDebugEnabled()) {
-                log.debug("decode ask for more data after " + in);
-            }
+            LOG.info("decode ask for more data after {}", in);
             in.resetReaderIndex();
             return;
         }
+
+        if (Utils.isMQTT3_1_1(ctx)) {
+            if (message.getQos() == AbstractMessage.QOSType.MOST_ONE && message.isDupFlag()) {
+                //bad protocol, if QoS=0 => DUP = 0
+                throw new CorruptedFrameException("Received a PUBLISH with QoS=0 & DUP = 1, MQTT 3.1.1 violation");
+            }
+
+            if (message.getQos() == AbstractMessage.QOSType.RESERVED) {
+                throw new CorruptedFrameException("Received a PUBLISH with QoS flags setted 10 b11, MQTT 3.1.1 violation");
+            }
+        }
+
         int remainingLength = message.getRemainingLength();
 
         //Topic name
@@ -40,6 +66,10 @@ class PublishDecoder extends DemuxDecoder {
             in.resetReaderIndex();
             return;
         }
+        if (topic.contains("+") || topic.contains("#")) {
+            throw new CorruptedFrameException("Received a PUBLISH with topic containting wild card chars, topic: " + topic);
+        }
+
         message.setTopicName(topic);
 
         if (message.getQos() == AbstractMessage.QOSType.LEAST_ONE ||

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PublishEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/PublishEncoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -5,6 +20,9 @@ import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.PublishMessage;
 
+/**
+ * @author andrea
+ */
 class PublishEncoder extends DemuxEncoder<PublishMessage> {
 
     @Override
@@ -15,13 +33,13 @@ class PublishEncoder extends DemuxEncoder<PublishMessage> {
         if (message.getTopicName() == null || message.getTopicName().isEmpty()) {
             throw new IllegalArgumentException("Found a message with empty or null topic name");
         }
-        
+
         ByteBuf variableHeaderBuff = ctx.alloc().buffer(2);
-        ByteBuf encodeBuffer = null;
+        ByteBuf buff = null;
         try {
             variableHeaderBuff.writeBytes(Utils.encodeString(message.getTopicName()));
-            if (message.getQos() == AbstractMessage.QOSType.LEAST_ONE || 
-                message.getQos() == AbstractMessage.QOSType.EXACTLY_ONCE ) {
+            if (message.getQos() == AbstractMessage.QOSType.LEAST_ONE ||
+                    message.getQos() == AbstractMessage.QOSType.EXACTLY_ONCE) {
                 if (message.getMessageID() == null) {
                     throw new IllegalArgumentException("Found a message with QOS 1 or 2 and not MessageID setted");
                 }
@@ -32,17 +50,17 @@ class PublishEncoder extends DemuxEncoder<PublishMessage> {
 
             byte flags = Utils.encodeFlags(message);
 
-            encodeBuffer = ctx.alloc().buffer(2 + variableHeaderSize);
-            encodeBuffer.writeByte(AbstractMessage.PUBLISH << 4 | flags);
-            encodeBuffer.writeBytes(Utils.encodeRemainingLength(variableHeaderSize));
-            encodeBuffer.writeBytes(variableHeaderBuff);
-            out.writeBytes(encodeBuffer);
+            buff = ctx.alloc().buffer(2 + variableHeaderSize);
+            buff.writeByte(AbstractMessage.PUBLISH << 4 | flags);
+            buff.writeBytes(Utils.encodeRemainingLength(variableHeaderSize));
+            buff.writeBytes(variableHeaderBuff);
+            out.writeBytes(buff);
         } finally {
             variableHeaderBuff.release();
-            if(encodeBuffer != null) {
-                encodeBuffer.release();
+            if (buff != null) {
+                buff.release();
             }
         }
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/SubAckDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/SubAckDecoder.java
@@ -1,31 +1,49 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.AttributeMap;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.SubAckMessage;
 
 import java.util.List;
 
+/**
+ * @author andrea
+ */
 class SubAckDecoder extends DemuxDecoder {
 
     @Override
-    void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+    void decode(AttributeMap ctx, ByteBuf in, List<Object> out) throws Exception {
         //Common decoding part
         in.resetReaderIndex();
         SubAckMessage message = new SubAckMessage();
-        if (!decodeCommonHeader(message, in)) {
+        if (!decodeCommonHeader(message, 0x00, in)) {
             in.resetReaderIndex();
             return;
         }
         int remainingLength = message.getRemainingLength();
-        
+
         //MessageID
         message.setMessageID(in.readUnsignedShort());
         remainingLength -= 2;
-        
+
         //Qos array
-        if (in.readableBytes() < remainingLength ) {
+        if (in.readableBytes() < remainingLength) {
             in.resetReaderIndex();
             return;
         }
@@ -33,8 +51,8 @@ class SubAckDecoder extends DemuxDecoder {
             byte qos = in.readByte();
             message.addType(AbstractMessage.QOSType.values()[qos]);
         }
-        
+
         out.add(message);
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/SubAckEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/SubAckEncoder.java
@@ -1,10 +1,29 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
+import org.dna.mqtt.moquette.proto.messages.AbstractMessage.QOSType;
 import org.dna.mqtt.moquette.proto.messages.SubAckMessage;
 
+/**
+ * @author andrea
+ */
 class SubAckEncoder extends DemuxEncoder<SubAckMessage> {
 
     @Override
@@ -16,11 +35,12 @@ class SubAckEncoder extends DemuxEncoder<SubAckMessage> {
         int variableHeaderSize = 2 + message.types().size();
         ByteBuf buff = chc.alloc().buffer(6 + variableHeaderSize);
         try {
-            buff.writeByte(AbstractMessage.SUBACK << 4 );
+            buff.writeByte(AbstractMessage.SUBACK << 4);
             buff.writeBytes(Utils.encodeRemainingLength(variableHeaderSize));
             buff.writeShort(message.getMessageID());
-            for (AbstractMessage.QOSType c : message.types()) {
-                buff.writeByte(c.ordinal());
+            for (QOSType c : message.types()) {
+                int qosValue = (c == QOSType.FAILURE) ? qosValue = 0x80 : c.ordinal();
+                buff.writeByte(qosValue);
             }
 
             out.writeBytes(buff);
@@ -28,5 +48,5 @@ class SubAckEncoder extends DemuxEncoder<SubAckMessage> {
             buff.release();
         }
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/SubscribeDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/SubscribeDecoder.java
@@ -1,50 +1,77 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.CorruptedFrameException;
+import io.netty.util.AttributeMap;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage.QOSType;
 import org.dna.mqtt.moquette.proto.messages.SubscribeMessage;
 
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 
+/**
+ * @author andrea
+ */
 class SubscribeDecoder extends DemuxDecoder {
 
     @Override
-    void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+    void decode(AttributeMap ctx, ByteBuf in, List<Object> out) throws Exception {
         //Common decoding part
         SubscribeMessage message = new SubscribeMessage();
         in.resetReaderIndex();
-        if (!decodeCommonHeader(message, in)) {
+        if (!decodeCommonHeader(message, 0x02, in)) {
             in.resetReaderIndex();
             return;
         }
-        
+
         //check qos level
         if (message.getQos() != QOSType.LEAST_ONE) {
             throw new CorruptedFrameException("Received Subscribe message with QoS other than LEAST_ONE, was: " + message.getQos());
         }
-            
+
         int start = in.readerIndex();
         //read  messageIDs
         message.setMessageID(in.readUnsignedShort());
         int readed = in.readerIndex() - start;
         while (readed < message.getRemainingLength()) {
             decodeSubscription(in, message);
-            readed = in.readerIndex()- start;
+            readed = in.readerIndex() - start;
         }
-        
+
+        if (message.subscriptions().isEmpty()) {
+            throw new CorruptedFrameException("subscribe MUST have got at least 1 couple topic/QoS");
+        }
+
         out.add(message);
     }
-    
+
     /**
      * Populate the message with couple of Qos, topic
      */
     private void decodeSubscription(ByteBuf in, SubscribeMessage message) throws UnsupportedEncodingException {
         String topic = Utils.decodeString(in);
-        byte qos = (byte)(in.readByte() & 0x03);
+        byte qosByte = in.readByte();
+        if ((qosByte & 0xFC) > 0) { //the first 6 bits is reserved => has to be 0
+            throw new CorruptedFrameException("subscribe MUST have QoS byte with reserved buts to 0, found " + Integer.toHexString(qosByte));
+        }
+        byte qos = (byte) (qosByte & 0x03);
+        //TODO check qos id 000000xx
         message.addSubscription(new SubscribeMessage.Couple(qos, topic));
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/SubscribeEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/SubscribeEncoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -5,24 +20,27 @@ import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.SubscribeMessage;
 
+/**
+ * @author andrea
+ */
 class SubscribeEncoder extends DemuxEncoder<SubscribeMessage> {
 
     @Override
     protected void encode(ChannelHandlerContext chc, SubscribeMessage message, ByteBuf out) {
-         if (message.subscriptions().isEmpty()) {
+        if (message.subscriptions().isEmpty()) {
             throw new IllegalArgumentException("Found a subscribe message with empty topics");
         }
 
         if (message.getQos() != AbstractMessage.QOSType.LEAST_ONE) {
             throw new IllegalArgumentException("Expected a message with QOS 1, found " + message.getQos());
         }
-        
+
         ByteBuf variableHeaderBuff = chc.alloc().buffer(4);
         ByteBuf buff = null;
         try {
             variableHeaderBuff.writeShort(message.getMessageID());
             for (SubscribeMessage.Couple c : message.subscriptions()) {
-                variableHeaderBuff.writeBytes(Utils.encodeString(c.getTopic()));
+                variableHeaderBuff.writeBytes(Utils.encodeString(c.getTopicFilter()));
                 variableHeaderBuff.writeByte(c.getQos());
             }
 
@@ -36,9 +54,9 @@ class SubscribeEncoder extends DemuxEncoder<SubscribeMessage> {
 
             out.writeBytes(buff);
         } finally {
-             variableHeaderBuff.release();
-             buff.release();
+            variableHeaderBuff.release();
+            buff.release();
         }
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/UnsubAckDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/UnsubAckDecoder.java
@@ -1,8 +1,26 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import org.dna.mqtt.moquette.proto.messages.MessageIDMessage;
 import org.dna.mqtt.moquette.proto.messages.UnsubAckMessage;
 
+/**
+ * @author andrea
+ */
 class UnsubAckDecoder extends MessageIDDecoder {
 
     @Override

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/UnsubAckEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/UnsubAckEncoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -5,8 +20,11 @@ import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.UnsubAckMessage;
 
+/**
+ * @author andrea
+ */
 class UnsubAckEncoder extends DemuxEncoder<UnsubAckMessage> {
-    
+
     @Override
     protected void encode(ChannelHandlerContext chc, UnsubAckMessage msg, ByteBuf out) {
         out.writeByte(AbstractMessage.UNSUBACK << 4).

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/UnsubscribeDecoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/UnsubscribeDecoder.java
@@ -1,41 +1,60 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.CorruptedFrameException;
+import io.netty.util.AttributeMap;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.UnsubscribeMessage;
 
 import java.util.List;
 
-
+/**
+ * @author andrea
+ */
 class UnsubscribeDecoder extends DemuxDecoder {
 
     @Override
-    void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+    void decode(AttributeMap ctx, ByteBuf in, List<Object> out) throws Exception {
         //Common decoding part
         in.resetReaderIndex();
         UnsubscribeMessage message = new UnsubscribeMessage();
-        if (!decodeCommonHeader(message, in)) {
+        if (!decodeCommonHeader(message, 0x02, in)) {
             in.resetReaderIndex();
             return;
         }
-        
+
         //check qos level
         if (message.getQos() != AbstractMessage.QOSType.LEAST_ONE) {
             throw new CorruptedFrameException("Found an Usubscribe message with qos other than LEAST_ONE, was: " + message.getQos());
         }
-            
+
         int start = in.readerIndex();
         //read  messageIDs
         message.setMessageID(in.readUnsignedShort());
-        int readed = in.readerIndex()- start;
+        int readed = in.readerIndex() - start;
         while (readed < message.getRemainingLength()) {
-            message.addTopic(Utils.decodeString(in));
-            readed = in.readerIndex()- start;
+            message.addTopicFilter(Utils.decodeString(in));
+            readed = in.readerIndex() - start;
         }
-        
+        if (message.topicFilters().isEmpty()) {
+            throw new CorruptedFrameException("unsubscribe MUST have got at least 1 topic");
+        }
         out.add(message);
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/UnsubscribeEncoder.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/parser/netty/UnsubscribeEncoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.parser.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -5,23 +20,27 @@ import io.netty.channel.ChannelHandlerContext;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.moquette.proto.messages.UnsubscribeMessage;
 
+
+/**
+ * @author andrea
+ */
 class UnsubscribeEncoder extends DemuxEncoder<UnsubscribeMessage> {
 
     @Override
     protected void encode(ChannelHandlerContext chc, UnsubscribeMessage message, ByteBuf out) {
-        if (message.topics().isEmpty()) {
+        if (message.topicFilters().isEmpty()) {
             throw new IllegalArgumentException("Found an unsubscribe message with empty topics");
         }
 
         if (message.getQos() != AbstractMessage.QOSType.LEAST_ONE) {
             throw new IllegalArgumentException("Expected a message with QOS 1, found " + message.getQos());
         }
-        
+
         ByteBuf variableHeaderBuff = chc.alloc().buffer(4);
         ByteBuf buff = null;
         try {
             variableHeaderBuff.writeShort(message.getMessageID());
-            for (String topic : message.topics()) {
+            for (String topic : message.topicFilters()) {
                 variableHeaderBuff.writeBytes(Utils.encodeString(topic));
             }
 
@@ -39,5 +58,5 @@ class UnsubscribeEncoder extends DemuxEncoder<UnsubscribeMessage> {
             buff.release();
         }
     }
-    
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/AbstractMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/AbstractMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 /**
@@ -23,7 +38,7 @@ public abstract class AbstractMessage {
     public static final byte DISCONNECT = 14; //Client is Disconnecting
 
     public static enum QOSType {
-        MOST_ONE(0), LEAST_ONE(1), EXACTLY_ONCE(2), RESERVED(3);
+        MOST_ONE(0), LEAST_ONE(1), EXACTLY_ONCE(2), RESERVED(3), FAILURE(4);
 
         private final int value; //The value can be either 0,1 or 2
 

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/ConnAckMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/ConnAckMessage.java
@@ -1,8 +1,23 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 /**
  * The attributes Qos, Dup and Retain aren't used.
- * 
+ *
  * @author andrea
  */
 public class ConnAckMessage extends AbstractMessage {
@@ -12,9 +27,10 @@ public class ConnAckMessage extends AbstractMessage {
     public static final byte SERVER_UNAVAILABLE = 0x03;
     public static final byte BAD_USERNAME_OR_PASSWORD = 0x04;
     public static final byte NOT_AUTHORIZED = 0x05;
-    
+
     private byte m_returnCode;
-    
+    private boolean sessionPresent;
+
     public ConnAckMessage() {
         m_messageType = AbstractMessage.CONNACK;
     }
@@ -26,5 +42,12 @@ public class ConnAckMessage extends AbstractMessage {
     public void setReturnCode(byte returnCode) {
         this.m_returnCode = returnCode;
     }
-    
+
+    public boolean isSessionPresent() {
+        return this.sessionPresent;
+    }
+
+    public void setSessionPresent(boolean present) {
+        this.sessionPresent = present;
+    }
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/ConnectMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/ConnectMessage.java
@@ -1,14 +1,29 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 /**
  * The attributes Qos, Dup and Retain aren't used for Connect message
- * 
+ *
  * @author andrea
  */
 public class ConnectMessage extends AbstractMessage {
     String m_protocolName;
     byte m_procotolVersion;
-    
+
     //Connection flags
     boolean m_cleanSession;
     boolean m_willFlag;
@@ -17,14 +32,14 @@ public class ConnectMessage extends AbstractMessage {
     boolean m_passwordFlag;
     boolean m_userFlag;
     int m_keepAlive;
-    
+
     //Variable part
     String m_username;
     String m_password;
     String m_clientID;
     String m_willtopic;
     String m_willMessage;
-    
+
     public ConnectMessage() {
         m_messageType = AbstractMessage.CONNECT;
     }
@@ -140,5 +155,14 @@ public class ConnectMessage extends AbstractMessage {
     public void setWillMessage(String willMessage) {
         this.m_willMessage = willMessage;
     }
-    
+
+    @Override
+    public String toString() {
+        String base = String.format("Connect [clientID: %s, prot: %s, ver: %02X, clean: %b]", m_clientID,
+                m_protocolName, m_procotolVersion, m_cleanSession);
+        if (m_willFlag) {
+            base += String.format(" Will [QoS: %d, retain: %b]", m_willQos, m_willRetain);
+        }
+        return base;
+    }
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/DisconnectMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/DisconnectMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 /**

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/MessageIDMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/MessageIDMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 /**

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/PingReqMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/PingReqMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 /**

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/PingRespMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/PingRespMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 /**

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/PubAckMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/PubAckMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 /**

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/PubCompMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/PubCompMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 /**

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/PubRecMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/PubRecMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 /**

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/PubRelMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/PubRelMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 /**

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/PublishMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/PublishMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 import java.nio.ByteBuffer;

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/SubAckMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/SubAckMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 import java.util.ArrayList;

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/SubscribeMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/SubscribeMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 import java.util.ArrayList;
@@ -12,19 +27,19 @@ public class SubscribeMessage extends MessageIDMessage {
     public static class Couple {
 
         private byte m_qos;
-        private String m_topic;
+        private String m_topicFilter;
 
         public Couple(byte qos, String topic) {
             m_qos = qos;
-            m_topic = topic;
+            m_topicFilter = topic;
         }
         
         public byte getQos() {
             return m_qos;
         }
 
-        public String getTopic() {
-            return m_topic;
+        public String getTopicFilter() {
+            return m_topicFilter;
         }
     }
     private List<Couple> m_subscriptions = new ArrayList<Couple>();

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/UnsubAckMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/UnsubAckMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 /**

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/UnsubscribeMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/UnsubscribeMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 import java.util.ArrayList;
@@ -14,11 +29,11 @@ public class UnsubscribeMessage extends MessageIDMessage {
         m_messageType = AbstractMessage.UNSUBSCRIBE;
     }
 
-    public List<String> topics() {
+    public List<String> topicFilters() {
         return m_types;
     }
 
-    public void addTopic(String type) {
+    public void addTopicFilter(String type) {
         m_types.add(type);
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/ZeroLengthMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/proto/messages/ZeroLengthMessage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package org.dna.mqtt.moquette.proto.messages;
 
 /**

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/server/netty/NettyAcceptor.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/server/netty/NettyAcceptor.java
@@ -28,24 +28,21 @@ import org.dna.mqtt.moquette.server.netty.metrics.MessageMetricsCollector;
 import org.dna.mqtt.moquette.server.netty.metrics.MessageMetricsHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.net.ssl.KeyManagerFactory;
+import org.wso2.andes.configuration.AndesConfigurationManager;
+import org.wso2.andes.configuration.enums.AndesConfiguration;
+import org.wso2.andes.transport.ConnectionSettings;
+import org.wso2.andes.transport.network.security.ssl.SSLUtil;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.security.KeyManagementException;
-import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.util.List;
 import java.util.Properties;
+import org.wso2.andes.configuration.modules.JKSStore;
 
 /**
  * @author andrea
@@ -292,45 +289,48 @@ public class NettyAcceptor implements ServerAcceptor {
         LOG.info(String.format("Bytes read: %d, bytes wrote: %d", bytesMetrics.readBytes(), bytesMetrics.wroteBytes()));
     }
 
+    /**
+     * Constructs connection settings required for ssl connectivity
+     *
+     * @param props holds information necessary to establish ssl connectivity
+     * @return ConnectionSettings
+     */
+    private ConnectionSettings constructConnectionSettings(Properties props) {
+        ConnectionSettings connectionSettings = new ConnectionSettings();
+        String certificateType = "SunX509";
 
+        String sslTrustStoreLocation = ((JKSStore) AndesConfigurationManager.readValue
+                (AndesConfiguration.TRANSPORTS_MQTT_SSL_CONNECTION_TRUSTSTORE)).getStoreLocation();
+        String sslTrustStorePassword = ((JKSStore) AndesConfigurationManager.readValue
+                (AndesConfiguration.TRANSPORTS_MQTT_SSL_CONNECTION_TRUSTSTORE)).getPassword();
+        String sslKeyStoreLocation = ((JKSStore) AndesConfigurationManager.readValue
+                (AndesConfiguration.TRANSPORTS_MQTT_SSL_CONNECTION_KEYSTORE)).getStoreLocation();
+        String sslKeyStorePassword = ((JKSStore) AndesConfigurationManager.readValue
+                (AndesConfiguration.TRANSPORTS_MQTT_SSL_CONNECTION_KEYSTORE)).getPassword();
+
+
+        connectionSettings.setTrustStorePath(sslTrustStoreLocation);
+        connectionSettings.setTrustStorePassword(sslTrustStorePassword);
+        connectionSettings.setTrustStoreCertType(certificateType);
+
+        connectionSettings.setKeyStorePath(sslKeyStoreLocation);
+        connectionSettings.setKeyStorePassword(sslKeyStorePassword);
+        connectionSettings.setKeyStoreCertType(certificateType);
+
+        return connectionSettings;
+    }
+
+
+    /**
+     * Initialization of SSLHandler
+     * @param props the configuration details
+     * @return
+     */
     private SslHandler initSSLHandler(Properties props) {
-        String jksPath = props.getProperty(Constants.JKS_PATH_PROPERTY_NAME);
-        //TODO remove the below hard coded
-        jksPath = "/Users/pamod/Desktop/dev/MQTTUpgrade/wso2mb-3.0.0-SNAPSHOT/repository/resources/security/wso2carbon.jks";
-        LOG.info("Starting SSL using keystore at {}", jksPath);
-        if (jksPath == null || jksPath.isEmpty()) {
-            //key_store_password or key_manager_password are empty
-            LOG.warn("You have configured the SSL port but not the jks_path, SSL not started");
-            return null;
-        }
-
-        //if we have the port also the jks then keyStorePassword and keyManagerPassword
-        //has to be defined
-        String keyStorePassword = props.getProperty(Constants.KEY_STORE_PASSWORD_PROPERTY_NAME);
-        String keyManagerPassword = props.getProperty(Constants.KEY_MANAGER_PASSWORD_PROPERTY_NAME);
-        //TODO remove the below
-        keyManagerPassword = "wso2carbon";
-        keyStorePassword = "wso2carbon";
-        if (keyStorePassword == null || keyStorePassword.isEmpty()) {
-            //key_store_password or key_manager_password are empty
-            LOG.warn("You have configured the SSL port but not the key_store_password, SSL not started");
-            return null;
-        }
-        if (keyManagerPassword == null || keyManagerPassword.isEmpty()) {
-            //key_manager_password or key_manager_password are empty
-            LOG.warn("You have configured the SSL port but not the key_manager_password, SSL not started");
-            return null;
-        }
 
         try {
-            InputStream jksInputStream = jksDatastore(jksPath);
-            SSLContext serverContext = SSLContext.getInstance("TLS");
-            final KeyStore ks = KeyStore.getInstance("JKS");
-            ks.load(jksInputStream, keyStorePassword.toCharArray());
-            final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            kmf.init(ks, keyManagerPassword.toCharArray());
-            serverContext.init(kmf.getKeyManagers(), null, null);
-
+            ConnectionSettings sslConnectionSettings = constructConnectionSettings(props);
+            SSLContext serverContext = SSLUtil.createSSLContext(sslConnectionSettings);
             SSLEngine engine = serverContext.createSSLEngine();
             engine.setUseClientMode(false);
             return new SslHandler(engine);
@@ -338,24 +338,12 @@ public class NettyAcceptor implements ServerAcceptor {
                 | KeyManagementException | IOException ex) {
             LOG.error("Can't start SSL layer!", ex);
             return null;
+        } catch (Exception e) {
+            //Here SSLUtils throws a generic type Exception, hence we need to catch it
+            //This is bad anyhow
+            LOG.error("Error while establishing ssl server context ", e.getMessage());
+            return null;
         }
     }
-
-    private InputStream jksDatastore(String jksPath) throws FileNotFoundException {
-        URL jksUrl = getClass().getClassLoader().getResource(jksPath);
-        if (jksUrl != null) {
-            LOG.info("Starting with jks at {}, jks normal {}", jksUrl.toExternalForm(), jksUrl);
-            return getClass().getClassLoader().getResourceAsStream(jksPath);
-        }
-        LOG.info("jks not found in bundled resources, try on the filesystem");
-        File jksFile = new File(jksPath);
-        if (jksFile.exists()) {
-            LOG.info("Using {} ", jksFile.getAbsolutePath());
-            return new FileInputStream(jksFile);
-        }
-        LOG.warn("File {} doesn't exists", jksFile.getAbsolutePath());
-        return null;
-    }
-
 
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/server/netty/NettyAcceptor.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/server/netty/NettyAcceptor.java
@@ -1,75 +1,278 @@
 package org.dna.mqtt.moquette.server.netty;
 
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.*;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import org.dna.mqtt.commons.Constants;
 import org.dna.mqtt.moquette.messaging.spi.IMessaging;
 import org.dna.mqtt.moquette.parser.netty.MQTTDecoder;
 import org.dna.mqtt.moquette.parser.netty.MQTTEncoder;
 import org.dna.mqtt.moquette.server.ServerAcceptor;
+import org.dna.mqtt.moquette.server.netty.metrics.BytesMetrics;
+import org.dna.mqtt.moquette.server.netty.metrics.BytesMetricsCollector;
+import org.dna.mqtt.moquette.server.netty.metrics.BytesMetricsHandler;
 import org.dna.mqtt.moquette.server.netty.metrics.MessageMetrics;
 import org.dna.mqtt.moquette.server.netty.metrics.MessageMetricsCollector;
 import org.dna.mqtt.moquette.server.netty.metrics.MessageMetricsHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.List;
 import java.util.Properties;
 
 /**
- *
  * @author andrea
  */
 public class NettyAcceptor implements ServerAcceptor {
-    
+
+    static class WebSocketFrameToByteBufDecoder extends MessageToMessageDecoder<BinaryWebSocketFrame> {
+
+        @Override
+        protected void decode(ChannelHandlerContext chc, BinaryWebSocketFrame frame, List<Object> out) throws Exception {
+            //convert the frame to a ByteBuf
+            ByteBuf bb = frame.content();
+            //System.out.println("WebSocketFrameToByteBufDecoder decode - " + ByteBufUtil.hexDump(bb));
+            bb.retain();
+            out.add(bb);
+        }
+    }
+
+    static class ByteBufToWebSocketFrameEncoder extends MessageToMessageEncoder<ByteBuf> {
+
+        @Override
+        protected void encode(ChannelHandlerContext chc, ByteBuf bb, List<Object> out) throws Exception {
+            //convert the ByteBuf to a WebSocketFrame
+            BinaryWebSocketFrame result = new BinaryWebSocketFrame();
+            //System.out.println("ByteBufToWebSocketFrameEncoder encode - " + ByteBufUtil.hexDump(bb));
+            result.content().writeBytes(bb);
+            out.add(result);
+        }
+    }
+
+    abstract class PipelineInitializer {
+
+        abstract void init(ChannelPipeline pipeline) throws Exception;
+    }
+
     private static final Logger LOG = LoggerFactory.getLogger(NettyAcceptor.class);
-    
+
     EventLoopGroup m_bossGroup;
     EventLoopGroup m_workerGroup;
-    //BytesMetricsCollector m_metricsCollector = new BytesMetricsCollector();
+    BytesMetricsCollector m_bytesMetricsCollector = new BytesMetricsCollector();
     MessageMetricsCollector m_metricsCollector = new MessageMetricsCollector();
 
-
+    @Override
     public void initialize(IMessaging messaging, Properties props) throws IOException {
         m_bossGroup = new NioEventLoopGroup();
         m_workerGroup = new NioEventLoopGroup();
-        
-        final NettyMQTTHandler handler = new NettyMQTTHandler();
-        handler.setMessaging(messaging);
 
+        initializePlainTCPTransport(messaging, props);
+        /**
+         * We leave the websockets commented for now since we do not support end to end integration with it
+         */
+        //initializeWebSocketTransport(messaging, props);
+        //TODO need to re look into using getProperty here
+        String sslTcpPortProp = props.get(Constants.SSL_PORT_PROPERTY_NAME).toString();
+        String wssPortProp = props.getProperty(Constants.WSS_PORT_PROPERTY_NAME);
+        /* if (sslTcpPortProp != null || wssPortProp != null) {
+            SslHandler sslHandler = initSSLHandler(props);
+            if (sslHandler == null) {
+                LOG.error("Can't initialize SSLHandler layer! Exiting, check your configuration of jks");
+                return;
+            }
+            initializeSSLTCPTransport(messaging, props, sslHandler);
+            initializeWSSTransport(messaging, props, sslHandler);
+        }*/
+
+        if (sslTcpPortProp != null) {
+            SslHandler sslHandler = initSSLHandler(props);
+            if (sslHandler == null) {
+                LOG.error("Can't initialize SSLHandler layer! Exiting, check your configuration of jks");
+                return;
+            }
+            initializeSSLTCPTransport(messaging, props, sslHandler);
+            /**
+             * We ommit web sockets for now
+             */
+            //initializeWSSTransport(messaging, props, sslHandler);
+        }
+    }
+
+    private void initFactory(String host, int port, final PipelineInitializer pipeliner) {
         ServerBootstrap b = new ServerBootstrap();
-            b.group(m_bossGroup, m_workerGroup)
-             .channel(NioServerSocketChannel.class) 
-             .childHandler(new ChannelInitializer<SocketChannel>() { 
-                 @Override
-                 public void initChannel(SocketChannel ch) throws Exception {
-                    ChannelPipeline pipeline = ch.pipeline();
-                    //pipeline.addFirst("metrics", new BytesMetricsHandler(m_metricsCollector));
-                    pipeline.addFirst("idleStateHandler", new IdleStateHandler(0, 0, Constants.DEFAULT_CONNECT_TIMEOUT));
-                    pipeline.addAfter("idleStateHandler", "idleEventHandler", new MoquetteIdleTimoutHandler());
-                    //pipeline.addLast("logger", new LoggingHandler("Netty", LogLevel.ERROR));
-                    pipeline.addLast("decoder", new MQTTDecoder());
-                    pipeline.addLast("encoder", new MQTTEncoder());
-                    pipeline.addLast("metrics", new MessageMetricsHandler(m_metricsCollector));
-                    pipeline.addLast("handler", handler);
-                 }
-             })
-             .option(ChannelOption.SO_BACKLOG, 128)
-             .option(ChannelOption.SO_REUSEADDR, true)
-             .childOption(ChannelOption.SO_KEEPALIVE, true);
+        b.group(m_bossGroup, m_workerGroup)
+                .channel(NioServerSocketChannel.class)
+                .childHandler(new ChannelInitializer<SocketChannel>() {
+                    @Override
+                    public void initChannel(SocketChannel ch) throws Exception {
+                        ChannelPipeline pipeline = ch.pipeline();
+                        try {
+                            pipeliner.init(pipeline);
+                        } catch (Throwable th) {
+                            LOG.error("Severe error during pipeline creation", th);
+                            throw th;
+                        }
+                    }
+                })
+                .option(ChannelOption.SO_BACKLOG, 128)
+                .option(ChannelOption.SO_REUSEADDR, true)
+                .option(ChannelOption.TCP_NODELAY, true)
+                .childOption(ChannelOption.SO_KEEPALIVE, true);
         try {
             // Bind and start to accept incoming connections.
-//            ChannelFuture f = b.bind(Constants.PORT);
-            ChannelFuture f = b.bind(props.getProperty("host"), Integer.parseInt(props.getProperty("port")));
-            LOG.info("Listening to MQTT on port : "+props.getProperty("port"));
+            ChannelFuture f = b.bind(host, port);
+            LOG.info("Server binded host: {}, port: {}", host, port);
             f.sync();
         } catch (InterruptedException ex) {
             LOG.error(null, ex);
         }
+    }
+
+    private void initializePlainTCPTransport(IMessaging messaging, Properties props) throws IOException {
+        final NettyMQTTHandler handler = new NettyMQTTHandler();
+        handler.setMessaging(messaging);
+        String host = props.getProperty(Constants.HOST_PROPERTY_NAME);
+        int port = Integer.parseInt(props.getProperty(Constants.PORT_PROPERTY_NAME));
+        initFactory(host, port, new PipelineInitializer() {
+            @Override
+            void init(ChannelPipeline pipeline) {
+                pipeline.addFirst("idleStateHandler", new IdleStateHandler(0, 0, Constants.DEFAULT_CONNECT_TIMEOUT));
+                pipeline.addAfter("idleStateHandler", "idleEventHandler", new MoquetteIdleTimoutHandler());
+                //pipeline.addLast("logger", new LoggingHandler("Netty", LogLevel.ERROR));
+                pipeline.addFirst("bytemetrics", new BytesMetricsHandler(m_bytesMetricsCollector));
+                pipeline.addLast("decoder", new MQTTDecoder());
+                pipeline.addLast("encoder", new MQTTEncoder());
+                pipeline.addLast("metrics", new MessageMetricsHandler(m_metricsCollector));
+                pipeline.addLast("handler", handler);
+            }
+        });
+    }
+
+    private void initializeWebSocketTransport(IMessaging messaging, Properties props) throws IOException {
+        String webSocketPortProp = props.getProperty(Constants.WEB_SOCKET_PORT_PROPERTY_NAME);
+        if (webSocketPortProp == null) {
+            //Do nothing no WebSocket configured
+            LOG.info("WebSocket is disabled");
+            return;
+        }
+        int port = Integer.parseInt(webSocketPortProp);
+
+        final NettyMQTTHandler handler = new NettyMQTTHandler();
+        handler.setMessaging(messaging);
+
+        String host = props.getProperty(Constants.HOST_PROPERTY_NAME);
+        initFactory(host, port, new PipelineInitializer() {
+            @Override
+            void init(ChannelPipeline pipeline) {
+                pipeline.addLast("httpEncoder", new HttpResponseEncoder());
+                pipeline.addLast("httpDecoder", new HttpRequestDecoder());
+                pipeline.addLast("aggregator", new HttpObjectAggregator(65536));
+                pipeline.addLast("webSocketHandler", new WebSocketServerProtocolHandler("/mqtt"/*"/mqtt"*/, "mqttv3.1, mqttv3.1.1"));
+                //pipeline.addLast("webSocketHandler", new WebSocketServerProtocolHandler(null, "mqtt"));
+                pipeline.addLast("ws2bytebufDecoder", new WebSocketFrameToByteBufDecoder());
+                pipeline.addLast("bytebuf2wsEncoder", new ByteBufToWebSocketFrameEncoder());
+                pipeline.addFirst("idleStateHandler", new IdleStateHandler(0, 0, Constants.DEFAULT_CONNECT_TIMEOUT));
+                pipeline.addAfter("idleStateHandler", "idleEventHandler", new MoquetteIdleTimoutHandler());
+                pipeline.addFirst("bytemetrics", new BytesMetricsHandler(m_bytesMetricsCollector));
+                pipeline.addLast("decoder", new MQTTDecoder());
+                pipeline.addLast("encoder", new MQTTEncoder());
+                pipeline.addLast("metrics", new MessageMetricsHandler(m_metricsCollector));
+                pipeline.addLast("handler", handler);
+            }
+        });
+    }
+
+    private void initializeSSLTCPTransport(IMessaging messaging, Properties props, final SslHandler sslHandler)
+            throws IOException {
+        String sslPortProp = props.getProperty(Constants.SSL_PORT_PROPERTY_NAME);
+        //TODO need to re visit
+        sslPortProp = props.get(Constants.SSL_PORT_PROPERTY_NAME).toString();
+        if (sslPortProp == null) {
+            //Do nothing no SSL configured
+            LOG.info("SSL is disabled");
+            return;
+        }
+
+        int sslPort = Integer.parseInt(sslPortProp);
+        LOG.info("Starting SSL on port {}", sslPort);
+
+        final NettyMQTTHandler handler = new NettyMQTTHandler();
+        handler.setMessaging(messaging);
+        String host = props.getProperty(Constants.HOST_PROPERTY_NAME);
+        initFactory(host, sslPort, new PipelineInitializer() {
+            @Override
+            void init(ChannelPipeline pipeline) throws Exception {
+                pipeline.addLast("ssl", sslHandler);
+                pipeline.addFirst("idleStateHandler", new IdleStateHandler(0, 0, Constants.DEFAULT_CONNECT_TIMEOUT));
+                pipeline.addAfter("idleStateHandler", "idleEventHandler", new MoquetteIdleTimoutHandler());
+                //pipeline.addLast("logger", new LoggingHandler("Netty", LogLevel.ERROR));
+                pipeline.addFirst("bytemetrics", new BytesMetricsHandler(m_bytesMetricsCollector));
+                pipeline.addLast("decoder", new MQTTDecoder());
+                pipeline.addLast("encoder", new MQTTEncoder());
+                pipeline.addLast("metrics", new MessageMetricsHandler(m_metricsCollector));
+                pipeline.addLast("handler", handler);
+            }
+        });
+    }
+
+    private void initializeWSSTransport(IMessaging messaging, Properties props, final SslHandler sslHandler)
+            throws IOException {
+        String sslPortProp = props.getProperty(Constants.WSS_PORT_PROPERTY_NAME);
+        if (sslPortProp == null) {
+            //Do nothing no SSL configured
+            LOG.info("SSL is disabled");
+            return;
+        }
+        int sslPort = Integer.parseInt(sslPortProp);
+        final NettyMQTTHandler handler = new NettyMQTTHandler();
+        handler.setMessaging(messaging);
+        String host = props.getProperty(Constants.HOST_PROPERTY_NAME);
+        initFactory(host, sslPort, new PipelineInitializer() {
+            @Override
+            void init(ChannelPipeline pipeline) throws Exception {
+                pipeline.addLast("ssl", sslHandler);
+                pipeline.addLast("httpEncoder", new HttpResponseEncoder());
+                pipeline.addLast("httpDecoder", new HttpRequestDecoder());
+                pipeline.addLast("aggregator", new HttpObjectAggregator(65536));
+                pipeline.addLast("webSocketHandler", new WebSocketServerProtocolHandler("/mqtt", "mqttv3.1, mqttv3.1.1"));
+                pipeline.addLast("ws2bytebufDecoder", new WebSocketFrameToByteBufDecoder());
+                pipeline.addLast("bytebuf2wsEncoder", new ByteBufToWebSocketFrameEncoder());
+                pipeline.addFirst("idleStateHandler", new IdleStateHandler(0, 0, Constants.DEFAULT_CONNECT_TIMEOUT));
+                pipeline.addAfter("idleStateHandler", "idleEventHandler", new MoquetteIdleTimoutHandler());
+                pipeline.addFirst("bytemetrics", new BytesMetricsHandler(m_bytesMetricsCollector));
+                pipeline.addLast("decoder", new MQTTDecoder());
+                pipeline.addLast("encoder", new MQTTEncoder());
+                pipeline.addLast("metrics", new MessageMetricsHandler(m_metricsCollector));
+                pipeline.addLast("handler", handler);
+            }
+        });
     }
 
     public void close() {
@@ -83,8 +286,76 @@ public class NettyAcceptor implements ServerAcceptor {
         m_bossGroup.shutdownGracefully();
 
         MessageMetrics metrics = m_metricsCollector.computeMetrics();
-        //LOG.info(String.format("Bytes read: %d, bytes wrote: %d", metrics.readBytes(), metrics.wroteBytes()));
         LOG.info("Msg read: {}, msg wrote: {}", metrics.messagesRead(), metrics.messagesWrote());
+
+        BytesMetrics bytesMetrics = m_bytesMetricsCollector.computeMetrics();
+        LOG.info(String.format("Bytes read: %d, bytes wrote: %d", bytesMetrics.readBytes(), bytesMetrics.wroteBytes()));
     }
-    
+
+
+    private SslHandler initSSLHandler(Properties props) {
+        String jksPath = props.getProperty(Constants.JKS_PATH_PROPERTY_NAME);
+        //TODO remove the below hard coded
+        jksPath = "/Users/pamod/Desktop/dev/MQTTUpgrade/wso2mb-3.0.0-SNAPSHOT/repository/resources/security/wso2carbon.jks";
+        LOG.info("Starting SSL using keystore at {}", jksPath);
+        if (jksPath == null || jksPath.isEmpty()) {
+            //key_store_password or key_manager_password are empty
+            LOG.warn("You have configured the SSL port but not the jks_path, SSL not started");
+            return null;
+        }
+
+        //if we have the port also the jks then keyStorePassword and keyManagerPassword
+        //has to be defined
+        String keyStorePassword = props.getProperty(Constants.KEY_STORE_PASSWORD_PROPERTY_NAME);
+        String keyManagerPassword = props.getProperty(Constants.KEY_MANAGER_PASSWORD_PROPERTY_NAME);
+        //TODO remove the below
+        keyManagerPassword = "wso2carbon";
+        keyStorePassword = "wso2carbon";
+        if (keyStorePassword == null || keyStorePassword.isEmpty()) {
+            //key_store_password or key_manager_password are empty
+            LOG.warn("You have configured the SSL port but not the key_store_password, SSL not started");
+            return null;
+        }
+        if (keyManagerPassword == null || keyManagerPassword.isEmpty()) {
+            //key_manager_password or key_manager_password are empty
+            LOG.warn("You have configured the SSL port but not the key_manager_password, SSL not started");
+            return null;
+        }
+
+        try {
+            InputStream jksInputStream = jksDatastore(jksPath);
+            SSLContext serverContext = SSLContext.getInstance("TLS");
+            final KeyStore ks = KeyStore.getInstance("JKS");
+            ks.load(jksInputStream, keyStorePassword.toCharArray());
+            final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            kmf.init(ks, keyManagerPassword.toCharArray());
+            serverContext.init(kmf.getKeyManagers(), null, null);
+
+            SSLEngine engine = serverContext.createSSLEngine();
+            engine.setUseClientMode(false);
+            return new SslHandler(engine);
+        } catch (NoSuchAlgorithmException | UnrecoverableKeyException | CertificateException | KeyStoreException
+                | KeyManagementException | IOException ex) {
+            LOG.error("Can't start SSL layer!", ex);
+            return null;
+        }
+    }
+
+    private InputStream jksDatastore(String jksPath) throws FileNotFoundException {
+        URL jksUrl = getClass().getClassLoader().getResource(jksPath);
+        if (jksUrl != null) {
+            LOG.info("Starting with jks at {}, jks normal {}", jksUrl.toExternalForm(), jksUrl);
+            return getClass().getClassLoader().getResourceAsStream(jksPath);
+        }
+        LOG.info("jks not found in bundled resources, try on the filesystem");
+        File jksFile = new File(jksPath);
+        if (jksFile.exists()) {
+            LOG.info("Using {} ", jksFile.getAbsolutePath());
+            return new FileInputStream(jksFile);
+        }
+        LOG.warn("File {} doesn't exists", jksFile.getAbsolutePath());
+        return null;
+    }
+
+
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/server/netty/NettyChannel.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/server/netty/NettyChannel.java
@@ -20,16 +20,19 @@ public class NettyChannel implements ServerChannel {
     private ChannelHandlerContext m_channel;
     
     private Map<Object, AttributeKey<Object>> m_attributesKeys = new HashMap<Object, AttributeKey<Object>>();
+    public static final String ATTR_USERNAME = "username";
     
     private static final AttributeKey<Object> ATTR_KEY_KEEPALIVE = new AttributeKey<Object>(Constants.KEEP_ALIVE);
     private static final AttributeKey<Object> ATTR_KEY_CLEANSESSION = new AttributeKey<Object>(Constants.CLEAN_SESSION);
     private static final AttributeKey<Object> ATTR_KEY_CLIENTID = new AttributeKey<Object>(Constants.ATTR_CLIENTID);
+    public static final AttributeKey<Object> ATTR_KEY_USERNAME = AttributeKey.valueOf(ATTR_USERNAME);
 
     NettyChannel(ChannelHandlerContext ctx) {
         m_channel = ctx;
         m_attributesKeys.put(Constants.KEEP_ALIVE, ATTR_KEY_KEEPALIVE);
         m_attributesKeys.put(Constants.CLEAN_SESSION, ATTR_KEY_CLEANSESSION);
         m_attributesKeys.put(Constants.ATTR_CLIENTID, ATTR_KEY_CLIENTID);
+        m_attributesKeys.put(ATTR_USERNAME,ATTR_KEY_USERNAME);
     }
 
     public Object getAttribute(Object key) {
@@ -38,7 +41,7 @@ public class NettyChannel implements ServerChannel {
     }
 
     public void setAttribute(Object key, Object value) {
-        Attribute<Object> attr = m_channel.attr(mapKey(key));
+        Attribute<Object> attr = m_channel.attr(mapKey(key.toString()));
         attr.set(value);
     }
     

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTopicManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTopicManager.java
@@ -286,7 +286,7 @@ public class MQTTopicManager {
         int mqttLocalMessageID = 1;
 
         //We need to keep track of the message if the QOS level is > 0
-        if (subscriberQOS > QOSLevel.AT_MOST_ONCE.getValue()) {
+        if (Math.min(publishedQOS,subscriberQOS) > QOSLevel.AT_MOST_ONCE.getValue()) {
             //We need to add the message information to maintain state, in-order to identify the messages
             // once the acks receive
 

--- a/modules/andes-core/pom.xml
+++ b/modules/andes-core/pom.xml
@@ -295,7 +295,7 @@
         </dependency>
         <!--MQTT Dependencies-->
         <dependency>
-            <groupId>io.netty</groupId>
+            <groupId>io.netty.wso2</groupId>
             <artifactId>netty-all</artifactId>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
             </dependency>
             <!--MQTT Dependencies-->
             <dependency>
-                <groupId>io.netty</groupId>
+                <groupId>io.netty.wso2</groupId>
                 <artifactId>netty-all</artifactId>
                 <version>${netty-all.version}</version>
                 <optional>true</optional>
@@ -610,7 +610,7 @@
         <velocity.version>1.5</velocity.version>
         <xalan.version>2.7.0</xalan.version>
         <ant.version>1.8.1</ant.version>
-        <netty-all.version>4.0.8.Final</netty-all.version>
+        <netty-all.version>4.0.23.wso2v1</netty-all.version>
         <hawtdb.version>1.6</hawtdb.version>
         <hawtbuf.version>1.9</hawtbuf.version>
         <hazelcast.version>3.2.6.wso2v2</hazelcast.version>


### PR DESCRIPTION
The upgrade basically allows MQTT 3.1.1 versioned headers to be accepted along with 3.1 versioned headers. 

The change will not include the following functionality which is define in the 3.1.1 specification, 

1. Session Present Flag - An additional flag introduced with 3.1.1 specification to indicate with the CONACK message, the existence of a session if a subscriber with clean session false re connects 
2. Subscription error codes -  Error returned through the SUBACK message to inform the subscribers at an event where the subscription is forbidden 
3. Anonymous Subscriptions -  Ability to subscribe with 0 byte client identifiers 
