### PR TITLE
message duplicate issue fixed in subscriber create and close connection per message

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
@@ -523,6 +523,8 @@ public class QpidAndesBridge {
                     UUID channelID = ((SubscriptionImpl.AckSubscription) subscription).getChannel().getId();
                     LocalSubscription localSubscription = AndesContext.getInstance().getSubscriptionStore()
                             .getLocalSubscriptionForChannelId(channelID);
+                    localSubscription.setHasExternalSubscriptions(subscription.isActive());
+                    localSubscription.setExclusive(((SubscriptionImpl.AckSubscription) subscription).isExclusive());
                     InboundSubscriptionEvent subscriptionEvent = new InboundSubscriptionEvent(localSubscription);
                     Andes.getInstance().closeLocalSubscription(subscriptionEvent);
                 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesSubscriptionManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesSubscriptionManager.java
@@ -268,12 +268,6 @@ public class AndesSubscriptionManager {
      */
     public void closeLocalSubscription(LocalSubscription subscription) throws AndesException {
 
-        /*
-         * Make subscription inactive as existing local subscription reference is
-         * passed here
-         */
-        subscription.setHasExternalSubscriptions(false);
-
         SubscriptionListener.SubscriptionChange changeType;
         /*
          * For durable topic subscriptions, mark this as a offline subscription.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
@@ -418,8 +418,8 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata{
                 messageStatus.add(state);
             } else {
                 log.warn("Invalid message state transition from " + messageStatus.get
-                        (messageStatus.size() - 1) + " suggested: " + state + " Message ID: " + messageID + "Status " +
-                        "Message Status History >> " + messageStatus);
+                        (messageStatus.size() - 1) + " suggested: " + state + " Message ID: " + messageID
+                        + " Message Status History >> " + messageStatus);
             }
         }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
@@ -155,7 +155,7 @@ public enum MessageStatus {
         SCHEDULED_TO_SEND.next = EnumSet.of(SENT_TO_ALL, SLOT_RETURNED);
         SCHEDULED_TO_SEND.previous = EnumSet.of(BUFFERED);
 
-        SENT_TO_ALL.next = EnumSet.of(SCHEDULED_TO_SEND, ACKED_BY_ALL, SLOT_RETURNED);
+        SENT_TO_ALL.next = EnumSet.of(SCHEDULED_TO_SEND, SENT_TO_ALL, ACKED_BY_ALL, SLOT_RETURNED);
         SENT_TO_ALL.previous = EnumSet.of(SCHEDULED_TO_SEND);
 
         ACKED_BY_ALL.next = EnumSet.of(DELETED, SLOT_RETURNED);
@@ -176,7 +176,10 @@ public enum MessageStatus {
         SLOT_REMOVED.next = EnumSet.complementOf(EnumSet.allOf(MessageStatus.class));
         SLOT_REMOVED.previous = EnumSet.of(DELETED);
 
-        SLOT_RETURNED.next = EnumSet.complementOf(EnumSet.allOf(MessageStatus.class));
+        /**
+         * next status of slot return status can be any state due to subscription could close at any given moment.
+         */
+        SLOT_RETURNED.next = EnumSet.allOf(MessageStatus.class);
         SLOT_RETURNED.previous = EnumSet.allOf(MessageStatus.class);
 
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -261,7 +261,7 @@ public class MessagingEngine {
         if(!messageMetadata.isOKToDispose()) {
             MessageFlusher.getInstance().scheduleMessageForSubscription(subscription, messageMetadata);
             //Tracing message activity
-            MessageTracer.trace(messageMetadata, MessageTracer.MESSAGE_REQUEUED);
+            MessageTracer.trace(messageMetadata, MessageTracer.MESSAGE_REQUEUED_SUBSCRIBER);
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
@@ -103,12 +103,21 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
                         if(subscription.isDurable()) {
                             //re-queue message to andes core so that it can find other subscriber to deliver
                             MessagingEngine.getInstance().reQueueMessage(message);
+                            message.removeScheduledDeliveryChannel(subscription.getChannelID());
+                            //Tracing Message
+                            MessageTracer.trace(message.getMessageID(), message.getDestination(),
+                                    MessageTracer.MESSAGE_REQUEUED_BUFFER);
                         } else {
                             if(!message.isOKToDispose()) {
                                 log.warn("Cannot send message id= " + message.getMessageID() + " as subscriber is closed");
                             }
                         }
                     }
+                } else {
+                    message.removeScheduledDeliveryChannel(subscription.getChannelID());
+                    //Tracing Message
+                    MessageTracer.trace(message.getMessageID(), message.getDestination(),
+                            MessageTracer.DISCARD_STALE_MESSAGE);
                 }
             } catch (Throwable e) {
                 log.error("Error while delivering message. Message id " + message.getMessageID(), e);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/tools/utils/MessageTracer.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/tools/utils/MessageTracer.java
@@ -42,12 +42,14 @@ public class MessageTracer {
     public static final String METADATA_BUFFERED_FOR_DELIVERY = "metadata buffered for delivery";
     public static final String CONTENT_READ = "content read from database";
     public static final String DISPATCHED_TO_PROTOCOL ="dispatched to protocol level for delivery";
-    public static final String MESSAGE_REJECTED = "rejected";
-    public static final String MESSAGE_REQUEUED = "re-queued";
-    public static final String MOVED_TO_DLC = "moved to DLC";
-    public static final String MESSAGE_DELETED = "deleted";
+    public static final String MESSAGE_REJECTED = "message rejected";
+    public static final String MESSAGE_REQUEUED_SUBSCRIBER = "message re-queued to subscriber";
+    public static final String MOVED_TO_DLC = "message moved to DLC";
+    public static final String MESSAGE_DELETED = "message deleted";
     public static final String ACK_RECEIVED_FROM_PROTOCOL = "ACK received from protocol";
     public static final String ACK_PUBLISHED_TO_DISRUPTOR = "ACK event submitted to disruptor";
+    public static final String MESSAGE_REQUEUED_BUFFER = "message re-queued to buffer";
+    public static final String DISCARD_STALE_MESSAGE = "discarding delivery as message is stale";
 
     /**
      * This method will print debug logs for message activities. This will accept parameters for


### PR DESCRIPTION
- duplicate messages received when subscriber create and close connection per message. It has fixed with this changes.
- new tracing inforamation added to Message Tracer to identify message requeue to buffer and message discarded when subscriber close
- Message status check changed to avoid sent to all to sent to all and slot return to sent to all