### PR TITLE
[MB-1268] Implemented message count retrieval for all queues

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -474,6 +474,16 @@ public class Andes {
     }
 
     /**
+     * Get a map of queue names and the message count in the database for each queue in the database
+     *
+     * @param queueNames list of queue names of which the message count should be retrieved
+     * @return Map of queue names and the message count for each queue
+     */
+    public Map<String, Integer> getMessageCountForAllQueues(List<String> queueNames) throws AndesException {
+        return MessagingEngine.getInstance().getMessageCountForAllQueues(queueNames);
+    }
+
+    /**
      * Get message count for queue
      *
      * @param queueName name of the queue

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
@@ -37,10 +37,8 @@ public interface MessageStore extends HealthAwareStore{
      * @return DurableStoreConnection object created to make the connection to store
      * @throws AndesException
      */
-    public DurableStoreConnection initializeMessageStore(AndesContextStore contextStore,
-                                                         ConfigurationProperties
-                                                                 connectionProperties)
-            throws AndesException;
+    DurableStoreConnection initializeMessageStore(AndesContextStore contextStore,
+                                                  ConfigurationProperties connectionProperties) throws AndesException;
 
     /**
      * store a message content chunk set
@@ -48,7 +46,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param partList message content chunk list
      * @throws AndesException
      */
-    public void storeMessagePart(List<AndesMessagePart> partList) throws AndesException;
+    void storeMessagePart(List<AndesMessagePart> partList) throws AndesException;
 
     /**
      * read content chunk from store
@@ -58,7 +56,7 @@ public interface MessageStore extends HealthAwareStore{
      * @return message content part
      * @throws AndesException
      */
-    public AndesMessagePart getContent(long messageId, int offsetValue) throws AndesException;
+    AndesMessagePart getContent(long messageId, int offsetValue) throws AndesException;
 
     /**
      * Read content for given message metadata list
@@ -67,7 +65,7 @@ public interface MessageStore extends HealthAwareStore{
      * @return <code>Map<Long, List<AndesMessagePart>></code> Message id and its corresponding message part list
      * @throws AndesException
      */
-    public Map<Long, List<AndesMessagePart> > getContent(List<Long> messageIDList) throws AndesException;
+    Map<Long, List<AndesMessagePart>> getContent(List<Long> messageIDList) throws AndesException;
 
     /**
      * store mata data of messages
@@ -75,7 +73,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param metadataList metadata list to store
      * @throws AndesException
      */
-    public void addMetadata(List<AndesMessageMetadata> metadataList) throws AndesException;
+    void addMetadata(List<AndesMessageMetadata> metadataList) throws AndesException;
 
     /**
      * store metadata of a single message
@@ -83,13 +81,13 @@ public interface MessageStore extends HealthAwareStore{
      * @param metadata metadata to store
      * @throws AndesException
      */
-    public void addMetadata(AndesMessageMetadata metadata) throws AndesException;
+    void addMetadata(AndesMessageMetadata metadata) throws AndesException;
 
     /**
      * Store messages into database.
      * @param messageList messages to be stored
      */
-    public void storeMessages(List<AndesMessage> messageList) throws AndesException;
+    void storeMessages(List<AndesMessage> messageList) throws AndesException;
 
     /**
      * store metadata specifically under a queue
@@ -98,8 +96,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param metadata metadata to store
      * @throws AndesException
      */
-    public void addMetadataToQueue(final String queueName, AndesMessageMetadata metadata)
-            throws AndesException;
+    void addMetadataToQueue(final String queueName, AndesMessageMetadata metadata) throws AndesException;
 
     /**
      * store metadata list specifically under a queue
@@ -108,8 +105,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param metadata metadata list to store
      * @throws AndesException
      */
-    public void addMetadataToQueue(final String queueName, List<AndesMessageMetadata> metadata)
-            throws AndesException;
+    void addMetadataToQueue(final String queueName, List<AndesMessageMetadata> metadata) throws AndesException;
 
     /**
      * Store a message in a different Queue without altering the meta data.
@@ -119,8 +115,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param targetQueueName  The target destination Queue name
      * @throws AndesException
      */
-    public void moveMetadataToQueue(long messageId, String currentQueueName, String targetQueueName) throws
-            AndesException;
+    void moveMetadataToQueue(long messageId, String currentQueueName, String targetQueueName) throws AndesException;
 
     /**
      * Method to move a message to dead letter channel
@@ -129,7 +124,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param dlcQueueName the dead letter channel queue name for the message to be moved
      * @throws AndesException
      */
-    public void moveMetadataToDLC(long messageId, String dlcQueueName) throws AndesException;
+    void moveMetadataToDLC(long messageId, String dlcQueueName) throws AndesException;
 
     /**
      * Method to move a list of messages to a specified dead letter channel
@@ -138,7 +133,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param dlcQueueName the dead letter channel queue name for the message to be moved
      * @throws AndesException
      */
-    public void moveMetadataToDLC(List<AndesMessageMetadata> messages, String dlcQueueName) throws AndesException;
+    void moveMetadataToDLC(List<AndesMessageMetadata> messages, String dlcQueueName) throws AndesException;
 
     /**
      * Update the meta data for the given message with the given information in the AndesMetaData. Update destination
@@ -148,7 +143,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param metadataList     The updated meta data list.
      * @throws AndesException
      */
-    public void updateMetadataInformation(String currentQueueName, List<AndesMessageMetadata> metadataList) throws
+    void updateMetadataInformation(String currentQueueName, List<AndesMessageMetadata> metadataList) throws
             AndesException;
 
     /**
@@ -158,7 +153,7 @@ public interface MessageStore extends HealthAwareStore{
      * @return metadata of the message
      * @throws AndesException
      */
-    public AndesMessageMetadata getMetadata(long messageId) throws AndesException;
+    AndesMessageMetadata getMetadata(long messageId) throws AndesException;
 
     /**
      * read a metadata list from store specifying a message id range
@@ -169,8 +164,8 @@ public interface MessageStore extends HealthAwareStore{
      * @return list of metadata
      * @throws AndesException
      */
-    public List<DeliverableAndesMetadata> getMetadataList(Slot slot, final String storageQueueName, long firstMsgId,
-                                                      long lastMsgID) throws AndesException;
+    List<DeliverableAndesMetadata> getMetadataList(Slot slot, final String storageQueueName, long firstMsgId,
+                                                   long lastMsgID) throws AndesException;
 
     /**
      * read  a metadata list from store specifying a starting message id and a count
@@ -181,9 +176,8 @@ public interface MessageStore extends HealthAwareStore{
      * @return list of metadata
      * @throws AndesException
      */
-    public List<AndesMessageMetadata> getNextNMessageMetadataFromQueue(final String storageQueueName,
-                                                                       long firstMsgId, int count)
-            throws AndesException;
+    List<AndesMessageMetadata> getNextNMessageMetadataFromQueue(final String storageQueueName,
+                                                                long firstMsgId, int count) throws AndesException;
 
     /**
      * Retrieve a metadata list from dead letter channel for a specific queue specifying a starting message id and a
@@ -196,7 +190,7 @@ public interface MessageStore extends HealthAwareStore{
      * @return list of metadata
      * @throws AndesException
      */
-    public List<AndesMessageMetadata> getNextNMessageMetadataForQueueFromDLC(final String storageQueueName, String
+    List<AndesMessageMetadata> getNextNMessageMetadataForQueueFromDLC(final String storageQueueName, String
             dlcQueueName, long firstMsgId, int count) throws AndesException;
 
     /**
@@ -208,7 +202,7 @@ public interface MessageStore extends HealthAwareStore{
      * @return list of metadata
      * @throws AndesException
      */
-    public List<AndesMessageMetadata> getNextNMessageMetadataFromDLC(String dlcQueueName, long firstMsgId, int count)
+    List<AndesMessageMetadata> getNextNMessageMetadataFromDLC(String dlcQueueName, long firstMsgId, int count)
             throws AndesException;
 
     /**
@@ -218,7 +212,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param messagesToRemove messages to remove
      * @throws AndesException
      */
-    public void deleteMessageMetadataFromQueue(final String storageQueueName, List<AndesMessageMetadata> messagesToRemove)
+    void deleteMessageMetadataFromQueue(final String storageQueueName, List<AndesMessageMetadata> messagesToRemove)
             throws AndesException;
 
     /**
@@ -232,7 +226,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param messagesToRemove  the list of messages to remove
      * @throws AndesException
      */
-    public void deleteMessages(final String storageQueueName, List<AndesMessageMetadata> messagesToRemove)
+    void deleteMessages(final String storageQueueName, List<AndesMessageMetadata> messagesToRemove)
             throws AndesException;
 
     /**
@@ -242,7 +236,7 @@ public interface MessageStore extends HealthAwareStore{
      * @return AndesRemovableMetadata
      * @throws AndesException
      */
-    public List<AndesMessageMetadata> getExpiredMessages(int limit) throws AndesException;
+    List<AndesMessageMetadata> getExpiredMessages(int limit) throws AndesException;
 
     /**
      * delete messages from expiry queue
@@ -250,7 +244,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param messagesToRemove message IDs to remove
      * @throws AndesException
      */
-    public void deleteMessagesFromExpiryQueue(List<Long> messagesToRemove) throws AndesException;
+    void deleteMessagesFromExpiryQueue(List<Long> messagesToRemove) throws AndesException;
 
     /**
      * add messages to expiry queue
@@ -261,8 +255,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param destination destination message is addressed to
      * @throws AndesException
      */
-    public void addMessageToExpiryQueue(Long messageId, Long expirationTime,
-                                        boolean isMessageForTopic, String destination)
+    void addMessageToExpiryQueue(Long messageId, Long expirationTime, boolean isMessageForTopic, String destination)
             throws AndesException;
 
     /**
@@ -272,7 +265,7 @@ public interface MessageStore extends HealthAwareStore{
      * @return the number of messages that were deleted
      * @throws AndesException
      */
-    public int deleteAllMessageMetadata(String storageQueueName) throws AndesException;
+    int deleteAllMessageMetadata(String storageQueueName) throws AndesException;
 
     /**
      * Store level method to remove all metadata in a dead letter channel
@@ -280,14 +273,14 @@ public interface MessageStore extends HealthAwareStore{
      * @param dlcQueueName name of the queue being purged
      * @throws AndesException
      */
-    public int clearDlcQueue(String dlcQueueName) throws AndesException;
+    int clearDlcQueue(String dlcQueueName) throws AndesException;
 
     /***
      * Get Message ID list addressed to a specific queue.
      * @param storageQueueName name of the queue being purged.
      * @throws AndesException
      */
-    public List<Long> getMessageIDsAddressedToQueue(String storageQueueName, Long startMessageID) throws AndesException;
+    List<Long> getMessageIDsAddressedToQueue(String storageQueueName, Long startMessageID) throws AndesException;
 
     /**
      * Add message counting entry for queue. queue count is initialised to zero. The counter for
@@ -297,7 +290,15 @@ public interface MessageStore extends HealthAwareStore{
      *
      * @param storageQueueName name of queue
      */
-    public void addQueue(String storageQueueName) throws AndesException;
+    void addQueue(String storageQueueName) throws AndesException;
+
+    /**
+     * Get a map of queue names and the message count in the database for each queue in the data store
+     *
+     * @param queueNames list of queue names of which the message count should be retrieved
+     * @return Map of queue names and the message count for each queue
+     */
+    Map<String, Integer> getMessageCountForAllQueues(List<String> queueNames) throws AndesException;
 
     /**
      * Get message count of queue
@@ -305,7 +306,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param storageQueueName name of queue
      * @return message count
      */
-    public long getMessageCountForQueue(String storageQueueName) throws AndesException;
+    long getMessageCountForQueue(String storageQueueName) throws AndesException;
 
     /**
      * Get message count of queue in DLC
@@ -315,7 +316,7 @@ public interface MessageStore extends HealthAwareStore{
      * @return message count
      * @throws AndesException
      */
-    public long getMessageCountForQueueInDLC(String storageQueueName, String dlcQueueName) throws AndesException;
+    long getMessageCountForQueueInDLC(String storageQueueName, String dlcQueueName) throws AndesException;
 
     /**
      * Get message count of in a dead letter channel
@@ -324,22 +325,21 @@ public interface MessageStore extends HealthAwareStore{
      * @return message count
      * @throws AndesException
      */
-    public long getMessageCountForDLCQueue(String dlcQueueName) throws AndesException;
+    long getMessageCountForDLCQueue(String dlcQueueName) throws AndesException;
 
     /**
      * Store level method to reset the message counter of a given queue to 0.
      * @param storageQueueName name of the queue being purged
      * @throws AndesException
      */
-    public void resetMessageCounterForQueue(String storageQueueName) throws AndesException;
+    void resetMessageCounterForQueue(String storageQueueName) throws AndesException;
 
     /**
      * Remove Message counting entry
      *
      * @param storageQueueName name of the queue actually stored in DB
      */
-    public void removeQueue(String storageQueueName) throws AndesException;
-
+    void removeQueue(String storageQueueName) throws AndesException;
 
     /**
      * Increment message counter for a queue by a given incrementBy value
@@ -347,8 +347,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param incrementBy           increment counter by
      * @throws AndesException
      */
-    public void incrementMessageCountForQueue(String storageQueueName, long incrementBy) throws AndesException;
-
+    void incrementMessageCountForQueue(String storageQueueName, long incrementBy) throws AndesException;
 
     /**
      * Decrement message counter for a queue
@@ -357,7 +356,7 @@ public interface MessageStore extends HealthAwareStore{
      * @param decrementBy           decrement counter by
      * @throws AndesException
      */
-    public void decrementMessageCountForQueue(String storageQueueName, long decrementBy) throws AndesException;
+    void decrementMessageCountForQueue(String storageQueueName, long decrementBy) throws AndesException;
 
     /**
      * Store retained message list in the message store.
@@ -365,7 +364,7 @@ public interface MessageStore extends HealthAwareStore{
      *
      * @param retainMap Retained messages map
      */
-    public void storeRetainedMessages(Map<String,AndesMessage> retainMap) throws AndesException;
+    void storeRetainedMessages(Map<String, AndesMessage> retainMap) throws AndesException;
 
     /**
      * Return all topic names with retained messages in the database
@@ -374,7 +373,7 @@ public interface MessageStore extends HealthAwareStore{
      * @return Topic list with retained messages
      * @throws AndesException
      */
-    public List<String> getAllRetainedTopics() throws AndesException;
+    List<String> getAllRetainedTopics() throws AndesException;
 
     /**
      * Get all content parts for the given message ID. The message ID should belong to a
@@ -385,7 +384,7 @@ public interface MessageStore extends HealthAwareStore{
      * @return List of content parts
      * @throws AndesException
      */
-    public Map<Integer, AndesMessagePart> getRetainedContentParts(long messageID) throws AndesException;
+    Map<Integer, AndesMessagePart> getRetainedContentParts(long messageID) throws AndesException;
 
     /**
      * Return retained message metadata for the given destination. Null is returned if
@@ -396,11 +395,11 @@ public interface MessageStore extends HealthAwareStore{
      * @return AndesMessageMetadata
      * @throws AndesException
      */
-    public DeliverableAndesMetadata getRetainedMetadata(String destination) throws AndesException;
+    DeliverableAndesMetadata getRetainedMetadata(String destination) throws AndesException;
 
     /**
      * close the message store
      */
-    public void close();
+    void close();
 
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -489,6 +489,16 @@ public class MessagingEngine {
     }
 
     /**
+     * Get a map of queue names and the message count for each queue from the message store
+     *
+     * @param queueNames list of queue names of which the message count should be retrieved
+     * @return Map of queue names and the message count for each queue
+     */
+    public Map<String, Integer> getMessageCountForAllQueues(List<String> queueNames) throws AndesException {
+        return messageStore.getMessageCountForAllQueues(queueNames);
+    }
+
+    /**
      * Get message count for queue
      *
      * @param queueName name of the queue

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
@@ -219,9 +219,21 @@ public class QueueManagementInformationMBean extends AMQManagedObject implements
 
     }
 
-    /***
+    /**
      * {@inheritDoc}
-     * @return
+     */
+    @Override
+    public Map<String, Integer> getAllQueueCounts() {
+        try {
+            return Andes.getInstance().getMessageCountForAllQueues(AndesContext.getInstance()
+                    .getAMQPConstructStore().getQueueNames());
+        } catch (AndesException exception) {
+            throw new RuntimeException("Error retrieving message count for all queues", exception);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
      */
     public boolean isQueueExists(String queueName) {
         try {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/DLCQueueUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/DLCQueueUtils.java
@@ -72,6 +72,27 @@ public class DLCQueueUtils {
     }
 
     /**
+     * Derive the Dead Letter Queue name of the tenant with respect to a given queue of the same
+     * tenant.
+     * <p/>
+     * The dead letter of the super domain is named as 'DeadLetterChannel' and the DLC of a tenant takes the
+     * format 'tenantDomain/DeadLetterChannel'
+     * Therefore, The DLC queue name return by this method takes either of the above formats.
+     *
+     * @param tenantDomain the domain name of the tenant
+     * @return The Dead Letter Queue name for the tenant.
+     */
+    public static String generateDLCQueueNameFromTenant(String tenantDomain) {
+        //If the tenantDomain is either null of if it is "carbon.super", the DLC of the super domain will be returned
+        //Else, the dlc for the respective tenant will be returned
+        if (null != tenantDomain && !("carbon.super".equals(tenantDomain))) {
+            return tenantDomain + AndesConstants.TENANT_SEPARATOR + AndesConstants.DEAD_LETTER_QUEUE_SUFFIX;
+        } else {
+            return AndesConstants.DEAD_LETTER_QUEUE_SUFFIX;
+        }
+    }
+
+    /**
      * Decides on whether a given queue name is a Dead Letter Queue or not.
      *
      * @param queueName The Queue name to test.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
@@ -437,6 +437,19 @@ public class FailureObservingMessageStore implements MessageStore {
      * {@inheritDoc}
      */
     @Override
+    public Map<String, Integer> getMessageCountForAllQueues(List<String> queueNames) throws AndesException {
+        try {
+            return wrappedInstance.getMessageCountForAllQueues(queueNames);
+        } catch (AndesStoreUnavailableException exception) {
+            notifyFailures(exception);
+            throw exception;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public long getMessageCountForQueue(String storageQueueName) throws AndesException {
         try {
             return wrappedInstance.getMessageCountForQueue(storageQueueName);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -186,6 +186,21 @@ public class RDBMSConstants {
             + " WHERE " + QUEUE_ID + "=?"
             + " AND " + DLC_QUEUE_ID + "=-1";
 
+    protected static final String ALIAS_FOR_QUEUES = "QUEUE_COUNT";
+
+    /**
+     * Prepared statement to select all the queue names with the number of messages remaining in the database
+     * by joining the tables MB_QUEUE_MAPPING and MB_METADATA.
+     */
+    protected static final String PS_SELECT_ALL_QUEUE_MESSAGE_COUNT =
+            "SELECT " + QUEUE_NAME + ", " + PS_ALIAS_FOR_COUNT
+            + " FROM " + QUEUES_TABLE + " LEFT OUTER JOIN "
+                + "(SELECT " + QUEUE_ID + ", COUNT(" + QUEUE_ID + ") AS " + PS_ALIAS_FOR_COUNT
+                + " FROM " + METADATA_TABLE
+                + " WHERE " + DLC_QUEUE_ID + "=-1"
+                + " GROUP BY " + QUEUE_ID + " ) " + ALIAS_FOR_QUEUES
+            + " ON " + QUEUES_TABLE + "." + QUEUE_ID + "=" + ALIAS_FOR_QUEUES + "." + QUEUE_ID;
+
     protected static final String PS_SELECT_QUEUE_MESSAGE_COUNT_FROM_DLC =
             "SELECT COUNT(" + MESSAGE_ID + ")"
             + " AS " + PS_ALIAS_FOR_COUNT
@@ -781,32 +796,26 @@ public class RDBMSConstants {
     protected static final String TASK_DELETING_MESSAGES = "deleting messages";
     protected static final String TASK_MOVING_METADATA_TO_DLC = "moving message metadata to dlc.";
 
-    protected static final String TASK_ADDING_METADATA_TO_QUEUE = "adding metadata to " +
-            "destination. ";
-    protected static final String TASK_ADDING_METADATA_LIST_TO_QUEUE = "adding metadata list to " +
-            "destination. ";
-    protected static final String TASK_RETRIEVING_QUEUE_MSG_COUNT = "retrieving message count for" +
-            " queue. ";
-    protected static final String TASK_RETRIEVING_QUEUE_MSG_COUNT_IN_DLC = "retrieving message count in DLC for" +
-            " queue. ";
+    protected static final String TASK_ADDING_METADATA_TO_QUEUE = "adding metadata to destination. ";
+    protected static final String TASK_ADDING_METADATA_LIST_TO_QUEUE = "adding metadata list to destination. ";
+    protected static final String TASK_RETRIEVING_ALL_QUEUE_MSG_COUNT = "retrieving message counts for all queues. ";
+    protected static final String TASK_RETRIEVING_QUEUE_MSG_COUNT = "retrieving message count for queue. ";
+    protected static final String TASK_RETRIEVING_QUEUE_MSG_COUNT_IN_DLC = "retrieving message count in DLC for"
+                                                                           + " queue. ";
     protected static final String TASK_RETRIEVING_METADATA = "retrieving metadata for message id. ";
-    protected static final String TASK_RETRIEVING_METADATA_RANGE_FROM_QUEUE = "retrieving " +
-            "metadata within a range from queue. ";
-    protected static final String TASK_RETRIEVING_METADATA_RANGE_IN_DLC_FROM_QUEUE = "retrieving " +
-            "metadata in dlc within a range from queue. ";
-    protected static final String TASK_RETRIEVING_METADATA_RANGE_IN_DLC = "retrieving " +
-            "metadata in dlc within a range. ";
-    protected static final String TASK_RETRIEVING_NEXT_N_METADATA_FROM_QUEUE = "retrieving " +
-            "metadata list from queue. ";
-    protected static final String TASK_RETRIEVING_NEXT_N_METADATA_IN_DLC_FOR_QUEUE = "retrieving " +
-            "metadata list in DLC for queue. ";
-    protected static final String TASK_RETRIEVING_NEXT_N_METADATA_FROM_DLC = "retrieving " +
-            "metadata list from DLC ";
-    protected static final String TASK_RETRIEVING_NEXT_N_MESSAGE_IDS_OF_QUEUE = "retrieving " +
-            "message ID list from queue. ";
+    protected static final String TASK_RETRIEVING_METADATA_RANGE_FROM_QUEUE = "retrieving metadata within a range "
+                                                                              + "from queue. ";
+    protected static final String TASK_RETRIEVING_METADATA_RANGE_IN_DLC_FROM_QUEUE = "retrieving metadata in dlc "
+                                                                                     + "within a range from queue. ";
+    protected static final String TASK_RETRIEVING_METADATA_RANGE_IN_DLC = "retrieving metadata in dlc within a range. ";
+    protected static final String TASK_RETRIEVING_NEXT_N_METADATA_FROM_QUEUE = "retrieving metadata list from queue. ";
+    protected static final String TASK_RETRIEVING_NEXT_N_METADATA_IN_DLC_FOR_QUEUE = "retrieving metadata list in DLC "
+                                                                                     + "for queue. ";
+    protected static final String TASK_RETRIEVING_NEXT_N_METADATA_FROM_DLC = "retrieving metadata list from DLC ";
+    protected static final String TASK_RETRIEVING_NEXT_N_MESSAGE_IDS_OF_QUEUE = "retrieving message ID list from "
+                                                                                + "queue. ";
     protected static final String TASK_DELETING_FROM_EXPIRY_TABLE = "deleting from expiry table.";
-    protected static final String TASK_DELETING_METADATA_FROM_QUEUE = "deleting metadata from " +
-            "queue. ";
+    protected static final String TASK_DELETING_METADATA_FROM_QUEUE = "deleting metadata from queue. ";
     protected static final String TASK_CLEARING_DLC_QUEUE = "clearing dlc queue. " ;
     protected static final String TASK_RESETTING_MESSAGE_COUNTER = "Resetting message counter for queue";
     protected static final String TASK_RETRIEVING_EXPIRED_MESSAGES = "retrieving expired messages.";
@@ -815,13 +824,10 @@ public class RDBMSConstants {
 
     // Message Store related retained message jdbc tasks executed
     protected static final String TASK_STORING_RETAINED_MESSAGE = "storing retained messages.";
-    protected static final String TASK_RETRIEVING_RETAINED_MESSAGE_PARTS = "retrieving retained " +
-            "message parts.";
+    protected static final String TASK_RETRIEVING_RETAINED_MESSAGE_PARTS = "retrieving retained message parts.";
     protected static final String TASK_RETRIEVING_RETAINED_TOPICS = "retrieving all retained topics";
-    protected static final String TASK_RETRIEVING_RETAINED_TOPIC_ID = "retrieving retained " +
-            " message id and topic id for given destination.";
-
-
+    protected static final String TASK_RETRIEVING_RETAINED_TOPIC_ID = "retrieving retained  message id and topic id "
+                                                                      + "for given destination.";
 
     // Andes Context Store related jdbc tasks executed
     protected static final String TASK_STORING_DURABLE_SUBSCRIPTION = "storing durable subscription";
@@ -829,21 +835,16 @@ public class RDBMSConstants {
     protected static final String TASK_UPDATING_DURABLE_SUBSCRIPTIONS = "updating durable subscriptions";
     protected static final String TASK_RETRIEVING_ALL_DURABLE_SUBSCRIPTIONS = "retrieving all durable subscriptions. ";
 
-    protected static final String TASK_REMOVING_DURABLE_SUBSCRIPTION = "removing durable " +
-            "subscription. ";
+    protected static final String TASK_REMOVING_DURABLE_SUBSCRIPTION = "removing durable subscription. ";
     protected static final String TASK_STORING_NODE_INFORMATION = "storing node information";
-    protected static final String TASK_RETRIEVING_ALL_NODE_DETAILS = "retrieving all node " +
-            "information. ";
+    protected static final String TASK_RETRIEVING_ALL_NODE_DETAILS = "retrieving all node information. ";
     protected static final String TASK_REMOVING_NODE_INFORMATION = "removing node information";
     protected static final String TASK_STORING_EXCHANGE_INFORMATION = "storing exchange information";
-    protected static final String TASK_RETRIEVING_ALL_EXCHANGE_INFO = "retrieving all exchange " +
-            "information. ";
-    protected static final String TASK_IS_EXCHANGE_EXIST = "checking whether an exchange " +
-            "exist. ";
+    protected static final String TASK_RETRIEVING_ALL_EXCHANGE_INFO = "retrieving all exchange information. ";
+    protected static final String TASK_IS_EXCHANGE_EXIST = "checking whether an exchange exist. ";
     protected static final String TASK_DELETING_EXCHANGE = "deleting an exchange ";
     protected static final String TASK_STORING_QUEUE_INFO = "storing queue information ";
-    protected static final String TASK_RETRIEVING_ALL_QUEUE_INFO = "retrieving all queue " +
-            "information. ";
+    protected static final String TASK_RETRIEVING_ALL_QUEUE_INFO = "retrieving all queue information. ";
     protected static final String TASK_DELETING_QUEUE_INFO = "deleting queue information. ";
     protected static final String TASK_DELETE_QUEUE_MAPPING = "deleting queue mapping";
     protected static final String TASK_STORING_BINDING = "storing binding information. ";

--- a/modules/andes-core/management/common/src/main/java/org/wso2/andes/management/common/mbeans/QueueManagementInformation.java
+++ b/modules/andes-core/management/common/src/main/java/org/wso2/andes/management/common/mbeans/QueueManagementInformation.java
@@ -28,6 +28,7 @@ import javax.management.openmbean.CompositeData;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This interface contains all operations invoked by the UI console with relation to queues. (addition, deletion, purging, etc.)
@@ -62,7 +63,15 @@ public interface QueueManagementInformation {
     @MBeanAttribute(name="Queues",description = "All queue names")
     String[] getAllQueueNames();
 
-    /***
+    /**
+     * Retrieve all queues with message counts
+     *
+     * @return List of all queues with the messageCounts
+     */
+    @MBeanAttribute(name = "AllQueueCounts", description = "Message counts of all queues")
+    Map<String, Integer> getAllQueueCounts();
+
+    /**
      * Retrieve current message count of a queue. This may be only a rough estimate in a fast pub/sub scenario.
      * @param queueName name of queue
      * @param msgPattern The exchange type used to transfer messages with the given queueName. e.g. "queue" or "topic"


### PR DESCRIPTION
Addresses the issue reported at https://wso2.org/jira/browse/MB-1268

The issue was caused by a large number of queries being executed on the database. The Method to retrieve all queues was implemented as follows:
1. Get all the queue names from the AMQPConstructStore
2. For each name, get the number of messages in the database from the metadata table

Therefore, a database call was made for each query in the construct store. The solution to the issue was to get the message count in the metadata table grouped by each queue_id by a single db call. This way, the operation to retrieve all queues is converted to a single operation rather than a number of operations retrieving each queue.

Please merge https://github.com/wso2/carbon-business-messaging/pull/171 and https://github.com/wso2/product-mb/pull/213 along with this