### PR TITLE
updated message delivery model.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPUtils.java
@@ -26,8 +26,6 @@ import org.wso2.andes.kernel.*;
 import org.wso2.andes.kernel.disruptor.inbound.InboundBindingEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundExchangeEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundQueueEvent;
-import org.wso2.andes.kernel.disruptor.inbound.InboundSubscriptionEvent;
-import org.wso2.andes.kernel.slot.Slot;
 import org.wso2.andes.server.ClusterResourceHolder;
 import org.wso2.andes.server.binding.Binding;
 import org.wso2.andes.server.exchange.DirectExchange;
@@ -45,7 +43,6 @@ import org.wso2.andes.store.StoredAMQPMessage;
 import org.wso2.andes.subscription.AMQPLocalSubscription;
 import org.wso2.andes.subscription.LocalSubscription;
 import org.wso2.andes.subscription.OutboundSubscription;
-import org.wso2.andes.subscription.SubscriptionStore;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -136,10 +133,10 @@ public class AMQPUtils {
      *         Content object which has access to the message content
      * @return AMQMessage
      */
-    public static AMQMessage getAMQMessageForDelivery(DeliverableAndesMetadata metadata, AndesContent content) {
+    public static AMQMessage getAMQMessageForDelivery(ProtocolMessage metadata, AndesContent content) {
         long messageId = metadata.getMessageID();
         //create message with meta data. This has access to message content
-        StorableMessageMetaData metaData = convertAndesMetadataToAMQMetadata(metadata);
+        StorableMessageMetaData metaData = convertAndesMetadataToAMQMetadata(metadata.getMessage());
         QpidStoredMessage<MessageMetaData> message = new QpidStoredMessage<MessageMetaData>(
                 new StoredAMQPMessage(messageId, metaData), content);
         AMQMessage amqMessage = new AMQMessage(message);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AMQPDeliveryRule.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AMQPDeliveryRule.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.andes.kernel;
+
+
+import org.wso2.andes.server.queue.QueueEntry;
+
+/**
+ * This interface have methods to implement to evaluate AMQP specific
+ * Deliver Rule
+ */
+public interface AMQPDeliveryRule {
+    boolean evaluate(QueueEntry message) throws AndesException;
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ChannelMessageStatus.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ChannelMessageStatus.java
@@ -34,30 +34,20 @@ public enum  ChannelMessageStatus {
     DISPATCHED(1),
 
     /**
-     * Message has been sent to its routed consumer
-     */
-    SENT(2),
-
-    /**
      * Message has been failed to send to its routed consumer
      */
-    SEND_FAILED(3),
-
-    /**
-     * Message has been sent more than once.
-     */
-    RESENT(4),
+    SEND_FAILED(2),
 
     /**
      * The consumer has acknowledged receipt of the message
      */
-    ACKED(5),
+    ACKED(3),
 
     /**
      * Consumer has rejected the message ad it has been buffered again for delivery (possibly to another waiting
      * consumer)
      */
-    CLIENT_REJECTED(6);
+    CLIENT_REJECTED(4);
 
 
     private int code;
@@ -120,25 +110,19 @@ public enum  ChannelMessageStatus {
     static {
 
         //Channel wise message status begins at DISPATCHED state.
-        // If message SEND_FAILED or ACKED there is no next state for message.
+        //If message ACKED there is no next state for message.
 
-        DISPATCHED.next = EnumSet.of(SENT, RESENT, SEND_FAILED);
+        DISPATCHED.next = EnumSet.of(SEND_FAILED, ACKED);
         DISPATCHED.previous = EnumSet.complementOf(EnumSet.allOf(ChannelMessageStatus.class));
 
-        SEND_FAILED.next = EnumSet.complementOf(EnumSet.allOf(ChannelMessageStatus.class));
+        SEND_FAILED.next = EnumSet.of(DISPATCHED);
         SEND_FAILED.previous = EnumSet.of(DISPATCHED);
 
-        SENT.next = EnumSet.of(ACKED, CLIENT_REJECTED);
-        SENT.previous = EnumSet.of(DISPATCHED);
-
-        RESENT.next = EnumSet.of(ACKED, CLIENT_REJECTED);
-        RESENT.previous = EnumSet.of(DISPATCHED);
-
         ACKED.next = EnumSet.complementOf(EnumSet.allOf(ChannelMessageStatus.class));
-        ACKED.previous = EnumSet.of(SENT, RESENT);
+        ACKED.previous = EnumSet.of(DISPATCHED);
 
         CLIENT_REJECTED.next = EnumSet.of(DISPATCHED);
-        CLIENT_REJECTED.previous = EnumSet.of(SENT, RESENT);
+        CLIENT_REJECTED.previous = EnumSet.of(DISPATCHED);
     }
 
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ChannelMessageStatus.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ChannelMessageStatus.java
@@ -112,7 +112,7 @@ public enum  ChannelMessageStatus {
         //Channel wise message status begins at DISPATCHED state.
         //If message ACKED there is no next state for message.
 
-        DISPATCHED.next = EnumSet.of(SEND_FAILED, ACKED);
+        DISPATCHED.next = EnumSet.of(SEND_FAILED, ACKED, CLIENT_REJECTED);
         DISPATCHED.previous = EnumSet.complementOf(EnumSet.allOf(ChannelMessageStatus.class));
 
         SEND_FAILED.next = EnumSet.of(DISPATCHED);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ChannelMessageStatus.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ChannelMessageStatus.java
@@ -47,7 +47,12 @@ public enum  ChannelMessageStatus {
      * Consumer has rejected the message ad it has been buffered again for delivery (possibly to another waiting
      * consumer)
      */
-    CLIENT_REJECTED(4);
+    CLIENT_REJECTED(4),
+
+    /**
+     * Consumer is closed
+     */
+    CLOSED(5);
 
 
     private int code;
@@ -110,19 +115,23 @@ public enum  ChannelMessageStatus {
     static {
 
         //Channel wise message status begins at DISPATCHED state.
-        //If message ACKED there is no next state for message.
+        //If message CLOSED there is no next state for message.
 
-        DISPATCHED.next = EnumSet.of(SEND_FAILED, ACKED, CLIENT_REJECTED);
+        DISPATCHED.next = EnumSet.of(SEND_FAILED, ACKED, CLIENT_REJECTED, CLOSED);
         DISPATCHED.previous = EnumSet.complementOf(EnumSet.allOf(ChannelMessageStatus.class));
 
-        SEND_FAILED.next = EnumSet.of(DISPATCHED);
+        SEND_FAILED.next = EnumSet.of(DISPATCHED, CLOSED);
         SEND_FAILED.previous = EnumSet.of(DISPATCHED);
 
-        ACKED.next = EnumSet.complementOf(EnumSet.allOf(ChannelMessageStatus.class));
+        ACKED.next = EnumSet.of(CLOSED);
         ACKED.previous = EnumSet.of(DISPATCHED);
 
-        CLIENT_REJECTED.next = EnumSet.of(DISPATCHED);
+        CLIENT_REJECTED.next = EnumSet.of(DISPATCHED, CLOSED);
         CLIENT_REJECTED.previous = EnumSet.of(DISPATCHED);
+
+        //this is because we directly mark close on channel close
+        CLOSED.next = EnumSet.of(SEND_FAILED, CLOSED);
+        CLOSED.previous = EnumSet.allOf(ChannelMessageStatus.class);
     }
 
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/CommonDeliveryRule.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/CommonDeliveryRule.java
@@ -15,14 +15,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.wso2.andes.kernel;
 
-
-import org.wso2.andes.server.queue.QueueEntry;
-
 /**
- * This interface have methods to implement to evaluate Deliver Rule
+ * This interface have methods to implement to evaluate common
+ * Deliver Rule
  */
-public interface DeliveryRule {
-    boolean evaluate(QueueEntry message) throws AndesException;
+public interface CommonDeliveryRule {
+
+    /**
+     * Evaluate delivery rule. This returns true if the rule is passed. Should be called in kernel
+     * before message is dispatched to the protocol. If failed message should not be sent and
+     * necessary actions should be taken
+     *
+     * @param message message to evaluate rules
+     * @return true if rule is passed
+     * @throws AndesException
+     */
+    boolean evaluate(DeliverableAndesMetadata message) throws AndesException;
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
@@ -66,6 +66,16 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata{
     }
 
     /**
+     * Generate a new protocol deliverable message. This will include a reference of this message
+     * plus snapshot of channel information message is delivered to
+     * @param channelID ID of the channel message is to be delivered
+     * @return new ProtocolMessage object
+     */
+    public ProtocolMessage generateProtocolDeliverableMessage(UUID channelID) {
+        return new ProtocolMessage(this, channelID);
+    }
+
+    /**
      * Check if message is expired
      * @return check expire result
      */

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/HasInterestRuleAMQP.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/HasInterestRuleAMQP.java
@@ -26,14 +26,14 @@ import org.wso2.andes.server.subscription.Subscription;
  * This class represents has Interest Delivery Rule
  * This class has info and methods to evaluate whether there is some subscriber's interests like jms Selectors
  */
-public class HasInterestRule implements DeliveryRule {
-    private static Log log = LogFactory.getLog(HasInterestRule.class);
+public class HasInterestRuleAMQP implements AMQPDeliveryRule {
+    private static Log log = LogFactory.getLog(HasInterestRuleAMQP.class);
     /**
      * This Subscription used to check whether subscription is interest in the message
      */
     private Subscription amqpSubscription;
 
-    public HasInterestRule(Subscription amqpSubscription) {
+    public HasInterestRuleAMQP(Subscription amqpSubscription) {
         this.amqpSubscription = amqpSubscription;
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MaximumNumOfDeliveryRuleAMQP.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MaximumNumOfDeliveryRuleAMQP.java
@@ -31,8 +31,8 @@ import java.util.UUID;
  * This class represents Counting Delivery Rule
  * This class has info and methods to evaluate counting delivery rule
  */
-public class MaximumNumOfDeliveryRule implements DeliveryRule {
-    private static Log log = LogFactory.getLog(MaximumNumOfDeliveryRule.class);
+public class MaximumNumOfDeliveryRuleAMQP implements AMQPDeliveryRule {
+    private static Log log = LogFactory.getLog(MaximumNumOfDeliveryRuleAMQP.class);
     private UUID amqChannelID;
     /**
      * Maximum number of times a message is tried to deliver
@@ -40,7 +40,7 @@ public class MaximumNumOfDeliveryRule implements DeliveryRule {
     private int maximumRedeliveryTimes = (Integer) AndesConfigurationManager
             .readValue(AndesConfiguration.TRANSPORTS_AMQP_MAXIMUM_REDELIVERY_ATTEMPTS);
 
-    public MaximumNumOfDeliveryRule(AMQChannel channel) {
+    public MaximumNumOfDeliveryRuleAMQP(AMQChannel channel) {
         this.amqChannelID = channel.getId();
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MaximumNumOfDeliveryRuleAMQP.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MaximumNumOfDeliveryRuleAMQP.java
@@ -54,8 +54,8 @@ public class MaximumNumOfDeliveryRuleAMQP implements AMQPDeliveryRule {
     public boolean evaluate(QueueEntry message) throws AndesException {
         long messageID = message.getMessage().getMessageNumber();
         //Check if number of redelivery tries has breached.
-        DeliverableAndesMetadata andesMetadata = ((AMQMessage)message.getMessage()).getAndesMetadataReference();
-        int numOfDeliveriesOfCurrentMsg = andesMetadata.getNumOfDeliveries4Channel(amqChannelID);
+        ProtocolMessage protocolMessage = ((AMQMessage)message.getMessage()).getAndesMetadataReference();
+        int numOfDeliveriesOfCurrentMsg = protocolMessage.getNumberOfDeliveriesForProtocolChannel();
 
         if (numOfDeliveriesOfCurrentMsg > maximumRedeliveryTimes) {
             log.warn("Number of Maximum Redelivery Tries Has Breached. Routing Message to DLC : id= " + messageID);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageExpiredRule.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageExpiredRule.java
@@ -19,13 +19,11 @@ package org.wso2.andes.kernel;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.andes.server.message.AMQMessage;
-import org.wso2.andes.server.queue.QueueEntry;
 
 /**
  * This class represents message expiration Delivery Rule
  */
-public class MessageExpiredRule implements DeliveryRule {
+public class MessageExpiredRule implements CommonDeliveryRule {
 
     private static Log log = LogFactory.getLog(MessageExpiredRule.class);
 
@@ -35,11 +33,10 @@ public class MessageExpiredRule implements DeliveryRule {
      * @return isOKToDelivery
      */
     @Override
-    public boolean evaluate(QueueEntry message) {
-        long messageID = message.getMessage().getMessageNumber();
-        DeliverableAndesMetadata andesMetadata = ((AMQMessage)message.getMessage()).getAndesMetadataReference();
+    public boolean evaluate(DeliverableAndesMetadata message) {
+        long messageID = message.getMessageID();
         //Check if destination entry has expired. Any expired message will not be delivered
-        if (andesMetadata.isExpired()) {
+        if (message.isExpired()) {
             log.warn("Message is expired. Routing Message to DLC : id= " + messageID);
             return false;
         } else {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageFlusher.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageFlusher.java
@@ -476,7 +476,8 @@ public class MessageFlusher {
             }
             //mark message as came into the subscription for deliver
             message.markAsDispatchedToDeliver(subscription.getChannelID());
-            flusherExecutor.submit(subscription, message);
+            ProtocolMessage protocolMessage = message.generateProtocolDeliverableMessage(subscription.getChannelID());
+            flusherExecutor.submit(subscription, protocolMessage);
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
@@ -147,7 +147,7 @@ public enum MessageStatus {
         BUFFERED.next = EnumSet.of(SCHEDULED_TO_SEND, SLOT_RETURNED);
         BUFFERED.previous = EnumSet.of(READ);
 
-        SCHEDULED_TO_SEND.next = EnumSet.of(ACKED_BY_ALL, SLOT_RETURNED);
+        SCHEDULED_TO_SEND.next = EnumSet.of(ACKED_BY_ALL, BUFFERED, DLC_MESSAGE, SLOT_RETURNED);
         SCHEDULED_TO_SEND.previous = EnumSet.of(BUFFERED);
 
         ACKED_BY_ALL.next = EnumSet.of(DELETED, SLOT_RETURNED);
@@ -156,7 +156,7 @@ public enum MessageStatus {
         EXPIRED.next = EnumSet.of(DELETED, SLOT_RETURNED);
         EXPIRED.previous = EnumSet.allOf(MessageStatus.class);
 
-        DLC_MESSAGE.next = EnumSet.of(BUFFERED, DELETED, SLOT_RETURNED);
+        DLC_MESSAGE.next = EnumSet.of(BUFFERED, SLOT_REMOVED, SLOT_RETURNED);
         DLC_MESSAGE.previous = EnumSet.of(SCHEDULED_TO_SEND);
 
         PURGED.next = EnumSet.of(DELETED, SLOT_RETURNED);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
@@ -42,45 +42,40 @@ public enum MessageStatus {
     SCHEDULED_TO_SEND(3),
 
     /**
-     * In a topic scenario, message has been sent to all subscribers
-     */
-    SENT_TO_ALL(4),
-
-    /**
      * In a topic scenario, all subscribed consumers have acknowledged receipt of message
      */
-    ACKED_BY_ALL(5),
+    ACKED_BY_ALL(4),
 
 
     /**
      * All messages of the slot containing this message have been handled successfully, causing it to be removed
      */
-    SLOT_REMOVED(6),
+    SLOT_REMOVED(5),
 
     /**
      * Message has expired (JMS Expiration duration sent with the message has passed)
      */
-    EXPIRED(7),
+    EXPIRED(6),
 
     /**
      * Message is moved to the DLC queue
      */
-    DLC_MESSAGE(8),
+    DLC_MESSAGE(7),
 
     /**
      * Message has been cleared from delivery due to a queue purge event.
      */
-    PURGED(9),
+    PURGED(8),
 
     /**
      * Message is deleted from the store
      */
-    DELETED(10),
+    DELETED(9),
 
     /**
      * Slot of the message is returned back to the coordinator, causing message to remove from memory
      */
-    SLOT_RETURNED(11);
+    SLOT_RETURNED(10);
 
 
     private int code;
@@ -152,20 +147,17 @@ public enum MessageStatus {
         BUFFERED.next = EnumSet.of(SCHEDULED_TO_SEND, SLOT_RETURNED);
         BUFFERED.previous = EnumSet.of(READ);
 
-        SCHEDULED_TO_SEND.next = EnumSet.of(SENT_TO_ALL, SLOT_RETURNED);
+        SCHEDULED_TO_SEND.next = EnumSet.of(ACKED_BY_ALL, SLOT_RETURNED);
         SCHEDULED_TO_SEND.previous = EnumSet.of(BUFFERED);
 
-        SENT_TO_ALL.next = EnumSet.of(SCHEDULED_TO_SEND, SENT_TO_ALL, ACKED_BY_ALL, SLOT_RETURNED);
-        SENT_TO_ALL.previous = EnumSet.of(SCHEDULED_TO_SEND);
-
         ACKED_BY_ALL.next = EnumSet.of(DELETED, SLOT_RETURNED);
-        ACKED_BY_ALL.previous = EnumSet.of(SENT_TO_ALL);
+        ACKED_BY_ALL.previous = EnumSet.of(SCHEDULED_TO_SEND);
 
         EXPIRED.next = EnumSet.of(DELETED, SLOT_RETURNED);
         EXPIRED.previous = EnumSet.allOf(MessageStatus.class);
 
         DLC_MESSAGE.next = EnumSet.of(BUFFERED, DELETED, SLOT_RETURNED);
-        DLC_MESSAGE.previous = EnumSet.of(SENT_TO_ALL);
+        DLC_MESSAGE.previous = EnumSet.of(SCHEDULED_TO_SEND);
 
         PURGED.next = EnumSet.of(DELETED, SLOT_RETURNED);
         PURGED.previous = EnumSet.allOf(MessageStatus.class);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -276,6 +276,9 @@ public class MessagingEngine {
     public void reQueueMessage(DeliverableAndesMetadata messageMetadata) throws AndesException {
         if(!messageMetadata.isOKToDispose()) {
             MessageFlusher.getInstance().reQueueMessage(messageMetadata);
+            //Tracing Message
+            MessageTracer.trace(messageMetadata.getMessageID(), messageMetadata.getDestination(),
+                    MessageTracer.MESSAGE_REQUEUED_BUFFER);
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -232,16 +232,16 @@ public class MessagingEngine {
      * @throws AndesException
      */
     public void messageRejected(DeliverableAndesMetadata andesMetadata, UUID channelID) throws AndesException {
-
+        andesMetadata.markAsRejectedByClient(channelID);
         LocalSubscription subToResend = subscriptionStore.getLocalSubscriptionForChannelId(channelID);
         if (subToResend != null) {
-            andesMetadata.markAsRejectedByClient(channelID);
             subToResend.msgRejectReceived(andesMetadata.messageID);
             reQueueMessageToSubscriber(andesMetadata, subToResend);
         } else {
             log.warn("Cannot handle reject. Subscription not found for channel " + channelID
                     + "Dropping message id= " + andesMetadata.getMessageID());
-            andesMetadata.removeScheduledDeliveryChannel(channelID);
+            andesMetadata.markDeliveredChannelAsClosed(channelID);
+            andesMetadata.evaluateMessageAcknowledgement();
         }
         //Tracing message activity
         MessageTracer.trace(andesMetadata, MessageTracer.MESSAGE_REJECTED);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLocalRuleAMQP.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLocalRuleAMQP.java
@@ -31,12 +31,12 @@ import org.wso2.andes.server.subscription.Subscription;
  * No Local option is clearly described in jms spec,
  * It allows us to control sending messages to subscribers whose using the same connection that the publisher used.
  */
-public class NoLocalRule implements DeliveryRule {
-    private static Log log = LogFactory.getLog(NoLocalRule.class);
+public class NoLocalRuleAMQP implements AMQPDeliveryRule {
+    private static Log log = LogFactory.getLog(NoLocalRuleAMQP.class);
     private Subscription amqpSubscription;
     private AMQChannel amqChannel;
 
-    public NoLocalRule(Subscription amqpSubscription, AMQChannel channel) {
+    public NoLocalRuleAMQP(Subscription amqpSubscription, AMQChannel channel) {
         this.amqpSubscription = amqpSubscription;
         this.amqChannel = channel;
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ProtocolDeliveryFailureException.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ProtocolDeliveryFailureException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+/**
+ * This exception represents an error occurred while delivering message
+ * to a protocol (AMQP/MQTT). The block which catches this exception should
+ * handle the failure state (i.e re-queuing/discarding/DLC)
+ */
+public class ProtocolDeliveryFailureException extends AndesException {
+
+    /***
+     * Constructor
+     * @param message descriptive message
+     * @param errorCode one of the above defined constants that classifies the error.
+     * @param cause reference to the exception for reference.
+     */
+    public ProtocolDeliveryFailureException(String message, String errorCode, Throwable cause){
+        super(message, errorCode, cause);
+    }
+
+    /***
+     * Constructor
+     * @param message descriptive message
+     * @param cause reference to the exception for reference.
+     */
+    public ProtocolDeliveryFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructor
+     * @param message descriptive message
+     */
+    public ProtocolDeliveryFailureException(String message) {
+        super(message);
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ProtocolDeliveryRulesFailureException.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ProtocolDeliveryRulesFailureException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+/**
+ * This exception represents an error occurred while evaluating delivery rules
+ * specific to a protocol (AMQP/MQTT). The block which catch this exception should
+ * handle the failure state (i.e re-queuing/discarding/DLC).
+ */
+public class ProtocolDeliveryRulesFailureException extends AndesException{
+    /***
+     * Constructor
+     * @param message descriptive message
+     * @param errorCode one of the above defined constants that classifies the error.
+     * @param cause reference to the exception for reference.
+     */
+    public ProtocolDeliveryRulesFailureException(String message, String errorCode, Throwable cause){
+        super(message, errorCode, cause);
+    }
+
+    /***
+     * Constructor
+     * @param message descriptive message
+     * @param cause reference to the exception for reference.
+     */
+    public ProtocolDeliveryRulesFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructor
+     * @param message descriptive message
+     */
+    public ProtocolDeliveryRulesFailureException(String message) {
+        super(message);
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ProtocolMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ProtocolMessage.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+import java.util.UUID;
+
+/**
+ * This class represents object of a message that is deliverable by any protocol.
+ * Channel wise fields extracted from DeliverableAndesMetadata required by protocol channel is snapshot from it and
+ * inject into this. Protocol delivery MUST read channel wise information from here
+ */
+public class ProtocolMessage {
+
+    /**
+     * Message reference to kernel side. Whenever we change message from kernel side
+     * it will be reflected here (i.e stale message)
+     */
+    private DeliverableAndesMetadata message;
+
+    /**
+     * ID of the message.
+     */
+    private long messageID;
+
+    /**
+     * ID of the channel message is delivered to
+     */
+    private UUID channelID;
+
+    /**
+     * Number of times message is delivered to this channel
+     */
+    private int numberOfDeliveriesForProtocolChannel;
+
+    /**
+     * Is message re-delivered to the channel
+     */
+    private boolean isRedelivered = false;
+
+
+    /**
+     * Constructor - create new ProtocolMessage
+     *
+     * @param message message to be delivered
+     * @param channelID Id of the channel message is delivered to
+     */
+    public ProtocolMessage(DeliverableAndesMetadata message, UUID channelID) {
+        this.message = message;
+        this.channelID = channelID;
+        this.messageID = message.getMessageID();
+        this.numberOfDeliveriesForProtocolChannel = message.getNumOfDeliveries4Channel(channelID);
+        if(numberOfDeliveriesForProtocolChannel > 1) {
+            isRedelivered = true;
+        }
+    }
+
+    public long getMessageID() {
+        return messageID;
+    }
+
+    /**
+     * Check if message is redelivered
+     *
+     * @return true if re-delivered
+     */
+    public boolean isRedelivered() {
+        return isRedelivered;
+    }
+
+    /**
+     * Get reference of message to deliver from kernel
+     *
+     * @return message to deliver
+     */
+    public DeliverableAndesMetadata getMessage() {
+        return message;
+    }
+
+    /**
+     * Get number of times message is delivered to the channel
+     *
+     * @return delivered times.
+     */
+    public int getNumberOfDeliveriesForProtocolChannel() {
+        return numberOfDeliveriesForProtocolChannel;
+    }
+
+    /**
+     * Get ID of the channel message is being delivered
+     *
+     * @return unique ID of the channel
+     */
+    public UUID getChannelID() {
+        return channelID;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/ConcurrentContentReadTaskBatchProcessor.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/ConcurrentContentReadTaskBatchProcessor.java
@@ -29,8 +29,7 @@ import com.lmax.disruptor.SequenceReportingEventHandler;
 import com.lmax.disruptor.Sequencer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.andes.kernel.AndesMessageMetadata;
-import org.wso2.andes.kernel.DeliverableAndesMetadata;
+import org.wso2.andes.kernel.ProtocolMessage;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -134,7 +133,7 @@ public class ConcurrentContentReadTaskBatchProcessor implements EventProcessor {
         notifyStart();
         DeliveryEventData event = null;
         int totalContentLength = 0;
-        List<DeliveryEventData> eventList = new ArrayList<DeliveryEventData>(this.batchSize);
+        List<DeliveryEventData> eventList = new ArrayList<>(this.batchSize);
         Set<Long> messageIDSet = new HashSet<>();
         long currentTurn;
         long nextSequence = sequence.get() + 1L;
@@ -145,12 +144,12 @@ public class ConcurrentContentReadTaskBatchProcessor implements EventProcessor {
                 while (nextSequence <= availableSequence) {
                     event = ringBuffer.get(nextSequence);
 
-                    DeliverableAndesMetadata metadata = event.getMetadata();
+                    ProtocolMessage metadata = event.getMetadata();
                     long currentMessageID = metadata.getMessageID();
                     currentTurn = currentMessageID % groupCount;
                     if (turn == currentTurn) {
                         eventList.add(event);
-                        totalContentLength = totalContentLength + metadata.getMessageContentLength();
+                        totalContentLength = totalContentLength + metadata.getMessage().getMessageContentLength();
                         messageIDSet.add(currentMessageID);
                     }
                     if (log.isDebugEnabled()) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/ContentCacheCreator.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/ContentCacheCreator.java
@@ -83,7 +83,7 @@ public class ContentCacheCreator {
         List<DeliveryEventData> messagesWithoutContent = new ArrayList<>();
 
         for (DeliveryEventData deliveryEventData: eventDataList) {
-            DeliverableAndesMetadata metadata = deliveryEventData.getMetadata();
+            ProtocolMessage metadata = deliveryEventData.getMetadata();
             long messageID =  metadata.getMessageID();
 
             DisruptorCachedContent content = contentCache.getIfPresent(messageID);
@@ -106,7 +106,7 @@ public class ContentCacheCreator {
 
         for (DeliveryEventData deliveryEventData : messagesWithoutContent) {
 
-            DeliverableAndesMetadata metadata = deliveryEventData.getMetadata();
+            ProtocolMessage metadata = deliveryEventData.getMetadata();
             long messageID =  metadata.getMessageID();
 
             // We check again for content put in cache in the previous iteration
@@ -122,7 +122,7 @@ public class ContentCacheCreator {
                 continue;
             }
 
-            int contentSize = metadata.getMessageContentLength();
+            int contentSize = metadata.getMessage().getMessageContentLength();
             List<AndesMessagePart> contentList = contentListMap.get(messageID);
 
             if (null != contentList) {
@@ -145,7 +145,7 @@ public class ContentCacheCreator {
             }
 
             //Tracing message
-            MessageTracer.trace(metadata, MessageTracer.CONTENT_READ);
+            MessageTracer.trace(metadata.getMessage(), MessageTracer.CONTENT_READ);
         }
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventData.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventData.java
@@ -21,6 +21,7 @@ package org.wso2.andes.kernel.disruptor.delivery;
 import com.lmax.disruptor.EventFactory;
 import org.wso2.andes.kernel.AndesContent;
 import org.wso2.andes.kernel.DeliverableAndesMetadata;
+import org.wso2.andes.kernel.ProtocolMessage;
 import org.wso2.andes.subscription.LocalSubscription;
 
 /**
@@ -35,7 +36,7 @@ public class DeliveryEventData {
     /**
      * Metadata of the message
      */
-    private DeliverableAndesMetadata metadata;
+    private ProtocolMessage metadata;
 
     /**
      * Indicate if any error occurred during processing handlers
@@ -111,7 +112,7 @@ public class DeliveryEventData {
      *
      * @return Metadata
      */
-    public DeliverableAndesMetadata getMetadata() {
+    public ProtocolMessage getMetadata() {
         return metadata;
     }
 
@@ -121,7 +122,7 @@ public class DeliveryEventData {
      * @param metadata
      *         Metadata
      */
-    public void setMetadata(DeliverableAndesMetadata metadata) {
+    public void setMetadata(ProtocolMessage metadata) {
         this.metadata = metadata;
     }
 
@@ -134,7 +135,7 @@ public class DeliveryEventData {
 
     @Override
     public String toString() {
-        return "Message ID: " + metadata.getMessageID() + ", Error occurred : " + isErrorOccurred();
+        return "Message ID: " + metadata.getMessage().getMessageID() + ", Error occurred : " + isErrorOccurred();
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
@@ -118,7 +118,6 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
                             MessageTracer.DISCARD_STALE_MESSAGE);
                 }
             } catch (ProtocolDeliveryRulesFailureException e) {
-                log.error("Error while delivering message. Message id " + message.getMessageID(), e);
                 onSendError(message, subscription);
                 routeMessageToDLC(message);
             } catch (ProtocolDeliveryFailureException ex) {
@@ -131,9 +130,7 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
                         log.warn("Cannot send message id= " + message.getMessageID() + " as subscriber is closed");
                     }
                 }
-
-            }
-            catch (Throwable e) {
+            } catch (Throwable e) {
                 log.error("Unexpected error while delivering message. Message id " + message.getMessageID(), e);
             } finally {
                 deliveryEventData.clearData();
@@ -167,7 +164,7 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
         // If message is a queue message we move the message to the Dead Letter Channel
         // since topics doesn't have a Dead Letter Channel
         if (!message.isTopic()) {
-            log.info("Moving message to Dead Letter Channel Due to Send Error. Message ID " + message.getMessageID());
+            log.warn("Moving message to Dead Letter Channel Due to Send Error. Message ID " + message.getMessageID());
             try {
                 Andes.getInstance().moveMessageToDeadLetterChannel(message, message.getDestination());
             } catch (AndesException dlcException) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
@@ -26,6 +26,7 @@ import org.wso2.andes.kernel.DeliverableAndesMetadata;
 import org.wso2.andes.kernel.MessagingEngine;
 import org.wso2.andes.kernel.ProtocolDeliveryFailureException;
 import org.wso2.andes.kernel.ProtocolDeliveryRulesFailureException;
+import org.wso2.andes.kernel.ProtocolMessage;
 import org.wso2.andes.metrics.MetricsConstants;
 import org.wso2.andes.subscription.LocalSubscription;
 import org.wso2.andes.tools.utils.MessageTracer;
@@ -79,7 +80,8 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
 
         // Filter tasks assigned to this handler
         if (channelModulus == ordinal) {
-            DeliverableAndesMetadata message = deliveryEventData.getMetadata();
+            ProtocolMessage protocolMessage = deliveryEventData.getMetadata();
+            DeliverableAndesMetadata message = protocolMessage.getMessage();
 
             try {
                 if (deliveryEventData.isErrorOccurred()) {
@@ -96,7 +98,7 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
                         Meter messageMeter = MetricManager.meter(Level.INFO, MetricsConstants.MSG_SENT_RATE);
                         messageMeter.mark();
 
-                        subscription.sendMessageToSubscriber(message, deliveryEventData.getAndesContent());
+                        subscription.sendMessageToSubscriber(protocolMessage, deliveryEventData.getAndesContent());
 
                     } else {
                         onSendError(message, subscription);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DisruptorBasedFlusher.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DisruptorBasedFlusher.java
@@ -30,6 +30,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
 import org.wso2.andes.kernel.DeliverableAndesMetadata;
+import org.wso2.andes.kernel.ProtocolMessage;
 import org.wso2.andes.metrics.MetricsConstants;
 import org.wso2.andes.subscription.LocalSubscription;
 import org.wso2.andes.tools.utils.MessageTracer;
@@ -127,10 +128,10 @@ public class DisruptorBasedFlusher {
      * @param metadata
      *         Message metadata
      */
-    public void submit(LocalSubscription subscription, DeliverableAndesMetadata metadata) {
+    public void submit(LocalSubscription subscription, ProtocolMessage metadata) {
 
         //Tracing Message
-        MessageTracer.trace(metadata, MessageTracer.PUBLISHED_TO_OUTBOUND_DISRUPTOR);
+        MessageTracer.trace(metadata.getMessage(), MessageTracer.PUBLISHED_TO_OUTBOUND_DISRUPTOR);
 
         long nextSequence = ringBuffer.next();
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/Slot.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/Slot.java
@@ -23,8 +23,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.DeliverableAndesMetadata;
-import org.wso2.andes.kernel.MessageStatus;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -189,7 +187,7 @@ public class Slot implements Serializable, Comparable<Slot> {
     public void markMessagesOfSlotAsReturned() {
         for (DeliverableAndesMetadata andesMetadata : messagesOfSlot.values()) {
             andesMetadata.markAsStale();
-            andesMetadata.addMessageStatus(MessageStatus.SLOT_RETURNED);
+            andesMetadata.markAsSlotReturned();
         }
         messagesOfSlot.clear();
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
@@ -123,10 +123,12 @@ public class MQTTLocalSubscription implements OutboundSubscription {
      * {@inheritDoc}
      */
     @Override
-    public boolean sendMessageToSubscriber(DeliverableAndesMetadata messageMetadata, AndesContent content)
+    public boolean sendMessageToSubscriber(ProtocolMessage protocolMessage, AndesContent content)
             throws AndesException {
 
         boolean sendSuccess;
+
+        DeliverableAndesMetadata messageMetadata = protocolMessage.getMessage();
 
         if(messageMetadata.isRetain()) {
             recordRetainedMessage(messageMetadata.getMessageID());

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
@@ -138,9 +138,6 @@ public class MQTTLocalSubscription implements OutboundSubscription {
         if (null != mqqtServerChannel) {
             try {
 
-                //Mark the message as sent to the subscriber
-                messageMetadata.markAsDeliveredToChannel(getChannelID());
-
                 //TODO:review - instead of getSubscribedDestination() used message destination
                 mqqtServerChannel.distributeMessageToSubscriber(wildcardDestination, message,
                         messageMetadata.getMessageID(), messageMetadata.getQosLevel(),

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/message/AMQMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/message/AMQMessage.java
@@ -21,7 +21,7 @@ import org.apache.log4j.Logger;
 import org.wso2.andes.AMQException;
 import org.wso2.andes.framing.ContentHeaderBody;
 import org.wso2.andes.framing.abstraction.MessagePublishInfo;
-import org.wso2.andes.kernel.DeliverableAndesMetadata;
+import org.wso2.andes.kernel.ProtocolMessage;
 import org.wso2.andes.server.AMQChannel;
 import org.wso2.andes.kernel.slot.Slot;
 import org.wso2.andes.server.store.StoredMessage;
@@ -60,7 +60,7 @@ public class AMQMessage implements ServerMessage
 
     private final long _size;
 
-    private DeliverableAndesMetadata andesMetadataRef;
+    private ProtocolMessage andesMetadataRef;
 
     private Object _sessionIdentifier;
     private static final byte IMMEDIATE_AND_DELIVERED = (byte) (IMMEDIATE | DELIVERED_TO_CONSUMER);
@@ -92,11 +92,11 @@ public class AMQMessage implements ServerMessage
         _channelRef = channelRef;
     }
 
-    public void setAndesMetadataReference(DeliverableAndesMetadata andesMetadataReference) {
+    public void setAndesMetadataReference(ProtocolMessage andesMetadataReference) {
         this.andesMetadataRef = andesMetadataReference;
     }
 
-    public DeliverableAndesMetadata getAndesMetadataReference() {
+    public ProtocolMessage getAndesMetadataReference() {
         return andesMetadataRef;
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/SubscriptionImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/SubscriptionImpl.java
@@ -31,6 +31,7 @@ import org.wso2.andes.configuration.qpid.SubscriptionConfigType;
 import org.wso2.andes.framing.AMQShortString;
 import org.wso2.andes.framing.FieldTable;
 import org.wso2.andes.kernel.AndesUtils;
+import org.wso2.andes.kernel.ProtocolDeliveryFailureException;
 import org.wso2.andes.protocol.AMQConstant;
 import org.wso2.andes.server.AMQChannel;
 import org.wso2.andes.server.filter.FilterManager;
@@ -261,17 +262,18 @@ public abstract class SubscriptionImpl implements Subscription, FlowCreditManage
                 // be resent
                 // when channel is available
                 if (getChannel().isClosing()) {
-
                     if ( log.isDebugEnabled()){
-                        log.debug("channel getting closed therefore, not trying to deliver : " + entry.getMessage().getMessageNumber()  );
+                        log.debug("channel getting closed therefore, not trying to deliver : "
+                                + entry.getMessage().getMessageNumber()  );
                         
                     }
-                    return;
+                    throw new ProtocolDeliveryFailureException("Channel " + getChannel().getClientID() + " is already"
+                            + " closed. Delivery failed message id = " + entry.getMessage().getMessageNumber());
                 }
 
                 if (log.isDebugEnabled()) {
-                    log.debug("sent message : " + entry.getMessageHeader().getMessageId() + " JMSMessageId " + ": " +
-                              entry.getMessageHeader().getMessageId() + " channel=" + getChannel().getChannelId());
+                    log.debug("sent message : " + entry.getMessageHeader().getMessageId() + " JMSMessageId " + ": "
+                            + entry.getMessageHeader().getMessageId() + " channel=" + getChannel().getChannelId());
 
                 }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/AMQPLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/AMQPLocalSubscription.java
@@ -106,7 +106,7 @@ public class AMQPLocalSubscription implements OutboundSubscription {
      * {@inheritDoc}
      */
     @Override
-    public boolean sendMessageToSubscriber(DeliverableAndesMetadata messageMetadata, AndesContent content)
+    public boolean sendMessageToSubscriber(ProtocolMessage messageMetadata, AndesContent content)
             throws AndesException {
 
         AMQMessage message = AMQPUtils.getAMQMessageForDelivery(messageMetadata, content);
@@ -114,7 +114,7 @@ public class AMQPLocalSubscription implements OutboundSubscription {
 
         if (evaluateDeliveryRules(messageToSend)) {
             //check if redelivered. If so, set the JMS header
-            if(messageMetadata.isRedelivered(getChannelID())) {
+            if(messageMetadata.isRedelivered()) {
                 messageToSend.setRedelivered();
             }
             sendMessage(messageToSend);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/LocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/LocalSubscription.java
@@ -27,6 +27,7 @@ import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.DeliverableAndesMetadata;
 import org.wso2.andes.kernel.MessageStatus;
 import org.wso2.andes.kernel.MessagingEngine;
+import org.wso2.andes.kernel.ProtocolMessage;
 import org.wso2.andes.mqtt.MQTTLocalSubscription;
 
 import java.util.ArrayList;
@@ -51,7 +52,8 @@ public class LocalSubscription  extends BasicSubscription implements InboundSubs
     private OutboundSubscription subscription;
 
     /**
-     * Map to track messages being sent <message id, MsgData reference>
+     * Map to track messages being sent <message id, MsgData reference>. This map bares message
+     * reference at kernel side
      */
     private final ConcurrentHashMap<Long, DeliverableAndesMetadata> messageSendingTracker
             = new ConcurrentHashMap<>();
@@ -108,7 +110,7 @@ public class LocalSubscription  extends BasicSubscription implements InboundSubs
      * @return true if the send is a success
      * @throws AndesException
      */
-    public boolean sendMessageToSubscriber(DeliverableAndesMetadata messageMetadata, AndesContent content) throws
+    public boolean sendMessageToSubscriber(ProtocolMessage messageMetadata, AndesContent content) throws
             AndesException {
 
         //It is needed to add the message reference to the tracker and increase un-ack message count BEFORE
@@ -236,7 +238,7 @@ public class LocalSubscription  extends BasicSubscription implements InboundSubs
      * Add message to sending tracker which keeps messages delivered to this channel
      * @param messageData message to add
      */
-    private void addMessageToSendingTracker(DeliverableAndesMetadata messageData) {
+    private void addMessageToSendingTracker(ProtocolMessage messageData) {
 
         if (log.isDebugEnabled()) {
             log.debug("Adding message to sending tracker channel id = " + getChannelID() + " message id = "
@@ -246,7 +248,8 @@ public class LocalSubscription  extends BasicSubscription implements InboundSubs
         DeliverableAndesMetadata messageDataToAdd = messageSendingTracker.get(messageData.getMessageID());
 
         if (null == messageDataToAdd) {
-            messageSendingTracker.put(messageData.getMessageID(), messageData);
+            //we need to put message reference to the sending tracker
+            messageSendingTracker.put(messageData.getMessageID(), messageData.getMessage());
             if(log.isDebugEnabled()) {
                 log.debug("Added message reference. Message Id = "
                         + messageData.getMessageID() + " subscriptionID= " + subscriptionID);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/LocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/LocalSubscription.java
@@ -218,10 +218,12 @@ public class LocalSubscription  extends BasicSubscription implements InboundSubs
      * {@inheritDoc}
      */
     public void close() throws AndesException {
+
         List<DeliverableAndesMetadata> messagesToRemove = new ArrayList<>();
 
         for (DeliverableAndesMetadata andesMetadata : messageSendingTracker.values()) {
-            andesMetadata.removeScheduledDeliveryChannel(getChannelID());
+            andesMetadata.markDeliveredChannelAsClosed(getChannelID());
+            andesMetadata.evaluateMessageAcknowledgement();
 
             //TODO: decide if we need to do this only for topics
             //for topic messages see if we can delete the message
@@ -231,6 +233,7 @@ public class LocalSubscription  extends BasicSubscription implements InboundSubs
                 }
             }
         }
+
         MessagingEngine.getInstance().deleteMessages(messagesToRemove);
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/OutboundSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/OutboundSubscription.java
@@ -20,7 +20,7 @@ package org.wso2.andes.subscription;
 
 import org.wso2.andes.kernel.AndesContent;
 import org.wso2.andes.kernel.AndesException;
-import org.wso2.andes.kernel.DeliverableAndesMetadata;
+import org.wso2.andes.kernel.ProtocolMessage;
 
 import java.util.UUID;
 
@@ -36,7 +36,7 @@ public interface OutboundSubscription {
      * @return delivery is success. If delivery rule evaluations are failed delivery will not be a success
      * @throws org.wso2.andes.kernel.AndesException
      */
-    public boolean sendMessageToSubscriber(DeliverableAndesMetadata messageMetadata, AndesContent content)throws
+    public boolean sendMessageToSubscriber(ProtocolMessage messageMetadata, AndesContent content)throws
             AndesException;
 
     /**


### PR DESCRIPTION
Message status - Removed SENT_TO_ALL status
Channel Message Status  - Removed SENT, RESENT status

Moved purge rule and message expiry rules to the kernel. Now we have two types of delivery rules

AMQPDeliveryRule - AMQP protocol specific
CommonDeliveryRule - kernel level delivery rule

Now state updates are not done inside outbound disruptor. If a send failure happens we detect two types of exceptions and operate on them. 

ProtocolDeliveryFailureException - protocol could not publish - requeue message if durable
ProtocolDeliveryRulesFailureException - protocol level delivery rules failed - send message to DLC if durable