### PR TITLE
fix safe zone calculation logic. 

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeleteSafeZoneCalc.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeleteSafeZoneCalc.java
@@ -68,8 +68,13 @@ public class SlotDeleteSafeZoneCalc implements Runnable {
                 try {
                     nodesWithPublishedMessages = SlotManagerClusterMode.getInstance().getMessagePublishedNodes();
                 } catch (AndesException e) {
-                    log.error("SlotDeleteSafeZoneCalc stopped due to failing to get message published nodes.", e);
-                    this.setLive(false);
+                    log.error("SlotDeleteSafeZoneCalc stopped due to failing to get message published nodes. "
+                           + "Retrying after 15 seconds" ,e);
+                    try {
+                        Thread.sleep(15 * 1000);
+                    } catch (InterruptedException e1) {
+                        //ignore
+                    }
                     continue;
                 }
                 Map<String, Long> nodeInformedSafeZones =
@@ -90,8 +95,12 @@ public class SlotDeleteSafeZoneCalc implements Runnable {
                                 .getLastPublishedIDByNode(nodeID);
                     } catch (AndesException e) {
                         log.error("SlotDeleteSafeZoneCalc stopped due to failing to get last published id for node:" +
-                                nodeID, e);
-                        this.setLive(false);
+                                nodeID + ". Retrying after 15 seconds", e);
+                        try {
+                            Thread.sleep(15 * 1000);
+                        } catch (InterruptedException e1) {
+                            //ignore
+                        }
                         continue;
                     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeleteSafeZoneCalc.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeleteSafeZoneCalc.java
@@ -42,6 +42,8 @@ public class SlotDeleteSafeZoneCalc implements Runnable {
 
     private int seekInterval;
 
+    private final int timeToSleepOnError;
+
 
     /**
      * Define a safe zone calculator. This will run once seekInterval
@@ -53,6 +55,7 @@ public class SlotDeleteSafeZoneCalc implements Runnable {
         this.seekInterval = seekInterval;
         this.running = true;
         this.isLive = true;
+        this.timeToSleepOnError = 15 * 1000;
         this.slotDeleteSafeZone = new AtomicLong(Long.MAX_VALUE);
         
     }
@@ -71,7 +74,7 @@ public class SlotDeleteSafeZoneCalc implements Runnable {
                     log.error("SlotDeleteSafeZoneCalc stopped due to failing to get message published nodes. "
                            + "Retrying after 15 seconds" ,e);
                     try {
-                        Thread.sleep(15 * 1000);
+                        Thread.sleep(timeToSleepOnError);
                     } catch (InterruptedException e1) {
                         //ignore
                     }
@@ -89,7 +92,7 @@ public class SlotDeleteSafeZoneCalc implements Runnable {
                     long safeZoneValue = Long.MAX_VALUE;
 
                     //get the maximum message id published by node so far
-                    Long safeZoneByPublishedMessages = null;
+                    Long safeZoneByPublishedMessages;
                     try {
                         safeZoneByPublishedMessages = SlotManagerClusterMode.getInstance()
                                 .getLastPublishedIDByNode(nodeID);
@@ -97,7 +100,7 @@ public class SlotDeleteSafeZoneCalc implements Runnable {
                         log.error("SlotDeleteSafeZoneCalc stopped due to failing to get last published id for node:" +
                                 nodeID + ". Retrying after 15 seconds", e);
                         try {
-                            Thread.sleep(15 * 1000);
+                            Thread.sleep(timeToSleepOnError);
                         } catch (InterruptedException e1) {
                             //ignore
                         }
@@ -146,7 +149,7 @@ public class SlotDeleteSafeZoneCalc implements Runnable {
                 }
             } else {
                 try {
-                    Thread.sleep(15 * 1000);
+                    Thread.sleep(timeToSleepOnError);
                 } catch (InterruptedException e) {
                     //silently ignore
                 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeleteSafeZoneCalc.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeleteSafeZoneCalc.java
@@ -42,7 +42,7 @@ public class SlotDeleteSafeZoneCalc implements Runnable {
 
     private int seekInterval;
 
-    private final int timeToSleepOnError;
+    private static final int TIME_TO_SLEEP_ON_ERROR = 15 * 1000;
 
 
     /**
@@ -55,7 +55,6 @@ public class SlotDeleteSafeZoneCalc implements Runnable {
         this.seekInterval = seekInterval;
         this.running = true;
         this.isLive = true;
-        this.timeToSleepOnError = 15 * 1000;
         this.slotDeleteSafeZone = new AtomicLong(Long.MAX_VALUE);
         
     }
@@ -74,9 +73,9 @@ public class SlotDeleteSafeZoneCalc implements Runnable {
                     log.error("SlotDeleteSafeZoneCalc stopped due to failing to get message published nodes. "
                            + "Retrying after 15 seconds" ,e);
                     try {
-                        Thread.sleep(timeToSleepOnError);
+                        Thread.sleep(TIME_TO_SLEEP_ON_ERROR);
                     } catch (InterruptedException e1) {
-                        //ignore
+                        setLive(false);
                     }
                     continue;
                 }
@@ -100,9 +99,9 @@ public class SlotDeleteSafeZoneCalc implements Runnable {
                         log.error("SlotDeleteSafeZoneCalc stopped due to failing to get last published id for node:" +
                                 nodeID + ". Retrying after 15 seconds", e);
                         try {
-                            Thread.sleep(timeToSleepOnError);
+                            Thread.sleep(TIME_TO_SLEEP_ON_ERROR);
                         } catch (InterruptedException e1) {
-                            //ignore
+                            setLive(false);
                         }
                         continue;
                     }
@@ -145,13 +144,13 @@ public class SlotDeleteSafeZoneCalc implements Runnable {
                 try {
                     Thread.sleep(seekInterval);
                 } catch (InterruptedException e) {
-                    //silently ignore
+                    setLive(false);
                 }
             } else {
                 try {
-                    Thread.sleep(timeToSleepOnError);
+                    Thread.sleep(TIME_TO_SLEEP_ON_ERROR);
                 } catch (InterruptedException e) {
-                    //silently ignore
+                    setLive(false);
                 }
             }
         }


### PR DESCRIPTION
safe zone calculation should never stop if the node is live. 
If the network is gone for the node, on exceptions it should backoff, and retry if when the network came back. 

Safe zone calculation is done only by coordinator node. If the coordination was removed from cluster, other nodes will detect member left, a new coordinator will be elected and that coordinator will remove the removed node's entry from safe zone calc. Otherwise safe zone will not proceed and slots will not removed from cluster. 
