### PR TITLE
[MB-1222] Slot creation timeout fix

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotMessageCounter.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotMessageCounter.java
@@ -205,9 +205,9 @@ public class SlotMessageCounter {
             if (slot.getMessageCount() >= slotWindowSize
                 || System.currentTimeMillis() - slotStartTime >= timeOutForMessagesInQueue) {
                 try {
-                    slotCoordinator.updateMessageId(storageQueueName, slot.getStartMessageId(), slot.getEndMessageId());
-                    queueToSlotMap.remove(storageQueueName);
                     slotTimeOutMap.remove(storageQueueName);
+                    queueToSlotMap.remove(storageQueueName);
+                    slotCoordinator.updateMessageId(storageQueueName, slot.getStartMessageId(), slot.getEndMessageId());
                 } catch (ConnectionException e) {
                     // we only log here since this is called again from timer task if previous attempt failed
                     log.error("Error occurred while connecting to the thrift coordinator.", e);


### PR DESCRIPTION
Jira Id is : https://wso2.org/jira/browse/MB-1222

Initial issue was, messages were not delivered to subscriber when slow publisher disconnected.
Messages were left in database, No slots created. Subscriber did not received messages again until publisher starts publishing messages again.

Cause of this problem was a race condition between concurrently adding and removing timestamp from slotTimeoutMap which is used to create slots using timeout.

We add an entry to slotTimeoutMap only when the new slot is created. But when submitting the previous slot, we clear the slotTimeoutMap. If the clearing happens after timestamp for new slot is added, new entry will be deleted. In that case, it won't be able to submit the new slot.