### PR TITLE
Fix mqtt clean session = false delivery path and resolve delivery when a subscriber changes the subscribed topic.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessageMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessageMetadata.java
@@ -322,8 +322,6 @@ public class AndesMessageMetadata implements Comparable<AndesMessageMetadata> {
         //TODO need to implement factory pattern here
         if (type.equals(MessageMetaDataType.META_DATA_MQTT)) {
             underlying = MQTTMetaDataHandler.constructMetadata(routingKey, buf, original_mdt, exchangeName);
-            //This needs to be set to the latest queue name
-            setStorageQueueName(routingKey);
         } else {
             underlying = AMQPMetaDataHandler.constructMetadata(routingKey, buf, original_mdt, exchangeName);
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
@@ -192,4 +192,13 @@ public class MQTTLocalSubscription implements OutboundSubscription {
         // Remove if received acknowledgment message id contains in retained message list.
         retainedMessageList.remove(messageID);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getStorageQueueName(String destination, String subscribedNode) {
+        // Inside Andes, MQTT subscription ID consists of client ID and topic details, hence using the same
+        return mqttSubscriptionID;
+    }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTopicManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTopicManager.java
@@ -400,19 +400,16 @@ public class MQTTopicManager {
     private String registerTopicSubscriptionInCluster(String topicName, String mqttClientID, String username,
                                                       boolean isCleanSession, QOSLevel qos, UUID subscriptionChannelID)
             throws MQTTException, SubscriptionAlreadyExistsException {
-        //Will generate a unique id for the client
-        //Per topic only one subscription will be created across the cluster
-        String topicSpecificClientID = MQTTUtils.generateTopicSpecficClientID(mqttClientID, topicName);
         if (log.isDebugEnabled()) {
-            log.debug("Cluster wide topic connection was created with id " + topicSpecificClientID + " for topic " +
+            log.debug("Cluster wide topic connection was created with id " + mqttClientID + " for topic " +
                     topicName + " with clean session " + isCleanSession);
         }
 
         //Will register the topic cluster wide
-        connector.addSubscriber(this, topicName, topicSpecificClientID, username, mqttClientID, isCleanSession,
+        connector.addSubscriber(this, topicName, mqttClientID, username, isCleanSession,
                 qos, subscriptionChannelID);
 
-        return topicSpecificClientID;
+        return mqttClientID;
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTopics.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTopics.java
@@ -242,7 +242,7 @@ public class MQTTopics {
             //Each subscription holds the cluster id <-> messages id in order to co-relate when ack is received
             subscription.markSent(clusterMessageID, messageID, metadata);
         } else {
-            String error = "Error occurred while dispatching the message to the subscriber for channel id " +
+            String error = "A subscriber has been disconnected while dispatching the message for channel id " +
                     channelId + " for topic " + topic;
             throw new MQTTException(error);
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/InMemoryConnector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/InMemoryConnector.java
@@ -83,7 +83,7 @@ public class InMemoryConnector implements MQTTConnector {
      * {@inheritDoc}
      */
     @Override
-    public void addSubscriber(MQTTopicManager channel, String topic, String clientID, String username, String mqttClientID,
+    public void addSubscriber(MQTTopicManager channel, String topic, String clientID, String username,
                               boolean isCleanSession, QOSLevel qos, UUID subscriptionChannelID)
             throws MQTTException, SubscriptionAlreadyExistsException {
 
@@ -92,7 +92,7 @@ public class InMemoryConnector implements MQTTConnector {
         if (null == subscribers) {
             subscribers = new ArrayList<String>();
         }
-        subscribers.add(mqttClientID);
+        subscribers.add(clientID);
         //Will add the final list to the subscription
         messageSubscription.put(topic, subscribers);
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/MQTTConnector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/MQTTConnector.java
@@ -70,13 +70,12 @@ public interface MQTTConnector {
      * @param topic                 the name of the topic which has subscriber/s
      * @param clientID              the id which will distinguish the topic channel (prefixed for cleanSession=false)
      * @param username              carbon username of logged user
-     * @param mqttClientID          the subscription id which is local to the subscriber
      * @param isCleanSession        should the connection be durable
      * @param qos                   the subscriber specific qos this can be either 0,1 or 2
      * @param subscriptionChannelID will hold the unique identifier of the subscription channel (for Andes)
      * @throws MQTTException
      */
-    public void addSubscriber(MQTTopicManager channel, String topic, String clientID, String username, String mqttClientID,
+    public void addSubscriber(MQTTopicManager channel, String topic, String clientID, String username,
                               boolean isCleanSession, QOSLevel qos, UUID subscriptionChannelID)
             throws MQTTException, SubscriptionAlreadyExistsException;
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/utils/MQTTUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/utils/MQTTUtils.java
@@ -170,20 +170,6 @@ public class MQTTUtils {
     }
 
     /**
-     * For each topic there will only be one subscriber connection cluster wide locally there can be multiple channels
-     * bound. This method will generate a unique id for the subscription created per topic
-     *
-     * TopicSpecificClientID = carbon:clientId:topic
-     *
-     * @param clientId The MQTT client Id
-     * @param topic The topic subscribed to
-     * @return the unique identifier
-     */
-    public static String generateTopicSpecficClientID(String clientId, String topic) {
-        return "carbon:" + clientId + ":" + topic;
-    }
-
-    /**
      * Will convert between the types of the QOS to adhere to the conversion of both andes and mqtt protocol
      *
      * @param qos the quality of service level the message should be published/subscribed
@@ -282,6 +268,10 @@ public class MQTTUtils {
         }
 
         return tenant;
+    }
+
+    public static String getTopicSpecificQueueName(String clientId, String topic) {
+        return "carbon:" + clientId + ":" + topic;
     }
 
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/AMQPLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/AMQPLocalSubscription.java
@@ -185,4 +185,24 @@ public class AMQPLocalSubscription implements OutboundSubscription {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getStorageQueueName(String destination, String subscribedNode) {
+
+        String storageQueueName;
+
+        String targetQueue = amqQueue.getName();
+
+        if (isBoundToTopic && !isDurable) {  // for normal topic subscriptions
+            storageQueueName = AndesUtils.getStorageQueueForDestination(destination, subscribedNode, true);
+        } else if (isBoundToTopic) {  //for durable topic subscriptions
+            storageQueueName = AndesUtils.getStorageQueueForDestination(targetQueue, subscribedNode, false);
+        } else { //For queue subscriptions. This is a must. Otherwise queue will not be shared among nodes
+            storageQueueName = AndesUtils.getStorageQueueForDestination(targetQueue, subscribedNode, false);
+        }
+
+        return storageQueueName;
+    }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/BasicSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/BasicSubscription.java
@@ -107,14 +107,14 @@ public class BasicSubscription implements AndesSubscription {
                 this.subscriptionType = SubscriptionType.valueOf(tokens[1]);
                 // Will automatically throw an IllegalArgumentException if the value does not match to any
                 // SubscriptionType
+            } else if (tokens[0].equals("storageQueueName")) {
+                this.storageQueueName = tokens[1];
             } else {
                 if (tokens[0].trim().length() > 0) {
                     throw new UnsupportedOperationException("Unexpected token " + tokens[0]);
                 }
             }
         }
-
-        setStorageQueueName();
     }
 
     /**
@@ -158,7 +158,6 @@ public class BasicSubscription implements AndesSubscription {
         this.targetQueueBoundExchangeType = targetQueueBoundExchangeType;
         this.isTargetQueueBoundExchangeAutoDeletable = isTargetQueueBoundExchangeAutoDeletable;
         this.hasExternalSubscriptions = hasExternalSubscriptions;
-        setStorageQueueName();
     }
 
     /**
@@ -342,7 +341,8 @@ public class BasicSubscription implements AndesSubscription {
                 .append(isTargetQueueBoundExchangeAutoDeletable == null ? "null" : isTargetQueueBoundExchangeAutoDeletable)
                 .append(",subscribedNode=").append(subscribedNode)
                 .append(",subscribedTime=").append(subscribeTime)
-                .append(",hasExternalSubscriptions=").append(hasExternalSubscriptions);
+                .append(",hasExternalSubscriptions=").append(hasExternalSubscriptions)
+                .append(",storageQueueName=").append(storageQueueName);
 
         if (subscriptionType != null) {
             builder.append(",subscriptionType=").append(subscriptionType);
@@ -381,14 +381,10 @@ public class BasicSubscription implements AndesSubscription {
 
     /**
      * Set storage queue name. Slot delivery worker will refer this name
+     *
+     * @param storageQueueName The storage queue name to set
      */
-    private void setStorageQueueName() {
-        if (isBoundToTopic && !isDurable) {  // for normal topic subscriptions
-            storageQueueName = AndesUtils.getStorageQueueForDestination(destination, subscribedNode, true);
-        } else if (isBoundToTopic) {  //for durable topic subscriptions
-            storageQueueName = AndesUtils.getStorageQueueForDestination(targetQueue, subscribedNode, false);
-        } else { //For queue subscriptions. This is a must. Otherwise queue will not be shared among nodes
-            storageQueueName = AndesUtils.getStorageQueueForDestination(targetQueue, subscribedNode, false);
-        }
+    protected void setStorageQueueName(String storageQueueName) {
+        this.storageQueueName = storageQueueName;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/LocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/LocalSubscription.java
@@ -90,11 +90,16 @@ public class LocalSubscription  extends BasicSubscription implements InboundSubs
 
         this.subscription = subscription;
 
-        //We need to keep the subscriptionType in basic subscription for notification
-        if(subscription instanceof AMQPLocalSubscription) {
-            setSubscriptionType(SubscriptionType.AMQP);
-        } else if(subscription instanceof MQTTLocalSubscription) {
-            setSubscriptionType(SubscriptionType.MQTT);
+        // In case of mock subscriptions, this becomes null
+        if (null != subscription) {
+            //We need to keep the subscriptionType in basic subscription for notification
+            if(subscription instanceof AMQPLocalSubscription) {
+                setSubscriptionType(SubscriptionType.AMQP);
+            } else if(subscription instanceof MQTTLocalSubscription) {
+                setSubscriptionType(SubscriptionType.MQTT);
+            }
+
+            setStorageQueueName(subscription.getStorageQueueName(destination, subscribedNode));
         }
 
         this.maxNumberOfUnAcknowledgedMessages = AndesConfigurationManager.readValue

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/OutboundSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/OutboundSubscription.java
@@ -52,4 +52,13 @@ public interface OutboundSubscription {
      */
     public UUID getChannelID();
 
+    /**
+     * Get the storage queue name for this subscription.
+     *
+     * @param destination The destination this subscriber subscribed to
+     * @param subscribedNode The node this subscriber subscribed to
+     * @return The storage queue name
+     */
+    public String getStorageQueueName(String destination, String subscribedNode);
+
 }


### PR DESCRIPTION
This pull fixes the following issues.

https://wso2.org/jira/browse/MB-1472
https://wso2.org/jira/browse/MB-1471
https://wso2.org/jira/browse/MB-1468
https://wso2.org/jira/browse/MB-1425
https://wso2.org/jira/browse/MB-1334
https://wso2.org/jira/browse/MB-1423

MQTT subscription handling is changed so that when a client is connected to two different topics, Andes will create two subscriptions, one per each topic, manipulating the subscription ID.

Changed the storage queue name for clean session = false subscribers to a combination of clienId + topic, instead of just client Id.