### PR TITLE
Change allAcksReceived check

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/OnflightMessageTracker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/OnflightMessageTracker.java
@@ -210,7 +210,7 @@ public class OnflightMessageTracker {
             trackingData.addMessageStatus(MessageStatus.ACKED);
 
             //we consider ack is received if all acks came for channels message was sent
-            if (trackingData.allAcksReceived() && getNumberOfScheduledDeliveries(messageID) == 0) {
+            if (trackingData.allAcksReceived()) {
                 trackingData.addMessageStatus(MessageStatus.ACKED_BY_ALL);
 
                 isOKToDeleteMessage = true;
@@ -360,6 +360,7 @@ public class OnflightMessageTracker {
         int numOfSchedules = 0;
         if (trackingData != null) {
             trackingData.addMessageStatus(MessageStatus.SCHEDULED_TO_SEND);
+            trackingData.incrementPendingAckCount(1);
             numOfSchedules = trackingData.numberOfScheduledDeliveries.incrementAndGet();
             if (log.isDebugEnabled()) {
                 log.debug("message id= " + messageID + " scheduled. Pending to execute= " + numOfSchedules);
@@ -381,6 +382,7 @@ public class OnflightMessageTracker {
         int numOfSchedules = 0;
         if (trackingData != null) {
             trackingData.addMessageStatus(MessageStatus.SCHEDULED_TO_SEND);
+            trackingData.incrementPendingAckCount(count);
             numOfSchedules = trackingData.numberOfScheduledDeliveries.addAndGet(count);
             if (log.isDebugEnabled()) {
                 log.debug("message id= " + messageID + " scheduled. Pending to execute= " + numOfSchedules);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/AckHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/AckHandler.java
@@ -21,13 +21,18 @@ package org.wso2.andes.kernel.disruptor.inbound;
 import com.google.common.util.concurrent.SettableFuture;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.andes.kernel.*;
+import org.wso2.andes.kernel.AndesAckData;
+import org.wso2.andes.kernel.AndesContext;
+import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.kernel.AndesRemovableMetadata;
+import org.wso2.andes.kernel.LocalSubscription;
+import org.wso2.andes.kernel.MessagingEngine;
+import org.wso2.andes.kernel.OnflightMessageTracker;
 import org.wso2.andes.kernel.disruptor.BatchEventHandler;
 import org.wso2.andes.store.AndesTranactionRollbackException;
 import org.wso2.andes.store.FailureObservingStoreManager;
 import org.wso2.andes.store.HealthAwareStore;
 import org.wso2.andes.store.StoreHealthListener;
-import org.wso2.andes.subscription.SubscriptionStore;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -134,7 +139,6 @@ public class AckHandler implements BatchEventHandler, StoreHealthListener {
 
         try {
             messagingEngine.deleteMessages(removableMetadata);
-            OnflightMessageTracker.getInstance().updateMessageDeliveryInSlot(removableMetadata);
 
             if (log.isTraceEnabled()) {
                 StringBuilder messageIDsString = new StringBuilder();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
@@ -239,8 +239,11 @@ public class SlotDeliveryWorker extends Thread implements StoreHealthListener{
     public void stopDeliveryForQueue(String storageQueue) {
         Set<Slot> orphanedSlots = subscriptionSlotTracker.remove(storageQueue);
 
-        for (Slot slot:orphanedSlots) {
-            clearAllTrackingWhenSlotOrphaned(slot);
+        // Check if there are any orphaned slots
+        if (null != orphanedSlots) {
+            for (Slot slot:orphanedSlots) {
+                clearAllTrackingWhenSlotOrphaned(slot);
+            }
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
@@ -181,8 +181,7 @@ public class SlotDeliveryWorker extends Thread implements StoreHealthListener{
 
                                     subscriptionSlotTracker.putIfAbsent(storageQueueName,new HashSet<Slot>());
 
-                                    Set<Slot> subscriptionSlots = subscriptionSlotTracker
-                                            .get(storageQueueName);
+                                    Set<Slot> subscriptionSlots = subscriptionSlotTracker.get(storageQueueName);
 
                                     subscriptionSlots.add(currentSlot);
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorkerManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorkerManager.java
@@ -123,7 +123,11 @@ public class SlotDeliveryWorkerManager {
      */
     public void stopDeliveryForDestination(String storageQueueName) {
         SlotDeliveryWorker slotWorker = getSlotWorker(storageQueueName);
-        slotWorker.stopDeliveryForQueue(storageQueueName);
+
+        // Check if there is a slot delivery worker for the storageQueueName
+        if (null != slotWorker) {
+            slotWorker.stopDeliveryForQueue(storageQueueName);
+        }
     }
 
 


### PR DESCRIPTION
Previouly we use numberOfScheduledDeliveries and
channelToNumOfDeliveries to check if a message can be deleted from
database. In this commit the pendingAckCount is used to track if
all the acks are received. This count is incremented when the
message is given to the outbound disruptor and decremented when an
ack is received.