### PR TITLE
[Shared Subscriptions] Fixing a problem in how slots are reassigned during client disconnect

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/BasicSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/BasicSubscription.java
@@ -18,23 +18,19 @@
 
 package org.wso2.andes.subscription;
 
-import com.ctc.wstx.util.StringUtil;
+import java.util.UUID;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.wso2.andes.kernel.AndesMessageMetadata;
 import org.wso2.andes.kernel.AndesSubscription;
-import org.wso2.andes.kernel.AndesUtils;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentSkipListMap;
 
 /**
  * This represents Basic Andes Subscription. Any type of subscription
  * (AMQP,MQTT) is inherited from this template
  */
 public class BasicSubscription implements AndesSubscription {
+    
+    
     // The id of the subscriber cluster wide this will be unique - MANDOTORY
     protected String subscriptionID;
     // The target queue or topic name - MANDOTORY

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionStore.java
@@ -189,17 +189,19 @@ public class SubscriptionStore {
      */
     public Set<LocalSubscription> getActiveLocalSubscribers(String destination, boolean isTopic) throws AndesException {
         Set<LocalSubscription> localSubscriptionMap = getLocalSubscriptionMap(destination, isTopic);
-        Set<LocalSubscription> list = new HashSet<>();
-        if (localSubscriptionMap != null) {
-            list = getLocalSubscriptionMap(destination, isTopic);
-        }
-
+        
         Set<LocalSubscription> activeLocalSubscriptionList = new HashSet<>();
-        for (LocalSubscription localSubscription : list) {
-            if (localSubscription.hasExternalSubscriptions()) {
-                activeLocalSubscriptionList.add(localSubscription);
+        
+        if (null != localSubscriptionMap ) {
+            
+            for (LocalSubscription localSubscription : localSubscriptionMap) {
+                if (localSubscription.hasExternalSubscriptions()) {
+                    activeLocalSubscriptionList.add(localSubscription);
+                }
             }
+            
         }
+        
         return activeLocalSubscriptionList;
     }
 


### PR DESCRIPTION
Scenarios:
 in a cluster: 
  1) 2 shared subscribers exists in same node and one disconnects 
  2) OrphanedSlotHandler will return those slots to coordinator
  3) These slots will be given to another node (sometimes) this leads to lots of errors 
      (in ackhandler and/or delivery path) in both nodes.

Fix is was to use proper queues/destinations etc. 