### PR TITLE
MB-1386, MB-1391, MB-1427, MB-1467

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AMQPConstructStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AMQPConstructStore.java
@@ -163,7 +163,8 @@ public class AMQPConstructStore {
      */
     public void addBinding(AndesBinding binding, boolean isLocal) throws AndesException {
         if (isLocal) {
-            andesContextStore.storeBindingInformation(binding.boundExchangeName, binding.boundQueue.queueName, binding.encodeAsString());
+            andesContextStore.storeBindingInformation(binding.boundExchangeName, binding.boundQueue.queueName,
+                    binding.encodeAsString());
         }
         if (andesBindings.get(binding.boundExchangeName) != null) {
             (andesBindings.get(binding.boundExchangeName)).put(binding.boundQueue.queueName, binding);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesUtils.java
@@ -221,4 +221,21 @@ public class AndesUtils {
         return destinations;
     }
 
+    /**
+     * Get topic name, without the tenant domain
+     * @param routingKey routing key for topic creation
+     * @return String routing key without tenant domain
+     */
+    public static String getTopicNameWithoutTenantDomain(String routingKey){
+        String routingKeyWithoutTenantDomain = routingKey;
+
+        /* If the topic is creating by a tenant, get the topic name, without tenant domain.*/
+        if(routingKey.contains(AndesConstants.TENANT_SEPARATOR)){
+            routingKeyWithoutTenantDomain =
+                    routingKey.substring(routingKey.indexOf(AndesConstants.TENANT_SEPARATOR) + 1);
+        }
+
+        return routingKeyWithoutTenantDomain;
+    }
+
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/exchange/AbstractExchangeMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/exchange/AbstractExchangeMBean.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.wso2.andes.AMQException;
-import org.wso2.andes.AMQSecurityException;
 import org.wso2.andes.server.management.AMQManagedObject;
 import org.wso2.andes.server.management.ManagedObject;
 import org.wso2.andes.server.management.ManagedObjectRegistry;
@@ -53,7 +52,6 @@ public abstract class AbstractExchangeMBean<T extends AbstractExchange> extends 
     protected CompositeType _bindingDataType;
     protected TabularType _bindinglistDataType;
 
-
     private T _exchange;
 
     public AbstractExchangeMBean(final T abstractExchange) throws NotCompliantMBeanException
@@ -71,7 +69,7 @@ public abstract class AbstractExchangeMBean<T extends AbstractExchange> extends 
                 COMPOSITE_ITEM_NAMES.toArray(new String[COMPOSITE_ITEM_NAMES.size()]),
                 COMPOSITE_ITEM_DESCRIPTIONS.toArray(new String[COMPOSITE_ITEM_DESCRIPTIONS.size()]), _bindingItemTypes);
         _bindinglistDataType = new TabularType("Exchange Bindings", "Exchange Bindings for " + getName(),
-                                               _bindingDataType, TABULAR_UNIQUE_INDEX.toArray(new String[TABULAR_UNIQUE_INDEX.size()]));
+                _bindingDataType, TABULAR_UNIQUE_INDEX.toArray(new String[TABULAR_UNIQUE_INDEX.size()]));
     }
 
     public ManagedObject getParentObject()
@@ -141,7 +139,7 @@ public abstract class AbstractExchangeMBean<T extends AbstractExchange> extends 
         try
         {
             vhost.getBindingFactory().addBinding(binding,queue,getExchange(),null);
-            //this is similiar to adding a subscription
+            //this is similar to adding a subscription
         }
         catch (AMQException ex)
         {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueBindHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueBindHandler.java
@@ -115,7 +115,7 @@ public class QueueBindHandler implements StateAwareMethodListener<QueueBindBody>
                 if (session == null || session.getConnectionModel() != protocolConnection)
                 {
                     throw body.getConnectionException(AMQConstant.NOT_ALLOWED,
-                                                      "Queue " + queue.getNameShortString() + " is exclusive, but not created on this Connection.");
+                        "Queue " + queue.getNameShortString() + " is exclusive, but not created on this Connection.");
                 }
             }
 

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/QueueSenderAdapter.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/QueueSenderAdapter.java
@@ -42,9 +42,8 @@ public class QueueSenderAdapter implements QueueSender
         _delegate = msgProducer;
         _queue = queue;
         
-        verifyQueueBindingBeforePublish =
-                                          Boolean.parseBoolean(System.getProperty("org.wso2.andes.client.verifyQueueBindingBeforePublish",
-                                                                                  "true"));
+        verifyQueueBindingBeforePublish = Boolean.parseBoolean(System.getProperty(
+                "org.wso2.andes.client.verifyQueueBindingBeforePublish", "true"));
     }
 
     public Queue getQueue() throws JMSException
@@ -220,7 +219,7 @@ public class QueueSenderAdapter implements QueueSender
                else
                {
                    throw new InvalidDestinationException("Queue: " + queue
-                       + " is not a valid destination (no bindings on server");
+                       + " is not a valid destination (no bindings on the server)");
                }
            }
        }


### PR DESCRIPTION
Changes related to queue/topic names:

MB-1386 : Queue/Topic names should be trimmed before saving
MB-1391 : If a message is published from UI to a topic with a name which has a space in-between the message is not routed to the subscribers
MB-1427 : Prevent topic creation which has two full stops subsequently e.g - Sports..
MB-1467 : Inconsistent behavior in super tenant and tenant space when trying to subscribe from JMS client

This fix validates queue/topic names, when creating queues/topics from clients.

As said in the AMQP specification, this PR allows only  alphanumeric, '.', '*' and '#' characters (apart from '/' which is used as the tenant separator) for the routing key when creates a binding for a topic exchange. Also, prohibited space, when creating queues. 