### PR TITLE
Fixed durable topic messages not being restored from DLC issue

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessageMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessageMetadata.java
@@ -275,6 +275,7 @@ public class AndesMessageMetadata implements Comparable<AndesMessageMetadata> {
         clone.arrivalTime = arrivalTime;
         clone.metaDataType = metaDataType;
         clone.propertyMap = propertyMap;
+        clone.messageContentLength = messageContentLength;
         return clone;
     }
 
@@ -396,7 +397,7 @@ public class AndesMessageMetadata implements Comparable<AndesMessageMetadata> {
         return messageContentLength;
     }
 
-    public void setMessageContentLength(int messageContentLength) {
+    public void setMessageContentLength(int messageContentLength){
         this.messageContentLength = messageContentLength;
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
@@ -328,6 +328,11 @@ public class QueueManagementInformationMBean extends AMQManagedObject implements
                     AndesMessageMetadata metadata = Andes.getInstance().getMessageMetaData(messageId);
                     String destination = metadata.getDestination();
 
+                    //Durable topic subscriptions are handled through internal queues
+                    //Therefore, we need to add the messages that are being restored to the respective queues
+                    //For that, set Topic should be set to false
+                    metadata.setTopic(false);
+
                     // Create a removable metadata to remove the current message
                     removableMetadataList.add(new AndesRemovableMetadata(messageId, destinationQueueName,
                             destinationQueueName));


### PR DESCRIPTION
Addresses the jira https://wso2.org/jira/browse/MB-1184.

The issue was due to the fact that the message content length was not being updated when metadata is cloned by the MessagePreProcessor. Resolving this issue solved the problem of ContentChunkHandler going out of memory.

Also message metadata in the cache having isTopic = true prevented messages from being delivered to durable subscriptions.

Please merge https://github.com/wso2/product-mb/pull/161 to enable the test case