### PR TITLE
Change MQTT storage queue name and restrict will message

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/messaging/spi/impl/ProtocolProcessor.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/messaging/spi/impl/ProtocolProcessor.java
@@ -205,12 +205,13 @@ public class ProtocolProcessor implements EventHandler<ValueEvent>, PubAckHandle
 
         //Handle will flag
         if (msg.isWillFlag()) {
-            AbstractMessage.QOSType willQos = AbstractMessage.QOSType.values()[msg.getWillQos()];
-            byte[] willPayload = msg.getWillMessage().getBytes();
-            ByteBuffer bb = (ByteBuffer) ByteBuffer.allocate(willPayload.length).put(willPayload).flip();
-            PublishEvent pubEvt = new PublishEvent(msg.getWillTopic(), willQos,
-                    bb, msg.isWillRetain(), msg.getClientID(), session);
-            processPublish(pubEvt);
+            log.warn("Andes does not support last will operation");
+//            AbstractMessage.QOSType willQos = AbstractMessage.QOSType.values()[msg.getWillQos()];
+//            byte[] willPayload = msg.getWillMessage().getBytes();
+//            ByteBuffer bb = (ByteBuffer) ByteBuffer.allocate(willPayload.length).put(willPayload).flip();
+//            PublishEvent pubEvt = new PublishEvent(msg.getWillTopic(), willQos,
+//                    bb, msg.isWillRetain(), msg.getClientID(), session);
+//            processPublish(pubEvt);
         }
 
         MQTTAuthorizationSubject authSubject = new MQTTAuthorizationSubject(msg.getClientID(), msg.isUserFlag());

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
@@ -198,7 +198,13 @@ public class MQTTLocalSubscription implements OutboundSubscription {
      */
     @Override
     public String getStorageQueueName(String destination, String subscribedNode) {
-        // Inside Andes, MQTT subscription ID consists of client ID and topic details, hence using the same
-        return mqttSubscriptionID;
+        String storageQueueName;
+        if (subscriberQOS > 0) {
+            storageQueueName = MQTTUtils.getTopicSpecificQueueName(mqttSubscriptionID, destination);
+        } else {
+            storageQueueName = AndesUtils.getStorageQueueForDestination(destination, subscribedNode, true);
+        }
+
+        return storageQueueName;
     }
 }


### PR DESCRIPTION
Fix for https://wso2.org/jira/browse/MB-1515.

Change MQTT storage queue name to behave the same as AMQP when it is not durable.
Remove processing of last will messages since it is not yet supported.