### PR TITLE
Separated method deleteMessages in MessagingEngine into two

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
@@ -222,17 +222,12 @@ public interface MessageStore extends HealthAwareStore{
 
     /**
      * Method to delete a set of messages from the database
-     * If deleteAllMetaData is set to true, the storageQueue in the metadata table could be cleared at once
-     * and the messages destined to that queue, given by the messagesToRemove list could be deleted from the content
-     * table
-     * Else, the messages in the list 'messagesToRemove' will be deleted
      *
      * @param storageQueueName  name of the queue
      * @param messagesToRemove  the list of messages to remove
-     * @param deleteAllMetaData whether to delete all metadata destined to the storageQueue
      * @throws AndesException
      */
-    public void deleteMessages(final String storageQueueName, List<Long> messagesToRemove, boolean deleteAllMetaData)
+    public void deleteMessages(final String storageQueueName, List<Long> messagesToRemove)
             throws AndesException;
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -433,8 +433,7 @@ public class MessagingEngine {
                 separateMessagesToStorageQueues(messagesToRemove);
 
         //delete message content along with metadata and update the message count for the queues
-        for (Map.Entry<String, AndesRemovableMetadataDTO> entry : storageSeparatedAndesRemovableMetadataDTOs
-                .entrySet()) {
+        for (Map.Entry<String, AndesRemovableMetadataDTO> entry : storageSeparatedAndesRemovableMetadataDTOs.entrySet()) {
             messageStore.deleteMessages(entry.getKey(), entry.getValue().messagesToRemove);
             decrementQueueCount(entry.getKey(), entry.getValue().msgCount);
         }
@@ -808,7 +807,7 @@ public class MessagingEngine {
                 storageSeparatedAndesRemovableMetadataDTOs.put(message.getStorageDestination(), dto);
             }
             dto.messagesToRemove.add(message.getMessageID());
-            dto.msgCount = dto.msgCount++;
+            dto.msgCount++;
         }
 
         return storageSeparatedAndesRemovableMetadataDTOs;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
@@ -153,7 +153,7 @@ public class NoLossBurstTopicMessageDeliveryImpl implements MessageDeliveryStrat
          * for the message and due to has no room to enqueue the message. Delete
          * call is blocking and then slot message count is dropped in order
          */
-        MessagingEngine.getInstance().deleteMessages(droppedTopicMessagesListRemovable, false);
+        MessagingEngine.getInstance().deleteMessages(droppedTopicMessagesListRemovable);
 
         for (AndesMessageMetadata messageToRemove : droppedTopicMessagesList) {
             OnflightMessageTracker.getInstance().decrementMessageCountInSlot(messageToRemove.getSlot());

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
@@ -163,7 +163,7 @@ public class SlowestSubscriberTopicMessageDeliveryImpl implements MessageDeliver
          * for the message and due to has no room to enqueue the message. Delete
          * call is blocking and then slot message count is dropped in order
          */
-        MessagingEngine.getInstance().deleteMessages(droppedTopicMessagesListRemovable, false);
+        MessagingEngine.getInstance().deleteMessages(droppedTopicMessagesListRemovable);
 
         for (AndesMessageMetadata messageToRemove : droppedTopicMessagesList) {
             OnflightMessageTracker.getInstance().decrementMessageCountInSlot(messageToRemove.getSlot());

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/AckHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/AckHandler.java
@@ -133,7 +133,7 @@ public class AckHandler implements BatchEventHandler, StoreHealthListener {
         }
 
         try {
-            messagingEngine.deleteMessages(removableMetadata, false);
+            messagingEngine.deleteMessages(removableMetadata);
             OnflightMessageTracker.getInstance().updateMessageDeliveryInSlot(removableMetadata);
 
             if (log.isTraceEnabled()) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundDeleteMessagesEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundDeleteMessagesEvent.java
@@ -80,7 +80,12 @@ public class InboundDeleteMessagesEvent implements AndesInboundStateEvent {
     public void updateState() throws AndesException {
         switch (eventType) {
             case DELETE_MESSAGES_EVENT:
-                messagingEngine.deleteMessages(messagesToRemove, moveToDLC);
+                if (!moveToDLC) {
+                    messagingEngine.deleteMessages(messagesToRemove);
+                }
+                else{
+                    messagingEngine.moveMessagesToDeadLetterChannel(messagesToRemove);
+                }
                 break;
             default:
                 log.error("Event type not set properly " + eventType);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundTransactionEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundTransactionEvent.java
@@ -328,7 +328,7 @@ public class InboundTransactionEvent implements AndesInboundStateEvent {
                     );
                 }
 
-                messagingEngine.deleteMessages(removableMetadataList, false);
+                messagingEngine.deleteMessages(removableMetadataList);
                 messagesStoredNotCommitted = false;
             }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
@@ -321,11 +321,9 @@ public class FailureObservingMessageStore implements MessageStore {
      * {@inheritDoc}
      */
     @Override
-    public void deleteMessages(final String storageQueueName,
-                               List<Long> messagesToRemove, boolean deleteAllMetaData)
-            throws AndesException {
+    public void deleteMessages(final String storageQueueName, List<Long> messagesToRemove) throws AndesException {
         try {
-            wrappedInstance.deleteMessages(storageQueueName, messagesToRemove, deleteAllMetaData);
+            wrappedInstance.deleteMessages(storageQueueName, messagesToRemove);
 
             //Tracing message activity
             if (MessageTracer.isEnabled()) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cassandra/CQLBasedMessageStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cassandra/CQLBasedMessageStoreImpl.java
@@ -791,8 +791,7 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
      * {@inheritDoc}
      */
     @Override
-    public void deleteMessages(final String storageQueueName, List<Long> messagesToRemove, boolean deleteAllMetaData)
-            throws AndesException {
+    public void deleteMessages(final String storageQueueName, List<Long> messagesToRemove) throws AndesException {
         Context context = MetricManager.timer(Level.INFO, MetricsConstants.DELETE_MESSAGE_META_DATA_AND_CONTENT)
                 .start();
 
@@ -800,26 +799,16 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
             //create separate batch statements to delete metadata and content
             BatchStatement batchStatement = new BatchStatement();
             batchStatement.setConsistencyLevel(config.getWriteConsistencyLevel());
-            //if all metadata is not be removed, add metadata and content of each message to delete
-            //else, add content of each message and all metadata for the queue to delete
-            if (!deleteAllMetaData) {
-                for (Long messageID : messagesToRemove) {
-                    batchStatement.add(psDeleteMetadata.bind(
-                            storageQueueName,
-                            messageID
-                    ));
-                    batchStatement.add(psDeleteMessagePart.bind(messageID));
-                }
-            } else {
-                batchStatement.add(QueryBuilder.delete().from(config.getKeyspace(), CQLConstants.METADATA_TABLE).
-                        where(eq(CQLConstants.QUEUE_NAME, storageQueueName)).
-                        setConsistencyLevel(config.getWriteConsistencyLevel()));
-                for (Long messageID : messagesToRemove) {
-                    batchStatement.add(psDeleteMessagePart.bind(messageID));
-                }
+
+            for (Long messageID : messagesToRemove) {
+                batchStatement.add(psDeleteMetadata.bind(
+                        storageQueueName,
+                        messageID
+                ));
+                batchStatement.add(psDeleteMessagePart.bind(messageID));
             }
             execute(batchStatement, "deleting metadata and content list from " + storageQueueName +
-                    " list size " + messagesToRemove.size());
+                                    " list size " + messagesToRemove.size());
         } finally {
             context.stop();
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cassandra/CQLBasedMessageStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cassandra/CQLBasedMessageStoreImpl.java
@@ -801,14 +801,11 @@ public class CQLBasedMessageStoreImpl implements MessageStore {
             batchStatement.setConsistencyLevel(config.getWriteConsistencyLevel());
 
             for (Long messageID : messagesToRemove) {
-                batchStatement.add(psDeleteMetadata.bind(
-                        storageQueueName,
-                        messageID
-                ));
+                batchStatement.add(psDeleteMetadata.bind(storageQueueName, messageID));
                 batchStatement.add(psDeleteMessagePart.bind(messageID));
             }
-            execute(batchStatement, "deleting metadata and content list from " + storageQueueName +
-                                    " list size " + messagesToRemove.size());
+            execute(batchStatement, "deleting metadata and content list from " + storageQueueName + " list size "
+                    + messagesToRemove.size());
         } finally {
             context.stop();
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cassandra/HectorBasedMessageStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cassandra/HectorBasedMessageStoreImpl.java
@@ -618,22 +618,17 @@ public class HectorBasedMessageStoreImpl implements MessageStore {
                 }
                 log.trace(messagesToRemove.size() + " messages removed : " + messageIDsString);
             }
-            Mutator<String> mutator = HFactory.createMutator(keyspace,
-                    HectorConstants.stringSerializer);
+            Mutator<String> mutator = HFactory.createMutator(keyspace, HectorConstants.stringSerializer);
 
             List<String> rows2Remove = new ArrayList<String>();
             for (Long messageID : messagesToRemove) {
-                HectorDataAccessHelper
-                        .deleteLongColumnFromRaw(
-                                HectorConstants.META_DATA_COLUMN_FAMILY,
-                                storageQueueName, messageID.longValue(), mutator, false);
-                rows2Remove.add(MESSAGE_CONTENT_CASSANDRA_ROW_NAME_PREFIX +
-                                messageID.longValue());
+                HectorDataAccessHelper.deleteLongColumnFromRaw(HectorConstants.META_DATA_COLUMN_FAMILY,
+                                                               storageQueueName, messageID.longValue(), mutator, false);
+                rows2Remove.add(MESSAGE_CONTENT_CASSANDRA_ROW_NAME_PREFIX + messageID.longValue());
             }
             if (!rows2Remove.isEmpty()) {
                 HectorDataAccessHelper.deleteIntegerRowListFromColumnFamily(
-                        HectorConstants.MESSAGE_CONTENT_COLUMN_FAMILY, rows2Remove,
-                        mutator, false);
+                        HectorConstants.MESSAGE_CONTENT_COLUMN_FAMILY, rows2Remove, mutator, false);
             }
 
             //batch execute

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cassandra/HectorBasedMessageStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cassandra/HectorBasedMessageStoreImpl.java
@@ -607,9 +607,7 @@ public class HectorBasedMessageStoreImpl implements MessageStore {
      * {@inheritDoc}
      */
     @Override
-    public void deleteMessages(final String storageQueueName,
-                               List<Long> messagesToRemove, boolean deleteAllMetaData)
-            throws AndesException {
+    public void deleteMessages(final String storageQueueName, List<Long> messagesToRemove) throws AndesException {
         Context context = MetricManager.timer(Level.INFO, MetricsConstants.DELETE_MESSAGE_META_DATA_AND_CONTENT)
                 .start();
         try {
@@ -624,23 +622,13 @@ public class HectorBasedMessageStoreImpl implements MessageStore {
                     HectorConstants.stringSerializer);
 
             List<String> rows2Remove = new ArrayList<String>();
-            //if all metadata is not be removed, add metadata and content of each message to delete
-            //else, add content of each message and all metadata for the queue to delete
-            if (!deleteAllMetaData) {
-                for (Long messageID : messagesToRemove) {
-                    HectorDataAccessHelper
-                            .deleteLongColumnFromRaw(
-                                    HectorConstants.META_DATA_COLUMN_FAMILY,
-                                    storageQueueName, messageID.longValue(), mutator, false);
-                    rows2Remove.add(MESSAGE_CONTENT_CASSANDRA_ROW_NAME_PREFIX +
-                            messageID.longValue());
-                }
-            } else {
-                mutator.addDeletion(storageQueueName, HectorConstants.META_DATA_COLUMN_FAMILY);
-                for (Long messageID : messagesToRemove) {
-                    rows2Remove.add(MESSAGE_CONTENT_CASSANDRA_ROW_NAME_PREFIX +
-                            messageID.longValue());
-                }
+            for (Long messageID : messagesToRemove) {
+                HectorDataAccessHelper
+                        .deleteLongColumnFromRaw(
+                                HectorConstants.META_DATA_COLUMN_FAMILY,
+                                storageQueueName, messageID.longValue(), mutator, false);
+                rows2Remove.add(MESSAGE_CONTENT_CASSANDRA_ROW_NAME_PREFIX +
+                                messageID.longValue());
             }
             if (!rows2Remove.isEmpty()) {
                 HectorDataAccessHelper.deleteIntegerRowListFromColumnFamily(

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSMessageStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSMessageStoreImpl.java
@@ -1116,7 +1116,7 @@ public class RDBMSMessageStoreImpl implements MessageStore {
                     .prepareStatement(RDBMSConstants.PS_DELETE_METADATA_FROM_QUEUE);
             for (Long messageID : messagesToRemove) {
                 preparedStatement.setInt(1, queueID);
-                preparedStatement.setLong(2, messageID.longValue());
+                preparedStatement.setLong(2, messageID);
                 preparedStatement.addBatch();
             }
             preparedStatement.executeBatch();
@@ -1159,8 +1159,7 @@ public class RDBMSMessageStoreImpl implements MessageStore {
 
             //Since referential integrity is imposed on the two tables: message content and metadata,
             //deleting message metadata will cause message content to be automatically deleted
-            metadataRemovalPreparedStatement = connection
-                    .prepareStatement(RDBMSConstants.PS_DELETE_METADATA);
+            metadataRemovalPreparedStatement = connection.prepareStatement(RDBMSConstants.PS_DELETE_METADATA);
 
             for (Long messageID : messagesToRemove) {
                 //add parameters to delete metadata
@@ -1173,14 +1172,14 @@ public class RDBMSMessageStoreImpl implements MessageStore {
             connection.commit();
 
             if (log.isDebugEnabled()) {
-                log.debug("Metadata and content removed. " + messagesToRemove.size() +
-                        " for destination queue" + storageQueueName);
+                log.debug("Metadata and content removed. " + messagesToRemove.size()
+                          + " for destination queue" + storageQueueName);
             }
         } catch (SQLException e) {
             rollback(connection, RDBMSConstants.TASK_DELETING_METADATA_FROM_QUEUE + storageQueueName
-                    + " and " + RDBMSConstants.TASK_DELETING_MESSAGE_PARTS);
-            throw rdbmsStoreUtils.convertSQLException("error occurred while deleting message metadata and content for queue ",
-                    e);
+                     + " and " + RDBMSConstants.TASK_DELETING_MESSAGE_PARTS);
+            throw rdbmsStoreUtils.convertSQLException("error occurred while deleting message metadata and content for "
+                                                      + "queue ", e);
         } finally {
 
             messageDeletionContext.stop();


### PR DESCRIPTION
This PR separates the method deleteMessages in MessagingEngine as deleteMessages and moveToDLC since having a single method to perform both tasks was confusing.

Addresses the jira https://wso2.org/jira/browse/MB-1186

Please merge https://github.com/wso2/product-mb/pull/163 along with this or else PurgeMessagesTestCase might fail. Even though there is no direct connection, the test case started failing after this change.