### PR TITLE
[MB-1217] Removed messages that are moved to DLC from cache

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cache/AndesMessageCache.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cache/AndesMessageCache.java
@@ -50,6 +50,13 @@ public interface AndesMessageCache {
     abstract void removeFromCache(List<Long> messagesToRemove);
 
     /**
+     * Removes a message with a given id from the cache
+     *
+     * @param messagesToRemove list of message Ids
+     */
+    abstract void removeFromCache(long messageToRemove);
+
+    /**
      * Returns a message if found in cache
      * 
      * @param messageId

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cache/DisabledMessageCacheImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cache/DisabledMessageCacheImpl.java
@@ -50,6 +50,13 @@ public class DisabledMessageCacheImpl implements AndesMessageCache {
      * {@inheritDoc}
      */
     @Override
+    public void removeFromCache(long messageToRemove) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public AndesMessage getMessageFromCache(long messageId) {
 
         return null;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cache/GuavaBasedMessageCacheImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cache/GuavaBasedMessageCacheImpl.java
@@ -149,6 +149,15 @@ public class GuavaBasedMessageCacheImpl implements AndesMessageCache {
      *
      */
     @Override
+    public void removeFromCache(long messageToRemove) {
+        cache.invalidate(messageToRemove);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     */
+    @Override
     public AndesMessage getMessageFromCache(long messageId) {
 
         return cache.getIfPresent(messageId);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSMessageStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSMessageStoreImpl.java
@@ -612,6 +612,9 @@ public class RDBMSMessageStoreImpl implements MessageStore {
                 .start();
         Context contextWrite = MetricManager.timer(Level.INFO, MetricsConstants.DB_WRITE).start();
 
+        //Remove the message from cache
+        removeFromCache(messageId);
+
         try {
             connection = getConnection();
             preparedStatement = connection.prepareStatement(RDBMSConstants.PS_MOVE_METADATA_TO_DLC);
@@ -645,6 +648,9 @@ public class RDBMSMessageStoreImpl implements MessageStore {
         Context moveMetadataToDLCContext = MetricManager.timer(Level.INFO, MetricsConstants.MOVE_METADATA_TO_DLC)
                 .start();
         Context contextWrite = MetricManager.timer(Level.INFO, MetricsConstants.DB_WRITE).start();
+
+        //remove messages from cache
+        removeFromCache(messageIds);
 
         try {
             connection = getConnection();
@@ -2133,6 +2139,15 @@ public class RDBMSMessageStoreImpl implements MessageStore {
      */
     private void removeFromCache(List<Long> messagesToRemove) {
         messageCache.removeFromCache(messagesToRemove);
+    }
+
+    /**
+     * Removes a message with a given Id from the cache
+     *
+     * @param messageToRemove message Id of the message to be removed
+     */
+    private void removeFromCache(long messageToRemove) {
+        messageCache.removeFromCache(messageToRemove);
     }
 
     /**


### PR DESCRIPTION
Addresses the jira https://wso2.org/jira/browse/MB-1217

When messages were moved to DLC, they were removed from the cache.