### PR TITLE
Consider durability in mqtt with regards to qos and clean session

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
@@ -35,25 +35,46 @@ import java.util.UUID;
  * engine to inform the relevant subscriptions which are channel bound
  */
 public class MQTTLocalSubscription implements OutboundSubscription {
-    //Will log the flows in relevant for this class
+
+    /**
+     * Will log the flows in relevant for this class
+     */
     private static Log log = LogFactory.getLog(MQTTLocalSubscription.class);
 
-    //The reference to the bridge object
+    /**
+     * The reference to the bridge object
+     */
     private MQTTopicManager mqqtServerChannel;
 
-    //Will store the MQTT channel id
+    /**
+     * Will store the MQTT channel id
+     */
     private String mqttSubscriptionID;
 
-    //Will set unique uuid as the channel of the subscription this will be used to track the delivery of messages
+    /**
+     * Will set unique uuid as the channel of the subscription this will be used to track the delivery of messages
+     */
     private UUID channelID;
 
-    //The QOS level the subscription is bound to
+    /**
+     * The QOS level the subscription is bound to
+     */
     private int subscriberQOS;
 
+    /**
+     * The destination subscriber subscribed to
+     */
     private String wildcardDestination;
 
-    //keep if the underlying subscription is active
+    /**
+     * keep if the underlying subscription is active
+     */
     private boolean isActive;
+
+    /**
+     * Should this subscriber act as a durable one
+     */
+    private boolean isDurable;
 
     /**
      * Track messages sent as retained messages
@@ -100,14 +121,17 @@ public class MQTTLocalSubscription implements OutboundSubscription {
     /**
      *  The relevant subscription will be registered
      *
+     * @param wildCardDestination The original destination subscriber subscribed to
      * @param channelID ID of the underlying subscription channel
      * @param isActive true if subscription is active (TCP connection is live)
+     * @param isDurable Should this subscriber fall into durable path
      */
-    public MQTTLocalSubscription(String wildCardDestination, UUID channelID, boolean isActive) {
+    public MQTTLocalSubscription(String wildCardDestination, UUID channelID, boolean isActive, boolean isDurable) {
 
         this.channelID = channelID;
         this.isActive = isActive;
         this.wildcardDestination = wildCardDestination;
+        this.isDurable = isDurable;
     }
 
     /**
@@ -194,12 +218,21 @@ public class MQTTLocalSubscription implements OutboundSubscription {
     }
 
     /**
+     * Should this subscription act as a durable subscription
+     *
+     * @return True if this falls into durable path
+     */
+    public boolean isDurable() {
+        return isDurable;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
     public String getStorageQueueName(String destination, String subscribedNode) {
         String storageQueueName;
-        if (subscriberQOS > 0) {
+        if (isDurable) {
             storageQueueName = MQTTUtils.getTopicSpecificQueueName(mqttSubscriptionID, destination);
         } else {
             storageQueueName = AndesUtils.getStorageQueueForDestination(destination, subscribedNode, true);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTopicManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTopicManager.java
@@ -190,7 +190,7 @@ public class MQTTopicManager {
         } catch (MQTTException ex) {
             //In case if an error occurs we need to rollback the subscription created cluster wide
             connector.removeSubscriber(this, topicName, subscriptionID, username, subscriptionChannelID,
-                    isCleanSession, mqttClientChannelID);
+                    isCleanSession, mqttClientChannelID, qos);
             final String message = "Error while adding the subscriber to the cluster";
             log.error(message, ex);
             throw ex;
@@ -232,18 +232,18 @@ public class MQTTopicManager {
                 String subscriberChannelID = subscription.getSubscriberChannelID();
                 UUID subscriberChannel = subscription.getSubscriptionChannel();
                 boolean isCleanSession = subscription.isCleanSession();
+                QOSLevel qos = subscription.getQOSLevel();
                 //The corresponding subscription created cluster wide will be topic name and the local channel id
                 //Will remove the subscriber cluster wide
                 try {
                     //Will indicate the disconnection of the topic
-                    if (action == SubscriptionEvent.DISCONNECT && !(subscription.getQOSLevel() == QOSLevel.AT_MOST_ONCE
-                            && !subscription.isCleanSession())) {
+                    if (action == SubscriptionEvent.DISCONNECT && MQTTUtils.isDurable(isCleanSession, qos.getValue())) {
                         connector.disconnectSubscriber(this, topic, username, subscriberChannelID, subscriberChannel,
-                                isCleanSession, mqttClientChannelID);
+                                isCleanSession, mqttClientChannelID, qos);
                     } else {
                         //If un-subscribed we need to remove the subscription off
                         connector.removeSubscriber(this, topic, username, subscriberChannelID, subscriberChannel,
-                                isCleanSession, mqttClientChannelID);
+                                isCleanSession, mqttClientChannelID, qos);
                     }
                     if (log.isDebugEnabled()) {
                         final String message = "Subscription with cluster id " + subscriberChannelID + " disconnected " +

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/InMemoryConnector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/InMemoryConnector.java
@@ -105,7 +105,7 @@ public class InMemoryConnector implements MQTTConnector {
     @Override
     public void removeSubscriber(MQTTopicManager channel, String subscribedTopic,String username,
                                  String subscriptionChannelID, UUID subscriberChannel,
-                                 boolean isCleanSession, String mqttClientID)
+                                 boolean isCleanSession, String mqttClientID, QOSLevel qosLevel)
             throws MQTTException {
 
         handleSubscriptionRemoval(subscribedTopic, mqttClientID);
@@ -117,9 +117,9 @@ public class InMemoryConnector implements MQTTConnector {
      * {@inheritDoc}
      */
     @Override
-    public void disconnectSubscriber(MQTTopicManager channel, String subscribedTopic,String username, String subscriptionChannelID,
-                                     UUID subscriberChannel, boolean isCleanSession, String mqttClientID)
-            throws MQTTException {
+    public void disconnectSubscriber(MQTTopicManager channel, String subscribedTopic, String username, String
+            subscriptionChannelID, UUID subscriberChannel, boolean isCleanSession, String mqttClientID, QOSLevel
+            qosLevel) throws MQTTException {
 
         handleSubscriptionRemoval(subscribedTopic, mqttClientID);
         log.info("Subscription with id " + mqttClientID + " removed from " + subscribedTopic);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/MQTTConnector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/MQTTConnector.java
@@ -90,11 +90,13 @@ public interface MQTTConnector {
      * @param subscriberChannel     the cluster wide unique identification of the subscription
      * @param isCleanSession        durability of the subscription
      * @param mqttClientID          the id of the client who subscribed to the topic
+     * @param qosLevel              the quality of service level subscribed to
+     *
      * @throws MQTTException
      */
-    public void removeSubscriber(MQTTopicManager channel, String subscribedTopic, String username, String subscriptionChannelID,
-                                 UUID subscriberChannel, boolean isCleanSession, String mqttClientID)
-            throws MQTTException;
+    public void removeSubscriber(MQTTopicManager channel, String subscribedTopic, String username, String
+            subscriptionChannelID, UUID subscriberChannel, boolean isCleanSession, String mqttClientID, QOSLevel
+            qosLevel) throws MQTTException;
 
     /**
      * Will trigger the subscription disconnect event
@@ -106,11 +108,13 @@ public interface MQTTConnector {
      * @param subscriberChannel     the cluster wide unique identification of the subscription
      * @param isCleanSession        durability of the subscription
      * @param mqttClientID          the id of the client who subscribed to the topic
+     * @param qosLevel              the quality of service level subscribed to
+     *
      * @throws MQTTException
      */
     public void disconnectSubscriber(MQTTopicManager channel, String subscribedTopic, String username,
                                      String subscriptionChannelID, UUID subscriberChannel,
-                                     boolean isCleanSession, String mqttClientID)
+                                     boolean isCleanSession, String mqttClientID, QOSLevel qosLevel)
             throws MQTTException;
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/utils/MQTTUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/utils/MQTTUtils.java
@@ -274,4 +274,22 @@ public class MQTTUtils {
         return "carbon:" + clientId + ":" + topic;
     }
 
+    /**
+     * Given the clean session value and qos level, decide whether it if falling into durable path.
+     *
+     * @param cleanSession The clean session value
+     * @param qos The quality of service level
+     *
+     * @return true if this falls into durable path
+     */
+    public static boolean isDurable(boolean cleanSession, int qos) {
+        boolean durable = false;
+
+        if (!cleanSession && qos > 0) {
+            durable = true;
+        }
+
+        return durable;
+    }
+
 }


### PR DESCRIPTION
In MQTT subscribers, it is consider as durable where clean session is false and qos is greater than 0. Use this logic in locations where MQTT durability is in required.