### PR TITLE
checkFlowControl() modification in andes-client

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionStore.java
@@ -578,10 +578,10 @@ public class SubscriptionStore {
 
             if (type == SubscriptionChange.ADDED) {
                 andesContextStore.storeDurableSubscription(destinationIdentifier, subscriptionID, subscription.encodeAsStr());
-                log.info("New local subscription " + type + " " + subscription.toString());
+                log.info("Local subscription " + type + " " + subscription.toString());
             } else { // @DISCONNECT
                 andesContextStore.updateDurableSubscription(destinationIdentifier, subscriptionID, subscription.encodeAsStr());
-                log.info("New local subscription " + type + " " + subscription.toString());
+                log.info("Local subscription " + type + " " + subscription.toString());
             }
 
             //add or update local subscription map
@@ -612,7 +612,7 @@ public class SubscriptionStore {
 
         } else if (type == SubscriptionChange.DELETED) {
             removeLocalSubscription(subscription);
-            log.info("Local Subscription Removed " + subscription.toString());
+            log.info("Local Subscription "  + type + " " + subscription.toString());
         }
         // Update channel id map
         if (type == SubscriptionChange.ADDED) {

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession.java
@@ -3146,11 +3146,13 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
                    (expiryTime == 0L ? (expiryTime = System.currentTimeMillis() + FLOW_CONTROL_WAIT_FAILURE)
                                      : expiryTime) >= System.currentTimeMillis() )
             {
-                //Check if failover already started, if true, then return
+                //Check if failover already started, if true, then throw an exception and return
                 //otherwise this cause timeout of publisher because failover thread waiting on lock
                 //which acquired by flow control thread
                 if(getAMQConnection()._protocolHandler.getIsFailoverStart().get()) {
-                    return false;
+                    String errorMessage = "Flow control enable while failover.";
+                    log.error(errorMessage);
+                    throw new JMSException(errorMessage);
                 }
                 flowControlIndicator.wait(FLOW_CONTROL_WAIT_PERIOD);
                 log.info("Message send delayed by " + (System.currentTimeMillis() +


### PR DESCRIPTION
- Previous change was to return false when publisher flow control while failover. This was change to throw an JMS exception to propage it to caller.
- Minor change to log messages in SubscriptionStore.