### PR TITLE
Modified debug log to info log in AMQProtocolHandler for client jar.

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/AMQProtocolHandler.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/AMQProtocolHandler.java
@@ -575,7 +575,7 @@ public class AMQProtocolHandler implements ProtocolEngine
         });
         if (PROTOCOL_DEBUG)
         {
-            _protocolLogger.debug(String.format("SEND: [%s] %s", this, frame));
+            _protocolLogger.info(String.format("SEND: [%s] %s", this, frame));
         }
 
         final long sentMessages = _messagesOut++;


### PR DESCRIPTION
When the client is started with "amqj.protocol.logging.level=1" system property, all received packets to the client will be logged. But the sent packets cannot be seen as it is in "debug" level. 

Therefore changing it to "info" log.

