### PR TITLE
cleared messages from  buffer when last local subscriber leaves.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
@@ -238,6 +238,8 @@ public class SlotDeliveryWorker extends Thread implements StoreHealthListener{
     }
 
     public void stopDeliveryForQueue(String storageQueue) {
+        MessageFlusher.getInstance().clearUpAllBufferedMessagesForDelivery
+                (storageQueueNameToDestinationMap.get(storageQueue));
         Set<Slot> orphanedSlots = subscriptionSlotTracker.remove(storageQueue);
 
         for (Slot slot:orphanedSlots) {


### PR DESCRIPTION
1. cleared messages from  buffer when last local subscriber leaves.
2. when requeue due to inactive subscriptions, requeue only if there are valid subscriptions for the destination of the message being re-queued 