### PR TITLE
Added new delivery strategies for topic message delivey

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/AndesConfigurationManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/AndesConfigurationManager.java
@@ -51,6 +51,7 @@ import org.jaxen.JaxenException;
 import org.w3c.dom.Document;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
 import org.wso2.andes.configuration.util.ConfigurationProperty;
+import org.wso2.andes.kernel.AndesContext;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.securevault.SecretResolver;
@@ -167,6 +168,11 @@ public class AndesConfigurationManager {
 
             // set carbonPortOffset coming from carbon
             AndesConfigurationManager.carbonPortOffset = portOffset;
+
+            //set delivery timeout for a message
+            int deliveryTimeoutForMessage = AndesConfigurationManager.readValue(AndesConfiguration
+                    .PERFORMANCE_TUNING_TOPIC_MESSAGE_DELIVERY_TIMEOUT);
+            AndesContext.getInstance().setDeliveryTimeoutForMessage(deliveryTimeoutForMessage);
 
         } catch (ConfigurationException e) {
             String error = "Error occurred when trying to construct configurations from file at path : " + brokerConfigFilePath;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -22,7 +22,7 @@ import org.wso2.andes.configuration.modules.JKSStore;
 import org.wso2.andes.configuration.util.ConfigurationProperty;
 import org.wso2.andes.configuration.util.ImmutableMetaProperties;
 import org.wso2.andes.configuration.util.MetaProperties;
-import org.wso2.andes.kernel.TopicMessageDeliveryStrategy;
+import org.wso2.andes.configuration.util.TopicMessageDeliveryStrategy;
 
 import java.util.List;
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -387,9 +387,20 @@ public enum AndesConfiguration implements ConfigurationProperty {
     PERFORMANCE_TUNING_ACK_HANDLING_MAX_UNACKED_MESSAGES("performanceTuning/ackHandling" +
             "/maxUnackedMessages", "1000", Integer.class),
 
+    /**
+     * When delivering topic messages to multiple topic subscribers a strategy can be chosen.
+     */
     PERFORMANCE_TUNING_TOPIC_MESSAGE_DELIVERY_STRATEGY("performanceTuning/delivery/"
-            + "topicMessageDeliveryStrategy", TopicMessageDeliveryStrategy.DISCARD_NONE.toString() ,
+            + "topicMessageDeliveryStrategy/strategyName", TopicMessageDeliveryStrategy.DISCARD_NONE.toString() ,
             TopicMessageDeliveryStrategy.class),
+
+    /**
+     * If you choose DISCARD_ALLOWED topic message delivery strategy, we keep messages in memory
+     * until ack is done until this timeout. If an ack is not received under this timeout, ack will
+     * be simulated internally and real acknowledgement is discarded.
+     */
+    PERFORMANCE_TUNING_TOPIC_MESSAGE_DELIVERY_TIMEOUT("performanceTuning/delivery/"
+            + "topicMessageDeliveryStrategy/deliveryTimeout", "60" , Integer.class),
 
     /**
      * Time interval after which the Virtual host syncing Task can sync host details across the cluster.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -22,6 +22,7 @@ import org.wso2.andes.configuration.modules.JKSStore;
 import org.wso2.andes.configuration.util.ConfigurationProperty;
 import org.wso2.andes.configuration.util.ImmutableMetaProperties;
 import org.wso2.andes.configuration.util.MetaProperties;
+import org.wso2.andes.kernel.TopicMessageDeliveryStrategy;
 
 import java.util.List;
 
@@ -385,6 +386,10 @@ public enum AndesConfiguration implements ConfigurationProperty {
      */
     PERFORMANCE_TUNING_ACK_HANDLING_MAX_UNACKED_MESSAGES("performanceTuning/ackHandling" +
             "/maxUnackedMessages", "1000", Integer.class),
+
+    PERFORMANCE_TUNING_TOPIC_MESSAGE_DELIVERY_STRATEGY("performanceTuning/delivery/"
+            + "topicMessageDeliveryStrategy", TopicMessageDeliveryStrategy.DISCARD_NONE.toString() ,
+            TopicMessageDeliveryStrategy.class),
 
     /**
      * Time interval after which the Virtual host syncing Task can sync host details across the cluster.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/util/TopicMessageDeliveryStrategy.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/util/TopicMessageDeliveryStrategy.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.wso2.andes.kernel;
+package org.wso2.andes.configuration.util;
 
 /**
  * Enum to specify message delivery strategies for topic messages. This is configured

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContext.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContext.java
@@ -40,6 +40,7 @@ public class AndesContext {
     private AMQPConstructStore AMQPConstructStore;
     private static AndesContext instance = new AndesContext();
     private MessageStore messageStore;
+    private int deliveryTimeoutForMessage;
 
     /**
      * This is mainly used by Cluster Manager to manger cluster communication
@@ -207,6 +208,24 @@ public class AndesContext {
             storeConfiguration.addContextStoreProperty(contextStoreProperty, (String) AndesConfigurationManager
                     .readValueOfChildByKey(AndesConfiguration.PERSISTENCE_CONTEXT_STORE_PROPERTY,contextStoreProperty));
         }
+    }
+
+    /**
+     * Get delivery time out of a message. If this is breached an ack for the message
+     * will be simulated internally.
+     * @return time out value
+     */
+    public int getDeliveryTimeoutForMessage() {
+        return deliveryTimeoutForMessage;
+    }
+
+    /**
+     * Set delivery time out of a message. If this is breached an ack for the message
+     * will be simulated internally.
+     * @param deliveryTimeoutForMessage time out value to set
+     */
+    public void setDeliveryTimeoutForMessage(int deliveryTimeoutForMessage) {
+        this.deliveryTimeoutForMessage = deliveryTimeoutForMessage;
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
@@ -64,7 +64,7 @@ public class FlowControlledQueueMessageDeliveryImpl implements MessageDeliverySt
                 Collection<LocalSubscription> subscriptions4Queue =
                         subscriptionStore.getActiveLocalSubscribers(destination, message.isTopic());
 
-                if (subscriptions4Queue.size() == 0) {
+                if (subscriptions4Queue.isEmpty()) {
                     // We don't have subscribers for this message
                     // Handle orphaned slot created with this no subscription scenario for queue
                     orphanedSlot = true;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.subscription.SubscriptionStore;
+
+import java.util.*;
+
+/**
+ * Strategy definition for queue message delivery
+ */
+public class FlowControlledQueueMessageDeliveryImpl implements MessageDeliveryStrategy {
+
+    private static Log log = LogFactory.getLog(FlowControlledQueueMessageDeliveryImpl.class);
+    private SubscriptionStore subscriptionStore;
+
+    public FlowControlledQueueMessageDeliveryImpl(SubscriptionStore subscriptionStore) {
+        this.subscriptionStore = subscriptionStore;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int deliverMessageToSubscriptions(String destination, Set<AndesMessageMetadata> messages) throws
+            AndesException {
+
+        int sentMessageCount = 0;
+        boolean orphanedSlot = false;
+        Iterator<AndesMessageMetadata> iterator = messages.iterator();
+
+
+        while (iterator.hasNext()) {
+
+            try {
+
+                AndesMessageMetadata message = iterator.next();
+
+                /**
+                 * get all relevant type of subscriptions. This call does NOT
+                 * return hierarchical subscriptions for the destination. There
+                 * are duplicated messages for each different subscribed destination.
+                 * For durable topic subscriptions this should return queue subscription
+                 * bound to unique queue based on subscription id
+                 */
+                Collection<LocalSubscription> subscriptions4Queue =
+                        subscriptionStore.getActiveLocalSubscribers(destination, message.isTopic());
+
+                if (subscriptions4Queue.size() == 0) {
+                    // We don't have subscribers for this message
+                    // Handle orphaned slot created with this no subscription scenario for queue
+                    orphanedSlot = true;
+                    break; // break the loop
+                }
+
+                int numOfCurrentMsgDeliverySchedules = 0;
+
+                /**
+                 * if message is addressed to queues, only ONE subscriber should
+                 * get the message. Otherwise, loop for every subscriber
+                 */
+                for (int j = 0; j < subscriptions4Queue.size(); j++) {
+                    LocalSubscription localSubscription = MessageFlusher.getInstance().
+                            findNextSubscriptionToSent(destination, subscriptions4Queue);
+                    if (localSubscription.hasRoomToAcceptMessages()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Scheduled to send id = " + message.getMessageID());
+                        }
+
+                        // In a re-queue for delivery scenario we need the correct destination. Hence setting
+                        // it back correctly in AndesMetadata for durable subscription for topics
+                        if (localSubscription.isBoundToTopic()) {
+                            message.setDestination(localSubscription.getSubscribedDestination());
+                        }
+
+                        MessageFlusher.getInstance().deliverMessageAsynchronously(localSubscription, message);
+                        numOfCurrentMsgDeliverySchedules++;
+
+                        //for queue messages and durable topic messages (as they are now queue messages)
+                        // we only send to one selected subscriber if it is a queue message
+                        break;
+                    }
+                }
+
+                if (numOfCurrentMsgDeliverySchedules == 1) {
+                    iterator.remove();
+                    if (log.isDebugEnabled()) {
+                        log.debug("Removing Scheduled to send message from buffer. MsgId= " + message.getMessageID());
+                    }
+                    sentMessageCount++;
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("All subscriptions for destination " + destination + " have max unacked " +
+                                "messages " + message.getDestination());
+                    }
+                    //if we continue message order will break
+                    break;
+                }
+
+            } catch (NoSuchElementException ex) {
+                // This exception can occur because the iterator of ConcurrentSkipListSet loads the at-the-time snapshot.
+                // Some records could be deleted by the time the iterator reaches them.
+                // However, this can only happen at the tail of the collection, not in middle, and it would cause the loop
+                // to blindly check for a batch of deleted records.
+                // Given this situation, this loop should break so the sendFlusher can re-trigger it.
+                // for tracing purposes can use this : log.warn("NoSuchElementException thrown",ex);
+                log.warn("NoSuchElementException thrown. ", ex);
+                break;
+            }
+        }
+        // clear all tracking when orphan slot situation
+        if (orphanedSlot) {
+            for (AndesMessageMetadata message : messages) {
+                OnflightMessageTracker.getInstance().clearAllTrackingWhenSlotOrphaned(message.getSlot());
+            }
+            messages.clear();
+        }
+
+        return sentMessageCount;
+    }
+
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageDeliveryStrategy.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageDeliveryStrategy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+
+import java.util.Set;
+
+/**
+ * This interface defines the structure of a message delivery strategy
+ */
+public interface MessageDeliveryStrategy {
+
+    /**
+     * Deliver message. It will find current subscriptions to deliver by the destination of the message
+     * and send the messages accordingly
+     * @param destination destination of messages
+     * @param messages messages to be sent
+     * @return number of messages sent
+     * @throws AndesException in case of a delivery failure
+     */
+    public int deliverMessageToSubscriptions(String destination, Set<AndesMessageMetadata> messages) throws
+            AndesException;
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageFlusher.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageFlusher.java
@@ -485,7 +485,8 @@ public class MessageFlusher {
                          * In this delivery strategy, we do not discard any message. This might cause OOM if
                          * subscribers did not ACK to release the resources fast enough.
                          */
-                    } else if(topicMessageDeliveryStrategy.equals(TopicMessageDeliveryStrategy.DISCARD_NONE)) {
+                    } else if(topicMessageDeliveryStrategy.equals(TopicMessageDeliveryStrategy.DISCARD_NONE) ||
+                            topicMessageDeliveryStrategy.equals(TopicMessageDeliveryStrategy.DISCARD_ALLOWED)) {
                         for (int j = 0; j < subscriptions4Queue.size(); j++) {
                             LocalSubscription localSubscription = findNextSubscriptionToSent(destination,
                                     subscriptions4Queue);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageFlusher.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageFlusher.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
+import org.wso2.andes.configuration.util.TopicMessageDeliveryStrategy;
 import org.wso2.andes.kernel.disruptor.delivery.DisruptorBasedFlusher;
 import org.wso2.andes.kernel.slot.Slot;
 import org.wso2.andes.subscription.SubscriptionStore;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.server.store.MessageMetaDataType;
+import org.wso2.andes.subscription.SubscriptionStore;
+
+import java.util.*;
+
+/**
+ * This class implements topic message delivery. This implementation will deliver every message
+ * to every subscriber without any message loss or without considering overflowing memory.
+ */
+public class NoLossBurstTopicMessageDeliveryImpl implements MessageDeliveryStrategy {
+
+    private static Log log = LogFactory.getLog(NoLossBurstTopicMessageDeliveryImpl.class);
+    private SubscriptionStore subscriptionStore;
+
+    public NoLossBurstTopicMessageDeliveryImpl(SubscriptionStore subscriptionStore) {
+        this.subscriptionStore = subscriptionStore;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int deliverMessageToSubscriptions(String destination, Set<AndesMessageMetadata> messages) throws
+            AndesException {
+        int sentMessageCount = 0;
+        Iterator<AndesMessageMetadata> iterator = messages.iterator();
+        List<AndesRemovableMetadata> droppedTopicMessagesListRemovable = new ArrayList<AndesRemovableMetadata>();
+        List<AndesMessageMetadata> droppedTopicMessagesList = new ArrayList<AndesMessageMetadata>();
+
+
+        while (iterator.hasNext()) {
+
+            try {
+                AndesMessageMetadata message = iterator.next();
+
+                /**
+                 * get all relevant type of subscriptions. This call does NOT
+                 * return hierarchical subscriptions for the destination. There
+                 * are duplicated messages for each different subscribed destination.
+                 * For durable topic subscriptions this should return queue subscription
+                 * bound to unique queue based on subscription id
+                 */
+                Collection<LocalSubscription> subscriptions4Queue =
+                        subscriptionStore.getActiveLocalSubscribers(destination, message.isTopic());
+
+                //If this is a topic message, we remove all durable topic subscriptions here.
+                //Because durable topic subscriptions will get messages via queue path.
+                Iterator<LocalSubscription> subscriptionIterator = subscriptions4Queue.iterator();
+                while (subscriptionIterator.hasNext()) {
+                    LocalSubscription subscription = subscriptionIterator.next();
+                    /**
+                     * Here we need to consider the arrival time of the message. Only topic
+                     * subscribers who appeared before publishing this message should receive it
+                     */
+                    if (subscription.isDurable() || (subscription.getSubscribeTime() > message.getArrivalTime())) {
+                        subscriptionIterator.remove();
+                    }
+
+                    // Avoid sending if the subscriber is MQTT and message is not MQTT
+                    if (AndesSubscription.SubscriptionType.MQTT == subscription.getSubscriptionType()
+                            && MessageMetaDataType.META_DATA_MQTT != message.getMetaDataType()) {
+                        subscriptionIterator.remove();
+                        // Avoid sending if the subscriber is AMQP and message is MQTT
+                    } else if (AndesSubscription.SubscriptionType.AMQP == subscription.getSubscriptionType()
+                            && MessageMetaDataType.META_DATA_MQTT == message.getMetaDataType()) {
+                        subscriptionIterator.remove();
+                    }
+                }
+
+                if (subscriptions4Queue.size() == 0) {
+                    iterator.remove(); // remove buffer
+                    AndesRemovableMetadata removableMetadata = new AndesRemovableMetadata(message.getMessageID(),
+                            message.getDestination(), message.getStorageQueueName());
+                    droppedTopicMessagesListRemovable.add(removableMetadata);
+                    droppedTopicMessagesList.add(message);
+
+                    continue; // skip this iteration if no subscriptions for the message
+                }
+
+                for (int j = 0; j < subscriptions4Queue.size(); j++) {
+                    LocalSubscription localSubscription = MessageFlusher.getInstance()
+                            .findNextSubscriptionToSent(destination, subscriptions4Queue);
+                    MessageFlusher.getInstance().deliverMessageAsynchronously(localSubscription, message);
+                }
+                iterator.remove();
+                if (log.isDebugEnabled()) {
+                    log.debug("Removing Scheduled to send message from buffer. MsgId= " + message.getMessageID());
+                }
+                sentMessageCount++;
+
+
+            } catch (NoSuchElementException ex) {
+                // This exception can occur because the iterator of ConcurrentSkipListSet loads the at-the-time snapshot.
+                // Some records could be deleted by the time the iterator reaches them.
+                // However, this can only happen at the tail of the collection, not in middle, and it would cause the loop
+                // to blindly check for a batch of deleted records.
+                // Given this situation, this loop should break so the sendFlusher can re-trigger it.
+                // for tracing purposes can use this : log.warn("NoSuchElementException thrown",ex);
+                log.warn("NoSuchElementException thrown. ", ex);
+                break;
+            }
+        }
+
+
+        /**
+         * Here we do not need to have orphaned slot scenario (return slot). If there are no subscribers
+         * slot will be consumed and metadata will be removed. We duplicate topic messages per node
+         */
+
+
+        /**
+         * delete topic messages that were dropped due to no subscriptions
+         * for the message and due to has no room to enqueue the message. Delete
+         * call is blocking and then slot message count is dropped in order
+         */
+        MessagingEngine.getInstance().deleteMessages(droppedTopicMessagesListRemovable, false);
+
+        for (AndesMessageMetadata messageToRemove : droppedTopicMessagesList) {
+            OnflightMessageTracker.getInstance().decrementMessageCountInSlot(messageToRemove.getSlot());
+        }
+
+        return sentMessageCount;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.wso2.andes.kernel;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.server.store.MessageMetaDataType;
+import org.wso2.andes.subscription.SubscriptionStore;
+
+import java.util.*;
+
+/**
+ * This class implements topic message delivery. Topic message delivery to multiple subscriptions will be controlled
+ * to the slowest subscriber (acknowledge rate) message consuming rate.
+ */
+public class SlowestSubscriberTopicMessageDeliveryImpl implements MessageDeliveryStrategy {
+
+    private static Log log = LogFactory.getLog(SlowestSubscriberTopicMessageDeliveryImpl.class);
+    private SubscriptionStore subscriptionStore;
+
+    public SlowestSubscriberTopicMessageDeliveryImpl(SubscriptionStore subscriptionStore) {
+        this.subscriptionStore = subscriptionStore;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int deliverMessageToSubscriptions(String destination, Set<AndesMessageMetadata> messages) throws
+            AndesException {
+
+        int sentMessageCount = 0;
+        Iterator<AndesMessageMetadata> iterator = messages.iterator();
+        List<AndesRemovableMetadata> droppedTopicMessagesListRemovable = new ArrayList<AndesRemovableMetadata>();
+        List<AndesMessageMetadata> droppedTopicMessagesList = new ArrayList<AndesMessageMetadata>();
+
+
+        while (iterator.hasNext()) {
+
+            try {
+                AndesMessageMetadata message = iterator.next();
+
+
+                /**
+                 * get all relevant type of subscriptions. This call does NOT
+                 * return hierarchical subscriptions for the destination. There
+                 * are duplicated messages for each different subscribed destination.
+                 * For durable topic subscriptions this should return queue subscription
+                 * bound to unique queue based on subscription id
+                 */
+                Collection<LocalSubscription> subscriptions4Queue =
+                        subscriptionStore.getActiveLocalSubscribers(destination, message.isTopic());
+
+                //If this is a topic message, we remove all durable topic subscriptions here.
+                //Because durable topic subscriptions will get messages via queue path.
+                Iterator<LocalSubscription> subscriptionIterator = subscriptions4Queue.iterator();
+                while (subscriptionIterator.hasNext()) {
+                    LocalSubscription subscription = subscriptionIterator.next();
+                    /**
+                     * Here we need to consider the arrival time of the message. Only topic
+                     * subscribers who appeared before publishing this message should receive it
+                     */
+                    if (subscription.isDurable() || (subscription.getSubscribeTime() > message.getArrivalTime())) {
+                        subscriptionIterator.remove();
+                    }
+
+                    // Avoid sending if the subscriber is MQTT and message is not MQTT
+                    if (AndesSubscription.SubscriptionType.MQTT == subscription.getSubscriptionType()
+                            && MessageMetaDataType.META_DATA_MQTT != message.getMetaDataType()) {
+                        subscriptionIterator.remove();
+                        // Avoid sending if the subscriber is AMQP and message is MQTT
+                    } else if (AndesSubscription.SubscriptionType.AMQP == subscription.getSubscriptionType()
+                            && MessageMetaDataType.META_DATA_MQTT == message.getMetaDataType()) {
+                        subscriptionIterator.remove();
+                    }
+                }
+
+                if (subscriptions4Queue.size() == 0) {
+                    iterator.remove(); // remove buffer
+                    AndesRemovableMetadata removableMetadata = new AndesRemovableMetadata(message.getMessageID(),
+                            message.getDestination(), message.getStorageQueueName());
+                    droppedTopicMessagesListRemovable.add(removableMetadata);
+                    droppedTopicMessagesList.add(message);
+
+                    continue; // skip this iteration if no subscriptions for the message
+                }
+
+
+                /**
+                 * For normal non-durable topic we pre evaluate room for all subscribers and if all subs has room
+                 * to accept messages we send them. This means we operate to the speed of slowest subscriber (to
+                 * prevent OOM). If it is too slow to make others fast, make that topic subscriber a durable
+                 * topic subscriber.
+                 */
+                boolean allTopicSubscriptionsHasRoom = true;
+                for (LocalSubscription subscription : subscriptions4Queue) {
+                    if (!subscription.hasRoomToAcceptMessages()) {
+                        allTopicSubscriptionsHasRoom = false;
+                        break;
+                    }
+                }
+                if (allTopicSubscriptionsHasRoom) {
+                    //schedule message to all subscribers
+                    for (int j = 0; j < subscriptions4Queue.size(); j++) {
+                        LocalSubscription localSubscription = MessageFlusher.getInstance().
+                                findNextSubscriptionToSent(destination, subscriptions4Queue);
+                        MessageFlusher.getInstance().deliverMessageAsynchronously(localSubscription, message);
+                    }
+                    iterator.remove();
+                    if (log.isDebugEnabled()) {
+                        log.debug("Removing Scheduled to send message from buffer. MsgId= " + message.getMessageID());
+                    }
+                    sentMessageCount++;
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Some subscriptions for destination " + destination + " have max unacked " +
+                                "messages " + message.getDestination());
+                    }
+                    //if we continue message order will break
+                    break;
+                }
+
+
+            } catch (NoSuchElementException ex) {
+                // This exception can occur because the iterator of ConcurrentSkipListSet loads the at-the-time snapshot.
+                // Some records could be deleted by the time the iterator reaches them.
+                // However, this can only happen at the tail of the collection, not in middle, and it would cause the loop
+                // to blindly check for a batch of deleted records.
+                // Given this situation, this loop should break so the sendFlusher can re-trigger it.
+                // for tracing purposes can use this : log.warn("NoSuchElementException thrown",ex);
+                log.warn("NoSuchElementException thrown. ", ex);
+                break;
+            }
+        }
+
+        /**
+         * Here we do not need to have orphaned slot scenario (return slot). If there are no subscribers
+         * slot will be consumed and metadata will be removed. We duplicate topic messages per node
+         */
+
+
+        /**
+         * delete topic messages that were dropped due to no subscriptions
+         * for the message and due to has no room to enqueue the message. Delete
+         * call is blocking and then slot message count is dropped in order
+         */
+        MessagingEngine.getInstance().deleteMessages(droppedTopicMessagesListRemovable, false);
+
+        for (AndesMessageMetadata messageToRemove : droppedTopicMessagesList) {
+            OnflightMessageTracker.getInstance().decrementMessageCountInSlot(messageToRemove.getSlot());
+        }
+
+        return sentMessageCount;
+    }
+
+
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/TopicMessageDeliveryStrategy.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/TopicMessageDeliveryStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+/**
+ * Enum to specify message delivery strategies for topic messages
+ */
+public enum TopicMessageDeliveryStrategy {
+
+    /**
+     * broker do not loose any message to any subscriber. When there are slow
+     subscribers this can cause broker go Out of Memory.
+     */
+    DISCARD_NONE,
+
+    /**
+     * we deliver to the speed of the slowest topic subscriber. This can cause fast
+     subscribers to starve. But eliminate Out of Memory issue
+     */
+    SLOWEST_SUB_RATE,
+
+    /**
+     * broker will try best to deliver. To eliminate Out of Memory threat broker limits
+     sent but not acked message count to <maxUnackedMessages>. If it is breached, message can
+     either be lost or actually sent but ack is not honoured
+     */
+    DISCARD_ALLOWED
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/TopicMessageDeliveryStrategy.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/TopicMessageDeliveryStrategy.java
@@ -19,7 +19,8 @@
 package org.wso2.andes.kernel;
 
 /**
- * Enum to specify message delivery strategies for topic messages
+ * Enum to specify message delivery strategies for topic messages. This is configured
+ * at broker.xml under <delivery>/<topicMessageDeliveryStrategy>
  */
 public enum TopicMessageDeliveryStrategy {
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
@@ -143,7 +143,8 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
 
     private final MessageStore _messageStore;
 
-    private UnacknowledgedMessageMap _unacknowledgedMessageMap = new UnacknowledgedMessageMapImpl(DEFAULT_PREFETCH);
+    private UnacknowledgedMessageMap _unacknowledgedMessageMap = new UnacknowledgedMessageMapImpl(DEFAULT_PREFETCH,
+            this);
 
     // Set of messages being acknoweledged in the current transaction
     private SortedSet<QueueEntry> _acknowledgedMessages = new TreeSet<QueueEntry>();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/ack/LimitedSizeQueueEntryHolder.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/ack/LimitedSizeQueueEntryHolder.java
@@ -37,6 +37,7 @@ public class LimitedSizeQueueEntryHolder extends LinkedHashMap<Long, QueueEntry>
 
     protected static final Logger _logger = Logger.getLogger(LimitedSizeQueueEntryHolder.class);
 
+    //after the map size reach this limit eldest elements are considered to be removed
     private int growLimit;
 
     private AMQChannel amqChannel;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/ack/LimitedSizeQueueEntryHolder.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/ack/LimitedSizeQueueEntryHolder.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.server.ack;
+
+import org.apache.log4j.Logger;
+import org.wso2.andes.AMQException;
+import org.wso2.andes.amqp.AMQPUtils;
+import org.wso2.andes.amqp.QpidAndesBridge;
+import org.wso2.andes.configuration.AndesConfigurationManager;
+import org.wso2.andes.configuration.enums.AndesConfiguration;
+import org.wso2.andes.server.AMQChannel;
+import org.wso2.andes.server.message.AMQMessage;
+import org.wso2.andes.server.queue.QueueEntry;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class LimitedSizeQueueEntryHolder extends LinkedHashMap<Long, QueueEntry> {
+
+    protected static final Logger _logger = Logger.getLogger(LimitedSizeQueueEntryHolder.class);
+
+    private final int limit = AndesConfigurationManager.readValue
+            (AndesConfiguration.PERFORMANCE_TUNING_ACK_HANDLING_MAX_UNACKED_MESSAGES);
+
+    private AMQChannel amqChannel;
+
+    public LimitedSizeQueueEntryHolder(int initialCapacity, AMQChannel amqChannel) {
+        super(initialCapacity);
+        this.amqChannel = amqChannel;
+    }
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<Long, QueueEntry> eldest) {
+        if(size() > limit) {
+            QueueEntry eldestQueueEntry = eldest.getValue();
+            simulateAcknowledgement(eldestQueueEntry);
+            _logger.warn("Removing queue entry id= " + eldestQueueEntry.getMessage().getMessageNumber() + " as it is " +
+                    "growing");
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private void simulateAcknowledgement(QueueEntry queueEntry) {
+        try {
+            boolean isTopic = ((AMQMessage) queueEntry.getMessage()).getMessagePublishInfo()
+                    .getExchange()
+                    .equals(AMQPUtils
+                            .TOPIC_EXCHANGE_NAME);
+            QpidAndesBridge.ackReceived(amqChannel.getId(), queueEntry.getMessage().getMessageNumber(),
+                    queueEntry.getMessage().getRoutingKey(),
+                    isTopic);
+        } catch (AMQException e) {
+            _logger.error("Error while simulating acknowledgement for message id= " + queueEntry.getMessage()
+                    .getMessageNumber());
+        }
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/ack/LimitedSizeQueueEntryHolder.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/ack/LimitedSizeQueueEntryHolder.java
@@ -46,11 +46,13 @@ public class LimitedSizeQueueEntryHolder extends LinkedHashMap<Long, QueueEntry>
     }
     @Override
     protected boolean removeEldestEntry(Map.Entry<Long, QueueEntry> eldest) {
-        if(size() > limit) {
+        if(size() > limit && eldest.getValue().isTimelyDisposable()) {
             QueueEntry eldestQueueEntry = eldest.getValue();
+            eldestQueueEntry.getMessage().getArrivalTime();
+            _logger.warn("Simulating Acknowledgement and removing queue entry id= " + eldestQueueEntry.getMessage()
+                    .getMessageNumber() + " as it is "
+                    + "growing");
             simulateAcknowledgement(eldestQueueEntry);
-            _logger.warn("Removing queue entry id= " + eldestQueueEntry.getMessage().getMessageNumber() + " as it is " +
-                    "growing");
             return true;
         } else {
             return false;
@@ -68,7 +70,7 @@ public class LimitedSizeQueueEntryHolder extends LinkedHashMap<Long, QueueEntry>
                     isTopic);
         } catch (AMQException e) {
             _logger.error("Error while simulating acknowledgement for message id= " + queueEntry.getMessage()
-                    .getMessageNumber());
+                    .getMessageNumber(), e);
         }
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/ack/UnacknowledgedMessageMapImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/ack/UnacknowledgedMessageMapImpl.java
@@ -20,7 +20,7 @@ package org.wso2.andes.server.ack;
 import org.wso2.andes.AMQException;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
-import org.wso2.andes.kernel.TopicMessageDeliveryStrategy;
+import org.wso2.andes.configuration.util.TopicMessageDeliveryStrategy;
 import org.wso2.andes.server.AMQChannel;
 import org.wso2.andes.server.queue.QueueEntry;
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/ack/UnacknowledgedMessageMapImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/ack/UnacknowledgedMessageMapImpl.java
@@ -49,7 +49,9 @@ public class UnacknowledgedMessageMapImpl implements UnacknowledgedMessageMap
                 (AndesConfiguration.PERFORMANCE_TUNING_TOPIC_MESSAGE_DELIVERY_STRATEGY);
 
         if(messageDeliveryStrategy.equals(TopicMessageDeliveryStrategy.DISCARD_ALLOWED)) {
-            _map = new LimitedSizeQueueEntryHolder(_prefetchLimit, amqChannel);
+            int growLimit = AndesConfigurationManager.readValue
+                    (AndesConfiguration.PERFORMANCE_TUNING_ACK_HANDLING_MAX_UNACKED_MESSAGES);
+            _map = new LimitedSizeQueueEntryHolder(_prefetchLimit, growLimit, amqChannel);
         } else {
             _map = new LinkedHashMap<Long,QueueEntry>(prefetchLimit);
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/QueueEntry.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/QueueEntry.java
@@ -175,6 +175,13 @@ public interface QueueEntry extends Comparable<QueueEntry>, Filterable
 
     boolean isAvailable();
 
+    /**
+     * check if we need to keep queue entry in memory. Broker does not keep
+     * queue entries more than the configured time
+     * @return if disposable by above configuration
+     */
+    boolean isTimelyDisposable();
+
     boolean isAcquired();
 
     boolean acquire();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/QueueEntryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/QueueEntryImpl.java
@@ -22,6 +22,7 @@ import org.apache.log4j.Logger;
 import org.wso2.andes.AMQException;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
+import org.wso2.andes.kernel.AndesContext;
 import org.wso2.andes.server.exchange.Exchange;
 import org.wso2.andes.server.message.AMQMessageHeader;
 import org.wso2.andes.server.message.MessageReference;
@@ -54,6 +55,10 @@ public class QueueEntryImpl implements QueueEntry
 
     private volatile EntryState _state = AVAILABLE_STATE;
 
+    /**
+     * Holds the time the queue entry is created. This also represents
+     * delivery time stamp of a message.
+     */
     private long creationTime;
 
     private static final
@@ -166,9 +171,11 @@ public class QueueEntryImpl implements QueueEntry
         return _state == AVAILABLE_STATE;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public boolean isTimelyDisposable() {
-        int deliveryTimeoutInSec = AndesConfigurationManager.readValue(AndesConfiguration
-                .PERFORMANCE_TUNING_TOPIC_MESSAGE_DELIVERY_TIMEOUT);
+        int deliveryTimeoutInSec = AndesContext.getInstance().getDeliveryTimeoutForMessage();
         return (System.currentTimeMillis() - creationTime) > (deliveryTimeoutInSec * 1000);
     }
 

--- a/modules/andes-core/broker/src/test/java/org/wso2/andes/server/ExtractResendAndRequeueTest.java
+++ b/modules/andes-core/broker/src/test/java/org/wso2/andes/server/ExtractResendAndRequeueTest.java
@@ -68,7 +68,7 @@ public class ExtractResendAndRequeueTest extends TestCase
     @Override
     public void setUp() throws AMQException
     {
-        _unacknowledgedMessageMap = new UnacknowledgedMessageMapImpl(100);
+        _unacknowledgedMessageMap = new UnacknowledgedMessageMapImpl(100, null);
 
         long id = 0;
         SimpleQueueEntryList list = new SimpleQueueEntryList(_queue);

--- a/modules/andes-core/broker/src/test/java/org/wso2/andes/server/exchange/AbstractHeadersExchangeTestBase.java
+++ b/modules/andes-core/broker/src/test/java/org/wso2/andes/server/exchange/AbstractHeadersExchangeTestBase.java
@@ -342,6 +342,10 @@ public class AbstractHeadersExchangeTestBase extends InternalBrokerBaseCase
                     return false;  //To change body of implemented methods use File | Settings | File Templates.
                 }
 
+                public boolean isTimelyDisposable() {
+                    return false;
+                }    
+
                 public boolean isAvailable()
                 {
                     return false;  //To change body of implemented methods use File | Settings | File Templates.

--- a/modules/andes-core/broker/src/test/java/org/wso2/andes/server/queue/MockQueueEntry.java
+++ b/modules/andes-core/broker/src/test/java/org/wso2/andes/server/queue/MockQueueEntry.java
@@ -81,6 +81,10 @@ public class MockQueueEntry implements QueueEntry
 
     }
 
+    public boolean isTimelyDisposable() {
+        return false;
+    }
+
     public boolean expired() throws AMQException
     {
         return false;


### PR DESCRIPTION
We brought 3 TopicMessage delivery strategies

<!--When delivering topic messages to multiple topic subscribers one of following stratigies
can be choosen. 
   1. DISCARD_NONE - broker do not loose any message to any subscriber. When there are slow 
      subscribers this can cause broker go Out of Memory.

   2. SLOWEST_SUB_RATE - we deliver to the speed of the slowest topic subscriber. This can cause fast 
      subscribers to starve. But eliminate Out of Memory issue

   3. DISCARD_ALLOWED - broker will try best to deliver. To eliminate Out of Memory threat broker limits
      sent but not acked message count to <maxUnackedMessages>. If it is breached, and <deliveryTimeout> 
      is also breached message can either be lost or actually sent but ack is not honoured--> 


<topicMessageDeliveryStrategy>
	<strategyName>DISCARD_NONE </strategyName>
	<!-- If you choose DISCARD_ALLOWED topic message delivery strategy, we keep messages in memory
      	 until ack is done until this timeout. If an ack is not received under this timeout, ack will
	 be simulated internally and real acknowledgement is discarded.-->
	<deliveryTimeout>60</deliveryTimeout>
</topicMessageDeliveryStrategy>	


Default strategy is "DISCARD_NONE". 


Also added strategy pattern for message delivery strategies. Now when a new way of message delivery is required MessageDeliveryStrategy interface. 