### PR TITLE
[MB-1419] Use limited max unacked messages only for topic and restrict client session to have only one consumer

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/ack/UnacknowledgedMessageMapImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/ack/UnacknowledgedMessageMapImpl.java
@@ -41,14 +41,21 @@ public class UnacknowledgedMessageMapImpl implements UnacknowledgedMessageMap
 
     private final int _prefetchLimit;
 
-    public UnacknowledgedMessageMapImpl(int prefetchLimit, AMQChannel amqChannel)
+    /**
+     * Data structure to keep track of messages which are sent but not yet acknowledged.
+     *
+     * @param prefetchLimit Initial size of the data structure
+     * @param amqChannel The channel which this data structure belongs to
+     * @param isTopic Is this structure for created to keep topic messages
+     */
+    public UnacknowledgedMessageMapImpl(int prefetchLimit, AMQChannel amqChannel, boolean isTopic)
     {
         _prefetchLimit = prefetchLimit;
 
         TopicMessageDeliveryStrategy messageDeliveryStrategy = AndesConfigurationManager.readValue
                 (AndesConfiguration.PERFORMANCE_TUNING_TOPIC_MESSAGE_DELIVERY_STRATEGY);
 
-        if(messageDeliveryStrategy.equals(TopicMessageDeliveryStrategy.DISCARD_ALLOWED)) {
+        if(isTopic && messageDeliveryStrategy.equals(TopicMessageDeliveryStrategy.DISCARD_ALLOWED)) {
             int growLimit = AndesConfigurationManager.readValue
                     (AndesConfiguration.PERFORMANCE_TUNING_ACK_HANDLING_MAX_UNACKED_MESSAGES);
             _map = new LimitedSizeQueueEntryHolder(_prefetchLimit, growLimit, amqChannel);

--- a/modules/andes-core/broker/src/test/java/org/wso2/andes/server/ExtractResendAndRequeueTest.java
+++ b/modules/andes-core/broker/src/test/java/org/wso2/andes/server/ExtractResendAndRequeueTest.java
@@ -68,7 +68,7 @@ public class ExtractResendAndRequeueTest extends TestCase
     @Override
     public void setUp() throws AMQException
     {
-        _unacknowledgedMessageMap = new UnacknowledgedMessageMapImpl(100, null);
+        _unacknowledgedMessageMap = new UnacknowledgedMessageMapImpl(100, null, false);
 
         long id = 0;
         SimpleQueueEntryList list = new SimpleQueueEntryList(_queue);


### PR DESCRIPTION
Fixing - https://wso2.org/jira/browse/MB-1419

Use the LimitedSizeQueueEntryHolder only for topic messages and restrict andes client to allow only one consumer per session.
This is because although QPID is designed so that there can be many consumers per session, Andes is designed so that session and consumer is a one-to-one mapping.
