### PR TITLE
Message duplicate/loss issue fixed in pub/sub close.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
@@ -368,6 +368,9 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata{
                 break;
             }
         }
+        if(channelDeliveryInfo.entrySet().isEmpty()) {
+            isAcked = false;
+        }
         return isAcked;
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
@@ -155,7 +155,7 @@ public enum MessageStatus {
         SCHEDULED_TO_SEND.next = EnumSet.of(SENT_TO_ALL, SLOT_RETURNED);
         SCHEDULED_TO_SEND.previous = EnumSet.of(BUFFERED);
 
-        SENT_TO_ALL.next = EnumSet.of(ACKED_BY_ALL, SLOT_RETURNED);
+        SENT_TO_ALL.next = EnumSet.of(SCHEDULED_TO_SEND, ACKED_BY_ALL, SLOT_RETURNED);
         SENT_TO_ALL.previous = EnumSet.of(SCHEDULED_TO_SEND);
 
         ACKED_BY_ALL.next = EnumSet.of(DELETED, SLOT_RETURNED);


### PR DESCRIPTION
- Publisher and subscriber create and close connection for each message and did some test rounds. This was cause to duplicate and loss messages in new delivery model. It has fixed with changes in this commit.