### PR TITLE
[MB-1497] Made queue creation case insensitive

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
@@ -370,6 +370,13 @@ public class QpidAndesBridge {
             log.debug("AMQP BRIDGE: create queue: " + queue.getName());
         }
         try {
+            List<String> queues = AndesContext.getInstance().getAMQPConstructStore().getQueueNames();
+            for (String queueName : queues) {
+                if (queueName.equalsIgnoreCase(queue.getName())) {
+                    throw new AMQException("Cannot create queue: " + queue.getName()
+                                           + ". A queue name in a different case is registered.");
+                }
+            }
             Andes.getInstance().createQueue(AMQPUtils.createAndesQueue(queue));
         } catch (AndesException e) {
             log.error("error while creating queue", e);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeclareHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeclareHandler.java
@@ -60,7 +60,7 @@ public class QueueDeclareHandler implements StateAwareMethodListener<QueueDeclar
 
     public void methodReceived(AMQStateManager stateManager, QueueDeclareBody body, int channelId) throws AMQException
     {
-        try {
+
             final AMQProtocolSession protocolConnection = stateManager.getProtocolSession();
             final AMQSessionModel session = protocolConnection.getChannel(channelId);
             VirtualHost virtualHost = protocolConnection.getVirtualHost();
@@ -81,7 +81,7 @@ public class QueueDeclareHandler implements StateAwareMethodListener<QueueDeclar
             }
 
             AMQQueue queue;
-
+        try {
             //TODO: do we need to check that the queue already exists with exactly the same "configuration"?
 
             synchronized (queueRegistry)
@@ -208,6 +208,7 @@ public class QueueDeclareHandler implements StateAwareMethodListener<QueueDeclar
                 _logger.info("Queue " + queueName + " declared successfully");
             }
         } catch (AMQException e) {
+            queueRegistry.unregisterQueue(queueName);
             throw body.getChannelException(AMQConstant.INTERNAL_ERROR, e.getMessage());
         }
     }


### PR DESCRIPTION
Addresses the issue reported at https://wso2.org/jira/browse/MB-1497.

The issue is caused by the fact that the queue creation is case insensitive and thus subscription ids with different cases are considered as the same. The ideal solution would be to make the queue creation case sensitive. But due to https://wso2.org/jira/browse/CARBON-15535, queue creation cannot be made case sensitive. Thus prohibited queue creation in different cases. This should be changed with the fix for https://wso2.org/jira/browse/CARBON-15535.