### PR TITLE
Add tenant authentication for MQTT.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/messaging/spi/impl/ProtocolProcessor.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/messaging/spi/impl/ProtocolProcessor.java
@@ -26,8 +26,10 @@ import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.MQTTUserAuthenticationScheme;
 import org.wso2.andes.kernel.AndesMessageMetadata;
 import org.wso2.andes.kernel.disruptor.inbound.PubAckHandler;
+import org.wso2.andes.mqtt.MQTTAuthorizationSubject;
 import org.wso2.andes.mqtt.MQTTException;
 import org.wso2.andes.mqtt.utils.MQTTUtils;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -48,6 +50,11 @@ public class ProtocolProcessor implements EventHandler<ValueEvent>, PubAckHandle
     private SubscriptionsStore subscriptions;
     private IStorageService m_storageService;
     private IAuthenticator m_authenticator;
+
+    /**
+     * Keeps client data in memory for authorization of publishing and subscribing later. <ClientID, AuthData>
+     */
+    private Map<String, MQTTAuthorizationSubject> authSubjects = new HashMap<>();
 
     private RingBuffer<ValueEvent> m_ringBuffer;
 
@@ -141,6 +148,15 @@ public class ProtocolProcessor implements EventHandler<ValueEvent>, PubAckHandle
             return;
         }
 
+        //Server enforces user authentication but user doesn't supply credentials
+        // NOTE: this is just a interim solution for a potential security threat.
+        if ( isAuthenticationRequired && (! msg.isUserFlag())) {
+            ConnAckMessage okResp = new ConnAckMessage();
+            okResp.setReturnCode(ConnAckMessage.BAD_USERNAME_OR_PASSWORD);
+            session.write(okResp);
+            return;
+        }
+
         //if an old client with the same ID already exists close its session.
         if (m_clientIDs.containsKey(msg.getClientID())) {
             //clean the subscriptions if the old used a cleanSession = true
@@ -178,29 +194,28 @@ public class ProtocolProcessor implements EventHandler<ValueEvent>, PubAckHandle
             processPublish(pubEvt);
         }
 
-       
-       //Server enforces user authentication but user doesn't supply credentials
-       // NOTE: this is just a interim solution for a potential security threat.
-       if ( isAuthenticationRequired && (! msg.isUserFlag())) {
-           ConnAckMessage okResp = new ConnAckMessage();
-           okResp.setReturnCode(ConnAckMessage.BAD_USERNAME_OR_PASSWORD);
-           session.write(okResp);
-           return;
-       }
+        MQTTAuthorizationSubject authSubject = new MQTTAuthorizationSubject(msg.getClientID(), msg.isUserFlag());
 
        //handle user authentication
         if (msg.isUserFlag()) {
+            String username = msg.getUsername();
             String pwd = null;
             if (msg.isPasswordFlag()) {
                 pwd = msg.getPassword();
             }
-            if (!m_authenticator.checkValid(msg.getUsername(), pwd)) {
+            if (!m_authenticator.checkValid(username, pwd)) {
                 ConnAckMessage okResp = new ConnAckMessage();
                 okResp.setReturnCode(ConnAckMessage.BAD_USERNAME_OR_PASSWORD);
                 session.write(okResp);
                 return;
             }
+
+            // Keep the authorization details in memory to be used while publishing and subscribing
+            // to validate the client
+            authSubject.setTenantDomain(MultitenantUtils.getTenantDomain(username.replace('!', '@')));
         }
+
+        authSubjects.put(msg.getClientID(), authSubject);
 
         subscriptions.activate(msg.getClientID());
 
@@ -283,27 +298,41 @@ public class ProtocolProcessor implements EventHandler<ValueEvent>, PubAckHandle
             log.debug("processPublish invoked with " + evt);
         }
         final String topic = evt.getTopic();
-        final AbstractMessage.QOSType qos = evt.getQos();
-        final ByteBuffer message = evt.getMessage();
-        boolean retain = evt.isRetain();
-        //Added to maintain the state of the publishing clients
+
+        // Authorize publish
         String clientID = evt.getClientID();
+        MQTTAuthorizationSubject authSubject = authSubjects.get(clientID);
+        String tenant = MQTTUtils.getTenantFromTopic(topic);
 
-        String publishKey;
-
-        // For QOS 2 send publisher received
-        if (qos == AbstractMessage.QOSType.EXACTLY_ONCE) {
-            publishKey = String.format("%s%d", evt.getClientID(), evt.getMessageID());
-            //store the message in temp store
-            m_storageService.persistQoS2Message(publishKey, evt);
-            sendPubRec(evt.getClientID(), evt.getMessageID());
-            //We do not add the message to andes at this point since the message addition would happen upon the PUBREL
-        }else{
-            AndesMQTTBridge.onMessagePublished(topic, qos.ordinal(), evt.getMessage(), evt.isRetain(),
-                    evt.getMessageID(), clientID, this,evt.getSession().getSocketChannel());
-
+        boolean authenticated = false;
+        if ((!isAuthenticationRequired && !authSubject.isUserFlag())
+            || (authSubject.isUserFlag() && tenant.equals(authSubject.getTenantDomain()))) {
+            // user flag has to be set at this point, else not authenticated
+            authenticated = true;
         }
 
+        if (authenticated) {
+            final AbstractMessage.QOSType qos = evt.getQos();
+
+            String publishKey;
+
+            // For QOS 2 send publisher received
+            if (qos == AbstractMessage.QOSType.EXACTLY_ONCE) {
+                publishKey = String.format("%s%d", evt.getClientID(), evt.getMessageID());
+                //store the message in temp store
+                m_storageService.persistQoS2Message(publishKey, evt);
+                sendPubRec(evt.getClientID(), evt.getMessageID());
+                //We do not add the message to andes at this point since the message addition would happen upon the
+                // PUBREL
+            } else {
+                AndesMQTTBridge.onMessagePublished(topic, qos.ordinal(), evt.getMessage(), evt.isRetain(),
+                                                   evt.getMessageID(), clientID, this,
+                                                   evt.getSession().getSocketChannel());
+            }
+        } else {
+            // Log and continue since there is no method to inform the client about permission failure
+            log.error("Client " + clientID + " does not have permission to publish to tenant : " + tenant);
+        }
     }
 
     /**
@@ -598,6 +627,9 @@ public class ProtocolProcessor implements EventHandler<ValueEvent>, PubAckHandle
     }
 
     void processDisconnect(ServerChannel session, String clientID, boolean cleanSession) throws InterruptedException {
+
+        removeAuthorizationSubject(clientID);
+
         if (cleanSession) {
             //cleanup topic subscriptions
             processRemoveAllSubscriptions(clientID);
@@ -619,6 +651,9 @@ public class ProtocolProcessor implements EventHandler<ValueEvent>, PubAckHandle
     }
 
     void proccessConnectionLost(String clientID) {
+
+        removeAuthorizationSubject(clientID);
+
         //If already removed a disconnect message was already processed for this clientID
         if (m_clientIDs.remove(clientID) != null) {
 
@@ -636,6 +671,17 @@ public class ProtocolProcessor implements EventHandler<ValueEvent>, PubAckHandle
             }
             // bridge.onSubscriberDisconnection(clientID);
         }
+    }
+
+    /**
+     * Remove authorization data for a client.
+     *
+     * Each client when disconnected or connection is log this method should be called to clear the in memory data.
+     *
+     * @param clientID The client ID to remove data for.
+     */
+    private void removeAuthorizationSubject(String clientID) {
+        authSubjects.remove(clientID);
     }
 
     /**
@@ -673,7 +719,27 @@ public class ProtocolProcessor implements EventHandler<ValueEvent>, PubAckHandle
             log.debug("processSubscribe invoked from client " + clientID + " with msgID " + msg.getMessageID());
         }
 
+        // Authorize publish
+        MQTTAuthorizationSubject authSubject = authSubjects.get(clientID);
+
+        boolean authenticatedForOneOrMore = false;
+
         for (SubscribeMessage.Couple req : msg.subscriptions()) {
+
+            // Authorize subscribe
+            String tenant = MQTTUtils.getTenantFromTopic(req.getTopic());
+            if ((!isAuthenticationRequired && !authSubject.isUserFlag())
+                || (authSubject.isUserFlag() && tenant.equals(authSubject.getTenantDomain()))) {
+
+                authenticatedForOneOrMore = true;
+            } else {
+                // User flag has to be set at this point, else not authenticated
+                // Log and continue since there is no method to inform the client about permission failure
+                log.error("Client " + clientID + " does not have permission to subscribe to topic : " + req.getTopic());
+
+                continue;
+            }
+
             AbstractMessage.QOSType qos = AbstractMessage.QOSType.values()[req.getQos()];
             Subscription newSubscription = new Subscription(clientID, req.getTopic(), qos, cleanSession);
             subscribeSingleTopic(newSubscription);
@@ -688,19 +754,22 @@ public class ProtocolProcessor implements EventHandler<ValueEvent>, PubAckHandle
             }
         }
 
-        //ack the client
-        SubAckMessage ackMessage = new SubAckMessage();
-        ackMessage.setMessageID(msg.getMessageID());
+        if (authenticatedForOneOrMore) {
+            SubAckMessage ackMessage = new SubAckMessage();
+            ackMessage.setMessageID(msg.getMessageID());
 
-        //reply with requested qos
-        for (SubscribeMessage.Couple req : msg.subscriptions()) {
-            AbstractMessage.QOSType qos = AbstractMessage.QOSType.values()[req.getQos()];
-            ackMessage.addType(qos);
+            //reply with requested qos
+            for (SubscribeMessage.Couple req : msg.subscriptions()) {
+                AbstractMessage.QOSType qos = AbstractMessage.QOSType.values()[req.getQos()];
+                ackMessage.addType(qos);
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("replying with SubAck to MSG ID " + msg.getMessageID());
+            }
+            session.write(ackMessage);
+        } else {
+            log.error("Not sending sub ack message since client " + clientID + " does not have permission to subscribe to all given subscriptions.");
         }
-        if (log.isDebugEnabled()) {
-            log.debug("replying with SubAck to MSG ID " + msg.getMessageID());
-        }
-        session.write(ackMessage);
     }
 
     private void subscribeSingleTopic(Subscription newSubscription) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTAuthorizationSubject.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTAuthorizationSubject.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ */
+
+package org.wso2.andes.mqtt;
+
+/**
+ * Stores authorization details for MQTT clients.
+ */
+public class MQTTAuthorizationSubject {
+
+    /**
+     * The MQTT Client ID.
+     */
+    private String clientID;
+
+    /**
+     * User flag (true/false) of the connecting client.
+     */
+    private boolean userFlag;
+
+    /**
+     * The tenant domain client has connected to.
+     */
+    private String tenantDomain;
+
+    /**
+     * Initialize Authorization Subject with the clientID and userFlag which is required.
+     *
+     * @param clientID The MQTT ClientID
+     * @param userFlag Is the user flag set in the MQTT Client
+     */
+    public MQTTAuthorizationSubject(String clientID, boolean userFlag) {
+        this.clientID = clientID;
+        this.userFlag = userFlag;
+    }
+
+    public String getClientID() {
+        return clientID;
+    }
+
+    public void setClientID(String clientID) {
+        this.clientID = clientID;
+    }
+
+    public boolean isUserFlag() {
+        return userFlag;
+    }
+
+    public String getTenantDomain() {
+        return tenantDomain;
+    }
+
+    public void setTenantDomain(String tenantDomain) {
+        this.tenantDomain = tenantDomain;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/utils/MQTTUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/utils/MQTTUtils.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.dna.mqtt.moquette.messaging.spi.impl.subscriptions.SubscriptionsStore;
 import org.dna.mqtt.moquette.proto.messages.AbstractMessage;
 import org.dna.mqtt.wso2.QOSLevel;
+import org.wso2.andes.kernel.AndesConstants;
 import org.wso2.andes.kernel.AndesContent;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesMessageMetadata;
@@ -31,6 +32,7 @@ import org.wso2.andes.kernel.disruptor.inbound.PubAckHandler;
 import org.wso2.andes.mqtt.MQTTMessageContext;
 import org.wso2.andes.mqtt.MQTTPublisherChannel;
 import org.wso2.andes.server.store.MessageMetaDataType;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.nio.ByteBuffer;
 import java.util.UUID;
@@ -260,6 +262,22 @@ public class MQTTUtils {
         messageContext.setChannel(socket);
 
         return messageContext;
+    }
+
+    /**
+     * Extract tenant name from a given topic.
+     *
+     * @param topic The topic to retrieve tenant name
+     * @return Tenant name extracted from topic
+     */
+    public static String getTenantFromTopic(String topic) {
+        String tenant = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+
+        if (null != topic && topic.contains(AndesConstants.TENANT_SEPARATOR)) {
+            tenant = topic.split(AndesConstants.TENANT_SEPARATOR)[0];
+        }
+
+        return tenant;
     }
 
 }


### PR DESCRIPTION
MQTT publish or subscribe methods does not allow to provide
authentication information. Therefore keeps MQTT client
information in memory when connecting and use those information
when publishing or subscribing to do tenant validation.

These details are removed when the client is disconnected.

Modified changes done by @akalankapagoda, to send a sub ack if at
least one subscription is allowed for the user.