### PR TITLE
added fix to syncing durable topic subscriptions.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesRecoveryTask.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesRecoveryTask.java
@@ -72,7 +72,7 @@ public class AndesRecoveryTask implements Runnable, StoreHealthListener {
 				reloadQueuesFromDB();
 				reloadBindingsFromDB();
 				reloadSubscriptions();
-			} catch (AndesException e) {
+			} catch (Throwable e) {
 				log.error("Error in running andes recovery task", e);
 			}
 		} else {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/DLCQueueUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/DLCQueueUtils.java
@@ -129,6 +129,7 @@ public class DLCQueueUtils {
                             System.currentTimeMillis(), dlcQueueName, tenantOwner,
                             ExchangeDefaults.DIRECT_EXCHANGE_NAME.toString(), "DIRECT", null, false);
 
+            //TODO: review why we need a subscription for DLC at startup
             AndesContext.getInstance().getSubscriptionStore().createDisconnectOrRemoveClusterSubscription
                     (mockSubscription, SubscriptionListener.SubscriptionChange.ADDED);
 


### PR DESCRIPTION
Durable topic has been saved to DB with topic.carbon:subID signature. This causes problems with syncing it with in-memory maps as in maps we keep subscriptions w:r:t topic name. Modified to save durable topic subscriptions in DB as

topic.[topic name] (i.e topic.myTopic).

Also when syncing for durable topic subscriptions we have "hasExternalSubscriptions" attribute. This can be updated but not synced to maps. Thus when syncing for durable topic subscriptions we always DELETE the existing subscription and add whatever in DB. 
