### PR TITLE
DLC restoring using cached content issue fix

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MaximumNumOfDeliveryRule.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MaximumNumOfDeliveryRule.java
@@ -59,9 +59,11 @@ public class MaximumNumOfDeliveryRule implements DeliveryRule {
     public boolean evaluate(QueueEntry message) throws AndesException {
         long messageID = message.getMessage().getMessageNumber();
         //Check if number of redelivery tries has breached.
+        //we should allow a number of delivery attempts that is equal to the maximumRedeliveryTries + 1
+        //since we set the limit on maxRedeliveryTries rather than maxDeliveryTries
         Integer numOfDeliveriesOfCurrentMsg = message.getAndesMessageReference().getTrackingData()
                 .getNumOfDeliveires4Channel(amqChannelID);
-        if (numOfDeliveriesOfCurrentMsg > maximumRedeliveryTimes) {
+        if (numOfDeliveriesOfCurrentMsg > maximumRedeliveryTimes + 1) {
             log.warn("Number of Maximum Redelivery Tries Has Breached. Routing Message to DLC : id= " + messageID);
             return false;
         } else {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
@@ -322,7 +322,7 @@ public class QueueManagementInformationMBean extends AMQManagedObject implements
             description = "The Dead Letter Queue Name for the selected tenant") String destinationQueueName) {
 
         if (null != andesMetadataIDs) {
-            List<Long> andesMessageIdList = Arrays.asList(ArrayUtils.toObject(andesMetadataIDs));
+            List<Long> andesMessageIdList = new ArrayList<>(Arrays.asList(ArrayUtils.toObject(andesMetadataIDs)));
             List<AndesRemovableMetadata> removableMetadataList = new ArrayList<>(andesMessageIdList.size());
 
             try {
@@ -394,7 +394,7 @@ public class QueueManagementInformationMBean extends AMQManagedObject implements
             description = "The Dead Letter Queue Name for the selected tenant") String destinationQueueName) {
         if (null != andesMetadataIDs) {
 
-            List<Long> andesMessageIdList = Arrays.asList(ArrayUtils.toObject(andesMetadataIDs));
+            List<Long> andesMessageIdList = new ArrayList<>(Arrays.asList(ArrayUtils.toObject(andesMetadataIDs)));
             List<AndesRemovableMetadata> removableMetadataList = new ArrayList<>(andesMessageIdList.size());
 
             try {


### PR DESCRIPTION
Addresses https://wso2.org/jira/browse/MB-1208

The issue was caused by the usage of the method 'Arrays.asList(array)'
The list returned is not java.util.ArrayList, but a private static class defined inside java.util.Arrays which does not support the remove method.

Please merge https://github.com/wso2/product-mb/pull/174 to enable the test cases