### PR TITLE
findNextSubscriptionToSent is not used to pick subscription for topics

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
@@ -115,9 +115,7 @@ public class NoLossBurstTopicMessageDeliveryImpl implements MessageDeliveryStrat
 
                 message.markAsScheduledToDeliver(subscriptions4Queue);
 
-                for (int j = 0; j < subscriptions4Queue.size(); j++) {
-                    LocalSubscription localSubscription = MessageFlusher.getInstance()
-                            .findNextSubscriptionToSent(destination, subscriptions4Queue);
+                for (LocalSubscription localSubscription : subscriptions4Queue) {
                     MessageFlusher.getInstance().deliverMessageAsynchronously(localSubscription, message);
                 }
                 iterator.remove();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
@@ -118,9 +118,7 @@ public class SlowestSubscriberTopicMessageDeliveryImpl implements MessageDeliver
                     message.markAsScheduledToDeliver(subscriptions4Queue);
 
                     //schedule message to all subscribers
-                    for (int j = 0; j < subscriptions4Queue.size(); j++) {
-                        LocalSubscription localSubscription = MessageFlusher.getInstance().
-                                findNextSubscriptionToSent(destination, subscriptions4Queue);
+                    for (LocalSubscription localSubscription : subscriptions4Queue) {
                         MessageFlusher.getInstance().deliverMessageAsynchronously(localSubscription, message);
                     }
                     iterator.remove();


### PR DESCRIPTION
"findNextSubscriptionToSent" can give the same subscription to deliver
in some situation (when subscription iterator is swapped). This
behaviour is not acceptable for topics. Therefore call to
findNextSubscriptionToSent was replaced by a simple "for loop" in
topic delivery strategies.