### PR TITLE
[MB-1449] fix issue of replacing channelInfo object when rescheduled.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
@@ -167,24 +167,32 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata{
 
     /**
      * Mark message as scheduled to deliver to given subscribers
+     *
      * @param localSubscriptions local subscriptions to deliver. AMQP/MQTT subscribers have individual
-     *                         delivery channels
+     *                           delivery channels
      */
     public void markAsScheduledToDeliver(Collection<LocalSubscription> localSubscriptions) {
         for (LocalSubscription subscription : localSubscriptions) {
-            ChannelInformation channelInformation = new ChannelInformation();
-            channelDeliveryInfo.put(subscription.getChannelID(), channelInformation);
+            ChannelInformation channelInformation = channelDeliveryInfo.get(subscription.getChannelID());
+            if (null == channelInformation) {
+                channelInformation = new ChannelInformation();
+                channelDeliveryInfo.put(subscription.getChannelID(), channelInformation);
+            }
         }
         addMessageStatus(MessageStatus.SCHEDULED_TO_SEND);
     }
 
     /**
      * Mark message as scheduled to deliver to given subscriber
+     *
      * @param subscription subscription to deliver message
      */
     public void markAsScheduledToDeliver(LocalSubscription subscription) {
-        ChannelInformation channelInformation = new ChannelInformation();
-        channelDeliveryInfo.put(subscription.getChannelID(), channelInformation);
+        ChannelInformation channelInformation = channelDeliveryInfo.get(subscription.getChannelID());
+        if (null == channelInformation) {
+            channelInformation = new ChannelInformation();
+            channelDeliveryInfo.put(subscription.getChannelID(), channelInformation);
+        }
         addMessageStatus(MessageStatus.SCHEDULED_TO_SEND);
     }
 


### PR DESCRIPTION
This fix is related to : https://wso2.org/jira/browse/MB-1449.

If a delivery failure exception happened during message delivery (even a null pointer), message will be re-tried a finite number of times (see configuration MaximumNumberOfDeliveries) for a given subscriber. Then it will be moved to DLC. 
