### PR TITLE
Fixed UI test failures

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
@@ -450,9 +450,6 @@ public class QueueManagementInformationMBean extends AMQManagedObject implements
 
             List<AndesMessageMetadata> nextNMessageMetadataFromQueue;
             if (!DLCQueueUtils.isDeadLetterQueue(queueName)) {
-                if (nextMsgId == 0) {
-                    nextMsgId = Andes.getInstance().getLastAssignedSlotMessageId(queueName);
-                }
                 nextNMessageMetadataFromQueue = Andes.getInstance()
                         .getNextNMessageMetadataFromQueue(queueName, nextMsgId, maxMsgCount);
             } else {


### PR DESCRIPTION
Addresses the issue reported at https://wso2.org/jira/browse/MB-1393

The issue was caused due to the following factors:
1. When browsing a queue we select messages from the last assigned slot message id rather than from 0 .
2. The last assigned slot message id is retrieved from the slotIdMap which will only be initialized when subscribers are connected (Slots are assigned only when subscribers are present).
3. Therefore, when we create a queue and publish messages(without subscribing) and try to browse the queue, the slotIdmap is not initialized and an NPE occurs.
