### PR TITLE
[MB-1357] Remove hard coded admin in MQTT PersistenceStoreConnector.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/wso2/AndesMQTTBridge.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/wso2/AndesMQTTBridge.java
@@ -107,12 +107,13 @@ public final class AndesMQTTBridge {
      *
      * @param mqttClientChannelID the id of the client(subscriber) who requires disconnection
      * @param topic               the name of the topic unsubscribed
+     * @param username            carbon username of logged user
      * @param event               whether the subscription is initiated or disconnected unexpectedly
      *                            {@link org.dna.mqtt.wso2.AndesMQTTBridge.SubscriptionEvent}
      */
-    public void onSubscriberDisconnection(String mqttClientChannelID, String topic, SubscriptionEvent event) {
+    public void onSubscriberDisconnection(String mqttClientChannelID, String topic, String username, SubscriptionEvent event) {
         try {
-            MQTTopicManager.getInstance().removeOrDisconnectTopicSubscription(mqttClientChannelID, topic, event);
+            MQTTopicManager.getInstance().removeOrDisconnectTopicSubscription(mqttClientChannelID, topic, username, event);
         } catch (MQTTException e) {
             //Will capture the exception here and will not throw it any further
             final String message = "Error while disconnecting the subscription with the id " + mqttClientChannelID;
@@ -158,15 +159,16 @@ public final class AndesMQTTBridge {
      *
      * @param topic               the name of the topic the subscribed to
      * @param mqttClientChannelID the client identification maintained by the MQTT protocol lib
+     * @param username            carbon username of logged user
      * @param qos                 the type of qos the subscription is connected to this can be either MOST_ONE,LEAST_ONE,
      *                            EXACTLY_ONE
      * @param isCleanSession      whether the subscription is durable
      */
-    public void onTopicSubscription(String topic, String mqttClientChannelID, AbstractMessage.QOSType qos,
+    public void onTopicSubscription(String topic, String mqttClientChannelID, String username, AbstractMessage.QOSType qos,
                                     boolean isCleanSession) {
         try {
-            MQTTopicManager.getInstance().addTopicSubscription(topic,
-                    mqttClientChannelID, QOSLevel.getQoSFromValue(qos.getValue()), isCleanSession);
+            MQTTopicManager.getInstance().addTopicSubscription(topic, mqttClientChannelID, username,
+                                                               QOSLevel.getQoSFromValue(qos.getValue()), isCleanSession);
         } catch (MQTTException e) {
             //Will not throw the exception further since the bridge will handle the exceptions in both the realm
             final String message = "Error occurred while subscription is initiated for topic : " + topic +

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTAuthorizationSubject.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTAuthorizationSubject.java
@@ -29,6 +29,11 @@ public class MQTTAuthorizationSubject {
     private String clientID;
 
     /**
+     * Carbon username of MQTT client.
+     */
+    private String username;
+
+    /**
      * User flag (true/false) of the connecting client.
      */
     private boolean userFlag;
@@ -67,5 +72,13 @@ public class MQTTAuthorizationSubject {
 
     public void setTenantDomain(String tenantDomain) {
         this.tenantDomain = tenantDomain;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/InMemoryConnector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/InMemoryConnector.java
@@ -83,7 +83,7 @@ public class InMemoryConnector implements MQTTConnector {
      * {@inheritDoc}
      */
     @Override
-    public void addSubscriber(MQTTopicManager channel, String topic, String clientID, String mqttClientID,
+    public void addSubscriber(MQTTopicManager channel, String topic, String clientID, String username, String mqttClientID,
                               boolean isCleanSession, QOSLevel qos, UUID subscriptionChannelID)
             throws MQTTException, SubscriptionAlreadyExistsException {
 
@@ -103,8 +103,9 @@ public class InMemoryConnector implements MQTTConnector {
      * {@inheritDoc}
      */
     @Override
-    public void removeSubscriber(MQTTopicManager channel, String subscribedTopic, String subscriptionChannelID,
-                                 UUID subscriberChannel, boolean isCleanSession, String mqttClientID)
+    public void removeSubscriber(MQTTopicManager channel, String subscribedTopic,String username,
+                                 String subscriptionChannelID, UUID subscriberChannel,
+                                 boolean isCleanSession, String mqttClientID)
             throws MQTTException {
 
         handleSubscriptionRemoval(subscribedTopic, mqttClientID);
@@ -116,7 +117,7 @@ public class InMemoryConnector implements MQTTConnector {
      * {@inheritDoc}
      */
     @Override
-    public void disconnectSubscriber(MQTTopicManager channel, String subscribedTopic, String subscriptionChannelID,
+    public void disconnectSubscriber(MQTTopicManager channel, String subscribedTopic,String username, String subscriptionChannelID,
                                      UUID subscriberChannel, boolean isCleanSession, String mqttClientID)
             throws MQTTException {
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/MQTTConnector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/MQTTConnector.java
@@ -69,13 +69,14 @@ public interface MQTTConnector {
      * @param channel               the bridge connection as the channel
      * @param topic                 the name of the topic which has subscriber/s
      * @param clientID              the id which will distinguish the topic channel (prefixed for cleanSession=false)
+     * @param username              carbon username of logged user
      * @param mqttClientID          the subscription id which is local to the subscriber
      * @param isCleanSession        should the connection be durable
      * @param qos                   the subscriber specific qos this can be either 0,1 or 2
      * @param subscriptionChannelID will hold the unique identifier of the subscription channel (for Andes)
      * @throws MQTTException
      */
-    public void addSubscriber(MQTTopicManager channel, String topic, String clientID, String mqttClientID,
+    public void addSubscriber(MQTTopicManager channel, String topic, String clientID, String username, String mqttClientID,
                               boolean isCleanSession, QOSLevel qos, UUID subscriptionChannelID)
             throws MQTTException, SubscriptionAlreadyExistsException;
 
@@ -85,13 +86,14 @@ public interface MQTTConnector {
      *
      * @param channel               the connection reference to the bridge
      * @param subscribedTopic       the topic the subscription disconnection should be made
+     * @param username              carbon username of logged in user
      * @param subscriptionChannelID the channel id of the disconnected client
      * @param subscriberChannel     the cluster wide unique identification of the subscription
      * @param isCleanSession        durability of the subscription
      * @param mqttClientID          the id of the client who subscribed to the topic
      * @throws MQTTException
      */
-    public void removeSubscriber(MQTTopicManager channel, String subscribedTopic, String subscriptionChannelID,
+    public void removeSubscriber(MQTTopicManager channel, String subscribedTopic, String username, String subscriptionChannelID,
                                  UUID subscriberChannel, boolean isCleanSession, String mqttClientID)
             throws MQTTException;
 
@@ -100,14 +102,16 @@ public interface MQTTConnector {
      *
      * @param channel               the connection reference to the bridge
      * @param subscribedTopic       the topic the subscription disconnection should be made
+     * @param username              carbon username of logged in user
      * @param subscriptionChannelID the channel id of the disconnected client
      * @param subscriberChannel     the cluster wide unique identification of the subscription
      * @param isCleanSession        durability of the subscription
      * @param mqttClientID          the id of the client who subscribed to the topic
      * @throws MQTTException
      */
-    public void disconnectSubscriber(MQTTopicManager channel, String subscribedTopic, String subscriptionChannelID,
-                                     UUID subscriberChannel, boolean isCleanSession, String mqttClientID)
+    public void disconnectSubscriber(MQTTopicManager channel, String subscribedTopic, String username,
+                                     String subscriptionChannelID, UUID subscriberChannel,
+                                     boolean isCleanSession, String mqttClientID)
             throws MQTTException;
 
     /**


### PR DESCRIPTION
Currently "admin" user has hard coded as queue owner due to permission issues occured when purge/remove queues. with this fix queue owner is taken from carbon user of subscription.

jira - https://wso2.org/jira/browse/MB-1357