### PR TITLE
Add tenant support for MQTT.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTAuthorizationSubject.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTAuthorizationSubject.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ */
+
+package org.wso2.andes.mqtt;
+
+/**
+ * Stores authorization details for MQTT clients.
+ */
+public class MQTTAuthorizationSubject {
+
+    /**
+     * The MQTT Client ID.
+     */
+    private String clientID;
+
+    /**
+     * User flag (true/false) of the connecting client.
+     */
+    private boolean userFlag;
+
+    /**
+     * The tenant domain client has connected to.
+     */
+    private String tenantDomain;
+
+    /**
+     * Initialize Authorization Subject with the clientID and userFlag which is required.
+     *
+     * @param clientID The MQTT ClientID
+     * @param userFlag Is the user flag set in the MQTT Client
+     */
+    public MQTTAuthorizationSubject(String clientID, boolean userFlag) {
+        this.clientID = clientID;
+        this.userFlag = userFlag;
+    }
+
+    public String getClientID() {
+        return clientID;
+    }
+
+    public void setClientID(String clientID) {
+        this.clientID = clientID;
+    }
+
+    public boolean isUserFlag() {
+        return userFlag;
+    }
+
+    public void setUserFlag(boolean userFlag) {
+        this.userFlag = userFlag;
+    }
+
+    public String getTenantDomain() {
+        return tenantDomain;
+    }
+
+    public void setTenantDomain(String tenantDomain) {
+        this.tenantDomain = tenantDomain;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/utils/MQTTUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/utils/MQTTUtils.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.dna.mqtt.moquette.messaging.spi.impl.subscriptions.SubscriptionsStore;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.wso2.QOSLevel;
+import org.wso2.andes.kernel.AndesConstants;
 import org.wso2.andes.kernel.AndesContent;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesMessageMetadata;
@@ -31,6 +32,7 @@ import org.wso2.andes.kernel.disruptor.inbound.PubAckHandler;
 import org.wso2.andes.mqtt.MQTTMessageContext;
 import org.wso2.andes.mqtt.MQTTPublisherChannel;
 import org.wso2.andes.server.store.MessageMetaDataType;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.nio.ByteBuffer;
 import java.util.UUID;
@@ -260,6 +262,22 @@ public class MQTTUtils {
         messageContext.setChannel(socket);
 
         return messageContext;
+    }
+
+    /**
+     * Extract tenant name from a given topic.
+     *
+     * @param topic The topic to retrieve tenant name
+     * @return Tenant name extracted from topic
+     */
+    public static String getTenantFromTopic(String topic) {
+        String tenant = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+
+        if (null != topic && topic.contains(AndesConstants.TENANT_SEPARATOR)) {
+            tenant = topic.split(AndesConstants.TENANT_SEPARATOR)[0];
+        }
+
+        return tenant;
     }
 
 }


### PR DESCRIPTION
Add tenant authentication for MQTT.

MQTT publish or subscribe methods does not allow to provide authentication information. Therefore keeps MQTT client information in memory when connecting and use those information when publishing or subscribing to do tenant validation. 

These details are removed when the client is disconnected.