### PR TITLE
Fix for slot invalid state transition occurs when overlapping slots

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSAndesContextStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSAndesContextStoreImpl.java
@@ -1663,8 +1663,8 @@ public class RDBMSAndesContextStoreImpl implements AndesContextStore {
                 Slot slot = new Slot();
                 slot.setStartMessageId(resultSet.getLong(RDBMSConstants.START_MESSAGE_ID));
                 slot.setEndMessageId(resultSet.getLong(RDBMSConstants.END_MESSAGE_ID));
-                slot.setStorageQueueName(
-                        resultSet.getString(RDBMSConstants.STORAGE_QUEUE_NAME));
+                slot.setStorageQueueName(resultSet.getString(RDBMSConstants.STORAGE_QUEUE_NAME));
+                slot.addState(SlotState.ASSIGNED);
                 slotSet.add(slot);
             }
             return slotSet;


### PR DESCRIPTION
JIRA - https://wso2.org/jira/browse/MB-1234

We were retrieving assigned slots from database for checking overlapped slots. In previous implementation, we queried slot records and created list of slot objects using those records to return. But when creating list of slot objects, we did not set the slot slate of those new slots to ASSIGNED state. So those slots were in CREATED state. When an overlapped slot was found in the returned list of slots, we update that slot state to OVERLAPPED. In that case, warning will be displayed saying invalid state transition from CREATE to OVERLAPPED.

Fix is to set slot state to ASSIGNED when creating list of slots. Therefore when updating state to OVERLAPPED, it won't be an invalid state transition.