### PR TITLE
[MB-1314] NullPointerException when subscriber closes connection without consuming messages

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageFlusher.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageFlusher.java
@@ -233,6 +233,23 @@ public class MessageFlusher {
         return messageDeliveryInfo;
     }
 
+    /**
+     * Initialize message flusher for delivering messages for the given destination. This is the destination consumers
+     * subscribe.
+     *
+     * @param destination
+     *         Delivery Destination
+     * @throws AndesException
+     */
+    public void prepareForDelivery(String destination) throws AndesException {
+        MessageDeliveryInfo messageDeliveryInfo = new MessageDeliveryInfo();
+        messageDeliveryInfo.destination = destination;
+        Collection<LocalSubscription> localSubscribersForQueue = subscriptionStore
+                .getActiveLocalSubscribersForQueuesAndTopics(destination);
+
+        messageDeliveryInfo.iterator = localSubscribersForQueue.iterator();
+        subscriptionCursar4QueueMap.put(destination, messageDeliveryInfo);
+    }
 
     /**
      * Validates if the the buffer is empty, the messages will be read through this buffer and will be delivered to the
@@ -388,7 +405,6 @@ public class MessageFlusher {
      */
     public void clearUpAllBufferedMessagesForDelivery(String destination) {
         subscriptionCursar4QueueMap.get(destination).clearReadButUndeliveredMessages();
-
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
@@ -401,8 +401,9 @@ public class SlotDeliveryWorker extends Thread implements StoreHealthListener{
      *
      * @param storageQueueName queue name of the newly added queue
      */
-    public void addQueueToThread(String storageQueueName, String destination) {
+    public void addQueueToThread(String storageQueueName, String destination) throws AndesException {
         getStorageQueueNameToDestinationMap().put(storageQueueName, destination);
+        messageFlusher.prepareForDelivery(destination);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorkerManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorkerManager.java
@@ -91,7 +91,7 @@ public class SlotDeliveryWorkerManager {
      *
      * @param storageQueueName  name of the queue to start slot delivery worker for
      */
-    public synchronized void startSlotDeliveryWorker(String storageQueueName, String destinaton) {
+    public synchronized void startSlotDeliveryWorker(String storageQueueName, String destinaton) throws AndesException {
         int slotDeliveryWorkerId = getIdForSlotDeliveryWorker(storageQueueName);
         if (getSlotDeliveryWorkerMap().containsKey(slotDeliveryWorkerId)) {
             //if this queue is not already in the queue


### PR DESCRIPTION
Initialize the message flusher when slot delivery worker is given a
destination to deliver messages.

https://wso2.org/jira/browse/MB-1314