### PR TITLE
Update durable subscriptions properly when loaded from db

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/ClusterSubscriptionHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/ClusterSubscriptionHandler.java
@@ -40,18 +40,16 @@ public interface ClusterSubscriptionHandler {
     /**
      * Update a wildcard subscription to the underlying data structure
      * @param subscription The subscription to be updated
-     * @throws AndesException
      */
-    public void updateWildCardSubscription(AndesSubscription subscription) throws AndesException;
+    public void updateWildCardSubscription(AndesSubscription subscription);
 
     /**
      * Check if a subscription is already available.
      *
      * @param subscription The subscription to check for existence
      * @return True if available
-     * @throws org.wso2.andes.kernel.AndesException
      */
-    public boolean isSubscriptionAvailable(AndesSubscription subscription) throws AndesException;
+    public boolean isSubscriptionAvailable(AndesSubscription subscription);
 
     /**
      * Remove a wildcard subscription from the underlying data structure.


### PR DESCRIPTION
This pull fixes the following issues.

https://wso2.org/jira/browse/MB-1444
https://wso2.org/jira/browse/MB-1446

Update durable topics with wildcards from bitmap handler when loaded from db.