### PR TITLE
[MB-1245] DurableTopicsSubscribers are not getting unsubscribed

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
@@ -187,15 +187,15 @@ public class AndesContextInformationManager {
         //purge the queue cluster-wide
         MessagingEngine.getInstance().purgeMessages(queueName, null, false);
 
+        //delete all subscription entries if remaining (inactive entries)
+        ClusterResourceHolder.getInstance().getSubscriptionManager()
+                .deleteAllLocalSubscriptionsOfBoundQueue(queueName);
+
         // delete queue from construct store
         constructStore.removeQueue(queueName, true);
 
         //Notify cluster to delete queue
         notifyQueueListeners(queueToDelete, QueueListener.QueueEvent.DELETED);
-
-        //delete all subscription entries if remaining (inactive entries)
-        ClusterResourceHolder.getInstance().getSubscriptionManager()
-                .deleteAllLocalSubscriptionsOfBoundQueue(queueName);
         log.info("Delete queue : " + queueName);
     }
 


### PR DESCRIPTION
Addresses the issue reported at https://wso2.org/jira/browse/MB-1245.

If the user becomes unable to unsubscribe once, he will never be able to unsubscribe since the queue is deleted prior to unsubscribing (the existence of the queue is checked at an early stage of unsubscribing). This PR does not solve the issue completely, but minimizes the issue to some extent by deleting the queue only after unsubscribing, therefore becoming able to attempt once again.