### PR TITLE
Slot not deleting issue fixed.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/AckHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/AckHandler.java
@@ -115,7 +115,6 @@ public class AckHandler implements BatchEventHandler, StoreHealthListener {
             LocalSubscription subscription = AndesContext.getInstance().getSubscriptionStore()
                     .getLocalSubscriptionForChannelId(ack.getChannelID());
             subscription.ackReceived(ack.getMessageID());
-            event.clear();
         }
 
         /*


### PR DESCRIPTION
- AckHandler clear event when ack received. Therefore StateEventHandler not getting ACKNOWLEDGEMENT_EVENT. This is cause slot not getting deleted. Therefore event.clear() statement removed from AckHandler because event is finally getting clear in StateEventHandler.