### PR TITLE
Scheduled delivery count race condition fix

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
@@ -91,6 +91,7 @@ public class FlowControlledQueueMessageDeliveryImpl implements MessageDeliverySt
                             message.setDestination(localSubscription.getSubscribedDestination());
                         }
 
+                        OnflightMessageTracker.getInstance().incrementNumberOfScheduledDeliveries(message.getMessageID());
                         MessageFlusher.getInstance().deliverMessageAsynchronously(localSubscription, message);
                         numOfCurrentMsgDeliverySchedules++;
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageFlusher.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageFlusher.java
@@ -383,6 +383,7 @@ public class MessageFlusher {
      */
     public void scheduleMessageForSubscription(LocalSubscription subscription,
                                                final AndesMessageMetadata message) {
+        OnflightMessageTracker.getInstance().incrementNumberOfScheduledDeliveries(message.getMessageID());
         deliverMessageAsynchronously(subscription, message);
     }
 
@@ -396,7 +397,6 @@ public class MessageFlusher {
         if(log.isDebugEnabled()) {
             log.debug("Scheduled message id= " + message.getMessageID() + " to be sent to subscription= " + subscription);
         }
-        OnflightMessageTracker.getInstance().incrementNumberOfScheduledDeliveries(message.getMessageID());
         flusherExecutor.submit(subscription, message);
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
@@ -116,6 +116,7 @@ public class NoLossBurstTopicMessageDeliveryImpl implements MessageDeliveryStrat
                     break;
                 }
 
+                OnflightMessageTracker.getInstance().incrementNumberOfScheduledDeliveries(message.getMessageID(), subscriptions4Queue.size());
                 for (int j = 0; j < subscriptions4Queue.size(); j++) {
                     LocalSubscription localSubscription = MessageFlusher.getInstance()
                             .findNextSubscriptionToSent(destination, subscriptions4Queue);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/OnflightMessageTracker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/OnflightMessageTracker.java
@@ -30,11 +30,13 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * This class will track message delivery by broker
@@ -519,6 +521,28 @@ public class OnflightMessageTracker {
         }
         return numOfSchedules;
     }
+
+    /**
+     * Increment number of times this message is scheduled to be delivered
+     * to different subscribers. This value will be equal to the number
+     * of subscribers expecting the message at that instance.
+     *
+     * @param messageID identifier of the message
+     * @return num of scheduled times after increment
+     */
+    public int incrementNumberOfScheduledDeliveries(long messageID ,int count) {
+        MessageData trackingData = getTrackingData(messageID);
+        int numOfSchedules = 0;
+        if (trackingData != null) {
+            trackingData.addMessageStatus(MessageStatus.SCHEDULED_TO_SEND);
+            numOfSchedules = trackingData.numberOfScheduledDeliveries.addAndGet(count);
+            if (log.isDebugEnabled()) {
+                log.debug("message id= " + messageID + " scheduled. Pending to execute= " + numOfSchedules);
+            }
+        }
+        return numOfSchedules;
+    }
+
 
     /**
      * Decrement number of times this message is scheduled to be delivered.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
@@ -117,6 +117,8 @@ public class SlowestSubscriberTopicMessageDeliveryImpl implements MessageDeliver
                     }
                 }
                 if (allTopicSubscriptionsHasRoom) {
+                    OnflightMessageTracker.getInstance().incrementNumberOfScheduledDeliveries(message.getMessageID(), subscriptions4Queue.size());
+
                     //schedule message to all subscribers
                     for (int j = 0; j < subscriptions4Queue.size(); j++) {
                         LocalSubscription localSubscription = MessageFlusher.getInstance().

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
@@ -83,8 +83,6 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
             AndesMessageMetadata message = deliveryEventData.getMetadata();
 
             try {
-                //decrement number of schedule deliveries before send to subscriber to avoid parallel status update issues
-                OnflightMessageTracker.getInstance().decrementNumberOfScheduledDeliveries(message.getMessageID());
                 if (deliveryEventData.isErrorOccurred()) {
                     handleSendError(message);
                     return;
@@ -110,10 +108,9 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
                 }
             } catch (Throwable e) {
                 log.error("Error while delivering message. Message id " + message.getMessageID(), e);
-                //increment above schedule count because exception occurred while send message to subscriber
-                OnflightMessageTracker.getInstance().incrementNumberOfScheduledDeliveries(message.getMessageID());
                 handleSendError(message);
             } finally {
+                OnflightMessageTracker.getInstance().decrementNumberOfScheduledDeliveries(message.getMessageID());
                 deliveryEventData.clearData();
             }
         }


### PR DESCRIPTION
The reason was decrementing scheduled delivery count before sending the message to subscription. After moving the decrement call to finally block in the DeliveryEventHandler#onEvent we did not observe the null pointer exception.