### PR TITLE
[MB-1245] Fixed issue in unsubscribing durable subscriptions

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
@@ -66,6 +66,11 @@ public class AndesContextInformationManager {
     private SubscriptionStore subscriptionStore;
 
     /**
+     * Manages all operations related to subscription changes such as addition, disconnection and deletion
+     */
+    AndesSubscriptionManager subscriptionManager;
+
+    /**
      * Initializes the andes context information manager
      *
      * @param subscriptionStore The subscriptions store
@@ -75,6 +80,7 @@ public class AndesContextInformationManager {
                                           AndesContextStore contextStore,
                                           MessageStore messageStore) {
 
+        this.subscriptionManager = ClusterResourceHolder.getInstance().getSubscriptionManager();
         this.subscriptionStore = subscriptionStore;
         this.messageStore = messageStore;
         this.contextStore = contextStore;
@@ -187,9 +193,9 @@ public class AndesContextInformationManager {
         //purge the queue cluster-wide
         MessagingEngine.getInstance().purgeMessages(queueName, null, false);
 
-        //delete all subscription entries if remaining (inactive entries)
-        ClusterResourceHolder.getInstance().getSubscriptionManager()
-                .deleteAllLocalSubscriptionsOfBoundQueue(queueName);
+        //delete all local and cluster subscription entries if remaining (inactive entries)
+        subscriptionManager.deleteAllLocalSubscriptionsOfBoundQueue(queueName);
+        subscriptionManager.deleteAllClusterSubscriptionsOfBoundQueue(queueName);
 
         // delete queue from construct store
         constructStore.removeQueue(queueName, true);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesSubscriptionManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesSubscriptionManager.java
@@ -204,7 +204,7 @@ public class AndesSubscriptionManager {
                             subscriptionStore.removeSubscriptionDirectly(sub);
                         }
                         notifyLocalSubscriptionHasChanged(mockSubscription,
-                                                          SubscriptionListener.SubscriptionChange.DELETED);
+                                SubscriptionListener.SubscriptionChange.DELETED);
                     }
                 }
             }
@@ -233,7 +233,8 @@ public class AndesSubscriptionManager {
                         LocalSubscription mockSubscription = convertClusterSubscriptionToMockLocalSubscription(sub);
                         mockSubscription.close();
                         subscriptionStore.removeSubscriptionDirectly(sub);
-                        notifyClusterSubscriptionHasChanged(mockSubscription, SubscriptionListener.SubscriptionChange.DELETED);
+                        notifyClusterSubscriptionHasChanged(mockSubscription, SubscriptionListener.SubscriptionChange
+                                .DELETED);
                     }
                 }
             }
@@ -344,6 +345,29 @@ public class AndesSubscriptionManager {
             subscription.close();
             subscriptionStore.createDisconnectOrRemoveLocalSubscription(subscription, SubscriptionListener.SubscriptionChange.DELETED);
             notifyLocalSubscriptionHasChanged(subscription, SubscriptionListener.SubscriptionChange.DELETED);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Removed " + subscriptionsOfQueue.size() + " local subscriptions bound to queue: "
+                      + boundQueueName);
+        }
+    }
+
+    /**
+     * Delete all cluster subscription entries bound for queue
+     * @param boundQueueName queue name to delete subscriptions
+     * @throws AndesException
+     */
+    public synchronized void deleteAllClusterSubscriptionsOfBoundQueue(String boundQueueName) throws AndesException{
+        Set<AndesSubscription> subscriptionsOfQueue = subscriptionStore.getListOfClusterSubscriptionsBoundToQueue(
+                boundQueueName);
+        for(AndesSubscription subscription : subscriptionsOfQueue) {
+            subscriptionStore.createDisconnectOrRemoveClusterSubscription(subscription, SubscriptionListener
+                    .SubscriptionChange.DELETED);
+        }
+        subscriptionStore.removeClusterSubscriptions(subscriptionsOfQueue);
+        if (log.isDebugEnabled()) {
+            log.debug("Removed " + subscriptionsOfQueue.size() + " cluster subscriptions bound to queue: "
+                      + boundQueueName);
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/ClusterCoordinationHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/ClusterCoordinationHandler.java
@@ -43,9 +43,13 @@ public class ClusterCoordinationHandler implements QueueListener, ExchangeListen
                 ClusterResourceHolder.getInstance().getVirtualHostConfigSynchronizer().clusterQueueAdded(andesQueue);
                 break;
             case DELETED:
-                //delete queue
+                //Delete remaining subscriptions from the local and cluster subscription maps
                 ClusterResourceHolder.getInstance().getSubscriptionManager().deleteAllLocalSubscriptionsOfBoundQueue(
                         andesQueue.queueName);
+                ClusterResourceHolder.getInstance().getSubscriptionManager().deleteAllClusterSubscriptionsOfBoundQueue(
+                        andesQueue.queueName);
+
+                //delete queue
                 ClusterResourceHolder.getInstance().getVirtualHostConfigSynchronizer().clusterQueueRemoved(andesQueue);
                 break;
             case PURGED:


### PR DESCRIPTION
Addresses the issue reported at https://wso2.org/jira/browse/MB-1245.

The issue occurred when trying to unsubscribe durable subscriptions after restarting the whole cluster. The root cause for the issue was that the subscriptions were identified from local subscription maps and the local subscription maps were empty after restarting nodes.

The issue was solved by deleting all cluster subscriptions from the cluster subscription masp regardless of its presence in the local subscription map.