### PR TITLE
[MB-1172] Fix issues in remove non durable subscriptions

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
@@ -437,6 +437,14 @@ public class AndesKernelBoot {
         log.info("Syncing exchanges, queues, bindings and subscriptions");
         ClusterResourceHolder.getInstance().getAndesRecoveryTask()
                              .recoverExchangesQueuesBindingsSubscriptions();
+
+        // All non-durable subscriptions subscribed from this node will be deleted since, there
+        // can't be any non-durable subscriptions as node just started.
+        // closeAllClusterSubscriptionsOfNode() should only be called after
+        // recoverExchangesQueuesBindingsSubscriptions() executed.
+        String myNodeId = ClusterResourceHolder.getInstance().getClusterManager().getMyNodeID();
+        ClusterResourceHolder.getInstance().getSubscriptionManager()
+                             .closeAllLocalSubscriptionsOfNode(myNodeId);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionStore.java
@@ -613,8 +613,8 @@ public class SubscriptionStore {
      * @return the removed local subscription
      * @throws AndesException
      */
-    public LocalSubscription removeLocalSubscription(AndesSubscription subscription) throws AndesException {
-        ((LocalSubscription)subscription).close();
+    public LocalSubscription removeLocalSubscription(LocalSubscription subscription) throws AndesException {
+
         String destination = getDestination(subscription);
         String subscriptionID = subscription.getSubscriptionID();
         LocalSubscription subscriptionToRemove = null;


### PR DESCRIPTION
Fix issues occured when removing non-durable subscriptions.

This PR is related to https://github.com/wso2/andes/pull/286 PR. Following subscription removing senarios will be covered with these fixes.

1. Remove non-durable subscriptions during startup and shuting down the server for it's node id.
2. Remove non-durable subscriptions when member removed for removed node id.

jira - https://wso2.org/jira/browse/MB-1172