### PR TITLE
fix_jira_1389

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/exchange/topic/TopicExchangeResult.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/exchange/topic/TopicExchangeResult.java
@@ -53,13 +53,15 @@ public final class TopicExchangeResult implements TopicMatcherResult
     public void removeUnfilteredQueue(AMQQueue queue)
     {
         Integer instances = _unfilteredQueues.get(queue);
-        if(instances == 1)
-        {
-            _unfilteredQueues.remove(queue);
-        }
-        else
-        {
-            _unfilteredQueues.put(queue,instances - 1);
+
+        // if instances comes up null, that means there was anyway no unfiltered queue instance for the input AMQQueue.
+        // Therefore, only remove if not null.
+        if (null != instances) {
+            if (instances == 1) {
+                _unfilteredQueues.remove(queue);
+            } else {
+                _unfilteredQueues.put(queue, instances - 1);
+            }
         }
 
     }
@@ -134,7 +136,9 @@ public final class TopicExchangeResult implements TopicMatcherResult
                                    MessageFilter oldFilter,
                                    MessageFilter newFilter)
     {
+
         Map<MessageFilter,Integer> filters = _filteredQueues.get(queue);
+
         Map<MessageFilter,Integer> newFilters = new ConcurrentHashMap<MessageFilter,Integer>(filters);
         Integer oldFilterInstances = filters.get(oldFilter);
         if(oldFilterInstances == 1)
@@ -154,6 +158,7 @@ public final class TopicExchangeResult implements TopicMatcherResult
         {
             newFilters.put(newFilter, newFilterInstances+1);
         }
+
         _filteredQueues.put(queue,newFilters);
     }
 


### PR DESCRIPTION
Fix for : https://wso2.org/jira/browse/MB-1389

When a durable subscription is added with a selector, and then changed to exclude that selector, the code goes through https://github.com/wso2/andes/blob/master/modules/andes-core/broker/src/main/java/org/wso2/andes/server/binding/BindingFactory.java#L128, which causes the an unbind call to the registry, removing the registry entry for that subscription.

Problem was that, the entry addition was happening before the unbind. Without the registry subscription entry at "_system/governance/event/topics/topic1/jms.subscriptions/", the topic browse page hides the subscription.



