### PR TITLE
[MB-1220] Large message retrieval from cache indexOutOfBoundsException fixed

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPUtils.java
@@ -279,7 +279,7 @@ public class AMQPUtils {
      * @return Written byte count
      * @throws AndesException
      */
-    public static int getMessageContentChunkConvertedCorrectly(long messageId, int offsetValue, ByteBuffer dst) throws AndesException {
+    public static int fillBufferFromContent(long messageId, int offsetValue, ByteBuffer dst) throws AndesException {
         int written = 0;
         int initialBufferSize = dst.remaining();
         int currentOffsetValue = offsetValue;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
@@ -201,7 +201,7 @@ public class QpidAndesBridge {
     public static int getMessageContentChunk(long messageID, int offsetInMessage, ByteBuffer dst) throws AMQException {
         int contentLenWritten;
         try {
-            contentLenWritten = AMQPUtils.getMessageContentChunkConvertedCorrectly(messageID, offsetInMessage, dst);
+            contentLenWritten = AMQPUtils.fillBufferFromContent(messageID, offsetInMessage, dst);
         } catch (AndesException e) {
             log.error("Error in getting message content", e);
             throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error in getting message content chunk messageID " + messageID + " offset=" + offsetInMessage, e);


### PR DESCRIPTION
Addresses the jira https://wso2.org/jira/browse/MB-1220

Please merge https://github.com/wso2/product-mb/pull/184 to enable the ViewMessageContent test case