### PR TITLE
Fixed NPE when clearing buffered messages

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageFlusher.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageFlusher.java
@@ -370,8 +370,10 @@ public class MessageFlusher {
      * @param destination destination of messages to delete
      */
     public void clearUpAllBufferedMessagesForDelivery(String destination) {
-        subscriptionCursar4QueueMap.get(destination).clearReadButUndeliveredMessages();
-
+        //if subscriptions exist for the given destination, clear buffered messages
+        if (null != subscriptionCursar4QueueMap.get(destination)) {
+            subscriptionCursar4QueueMap.get(destination).clearReadButUndeliveredMessages();
+        }
     }
 
     /**


### PR DESCRIPTION
Addresses the issue in https://wso2.org/jira/browse/MB-1205

Added a null check to ensure that an entry with delivery info for each subscription exists before clearing delivery info.

Please merge https://github.com/wso2/product-mb/pull/170 along with this to enable the test cases.