### PR TITLE
Blocked queue creation from different cases

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
@@ -370,6 +370,12 @@ public class QpidAndesBridge {
             log.debug("AMQP BRIDGE: create queue: " + queue.getName());
         }
         try {
+            List<String> queues = AndesContext.getInstance().getAMQPConstructStore().getQueueNames();
+            for (String queueName : queues) {
+                if (queueName.equalsIgnoreCase(queue.getName())) {
+                    throw new AMQException("Cannot create already existing queue: " + queue.getName());
+                }
+            }
             Andes.getInstance().createQueue(AMQPUtils.createAndesQueue(queue));
         } catch (AndesException e) {
             log.error("error while creating queue", e);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeclareHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeclareHandler.java
@@ -58,137 +58,118 @@ public class QueueDeclareHandler implements StateAwareMethodListener<QueueDeclar
 
     private final AtomicInteger _counter = new AtomicInteger();
 
-    public void methodReceived(AMQStateManager stateManager, QueueDeclareBody body, int channelId) throws AMQException
-    {
+    public void methodReceived(AMQStateManager stateManager, QueueDeclareBody body, int channelId) throws AMQException {
+
+        final AMQProtocolSession protocolConnection = stateManager.getProtocolSession();
+        final AMQSessionModel session = protocolConnection.getChannel(channelId);
+        VirtualHost virtualHost = protocolConnection.getVirtualHost();
+        ExchangeRegistry exchangeRegistry = virtualHost.getExchangeRegistry();
+        QueueRegistry queueRegistry = virtualHost.getQueueRegistry();
+        DurableConfigurationStore store = virtualHost.getDurableConfigurationStore();
+
+        final AMQShortString queueName;
+
+        // if we aren't given a queue name, we create one which we return to the client
+        if ((null == body.getQueue()) || (0 == body.getQueue().length())) {
+            queueName = createName();
+        } else {
+            queueName = body.getQueue().intern();
+        }
+        AMQQueue queue;
         try {
-            final AMQProtocolSession protocolConnection = stateManager.getProtocolSession();
-            final AMQSessionModel session = protocolConnection.getChannel(channelId);
-            VirtualHost virtualHost = protocolConnection.getVirtualHost();
-            ExchangeRegistry exchangeRegistry = virtualHost.getExchangeRegistry();
-            QueueRegistry queueRegistry = virtualHost.getQueueRegistry();
-            DurableConfigurationStore store = virtualHost.getDurableConfigurationStore();
-
-            final AMQShortString queueName;
-
-            // if we aren't given a queue name, we create one which we return to the client
-            if ((body.getQueue() == null) || (body.getQueue().length() == 0))
-            {
-                queueName = createName();
-            }
-            else
-            {
-                queueName = body.getQueue().intern();
-            }
-
-            AMQQueue queue;
-
             //TODO: do we need to check that the queue already exists with exactly the same "configuration"?
 
-            synchronized (queueRegistry)
-            {
+            synchronized (queueRegistry) {
                 queue = queueRegistry.getQueue(queueName);
 
                 AMQSessionModel owningSession = null;
 
-                if (queue != null)
-                {
+                if (null != queue) {
                     owningSession = queue.getExclusiveOwningSession();
                 }
 
-                if (queue == null)
-                {
-                    if (body.getPassive())
-                    {
+                if (null == queue) {
+                    if (body.getPassive()) {
                         String msg = "Queue: " + queueName + " not found on VirtualHost(" + virtualHost + ").";
                         throw body.getChannelException(AMQConstant.NOT_FOUND, msg);
-                    }
-                    else
-                    {
+                    } else {
                         queue = createQueue(queueName, body, virtualHost, protocolConnection);
                         queue.setAuthorizationHolder(protocolConnection);
-                        if (queue.isDurable() && !queue.isAutoDelete())
-                        {
+                        if (queue.isDurable() && !queue.isAutoDelete()) {
                             store.createQueue(queue, body.getArguments());
 
                             //Tell Andes kernel to create queue
                             QpidAndesBridge.createQueue(queue);
                         }
-                        if(body.getAutoDelete())
-                        {
+                        if (body.getAutoDelete()) {
                             queue.setDeleteOnNoConsumers(true);
                         }
                         queueRegistry.registerQueue(queue);
-                        if (body.getExclusive())
-                        {
+                        if (body.getExclusive()) {
                             queue.setExclusiveOwningSession(protocolConnection.getChannel(channelId));
                             queue.setAuthorizationHolder(protocolConnection);
 
-                            if(!body.getDurable())
-                            {
+                            if (!body.getDurable()) {
                                 final AMQQueue q = queue;
-                                final AMQProtocolSession.Task sessionCloseTask = new AMQProtocolSession.Task()
-                                {
-                                    public void doTask(AMQProtocolSession session) throws AMQException
-                                    {
+                                final AMQProtocolSession.Task sessionCloseTask = new AMQProtocolSession.Task() {
+                                    public void doTask(AMQProtocolSession session) throws AMQException {
                                         q.setExclusiveOwningSession(null);
                                     }
                                 };
                                 protocolConnection.addSessionCloseTask(sessionCloseTask);
                                 queue.addQueueDeleteTask(new AMQQueue.Task() {
-                                    public void doTask(AMQQueue queue) throws AMQException
-                                    {
+                                    public void doTask(AMQQueue queue) throws AMQException {
                                         protocolConnection.removeSessionCloseTask(sessionCloseTask);
                                     }
                                 });
                             }
                         }
-                        if (autoRegister)
-                        {
+                        if (autoRegister) {
                             Exchange defaultExchange = exchangeRegistry.getDefaultExchange();
 
-                            virtualHost.getBindingFactory().addBinding(String.valueOf(queueName), queue, defaultExchange, Collections.EMPTY_MAP);
-                            _logger.info("Queue " + queueName + " bound to default exchange(" + defaultExchange.getNameShortString() + ")");
+                            virtualHost.getBindingFactory().addBinding(String.valueOf(queueName), queue,
+                                    defaultExchange, Collections.EMPTY_MAP);
+                            _logger.info("Queue " + queueName + " bound to default exchange("
+                                         + defaultExchange.getNameShortString() + ")");
                         }
                     }
-                }
-                else if (queue.isExclusive() && !queue.isDurable() && (owningSession == null || owningSession.getConnectionModel() != protocolConnection))
-                {
+                } else if (queue.isExclusive() && !queue.isDurable() && (owningSession == null
+                                                                         || owningSession.getConnectionModel()
+                                                                            != protocolConnection)) {
                     throw body.getConnectionException(AMQConstant.NOT_ALLOWED,
-                            "Queue " + queue.getNameShortString() + " is exclusive, but not created on this Connection.");
-                }
-                else if(!body.getPassive() && ((queue.isExclusive()) != body.getExclusive()))
-                {
+                            "Queue " + queue.getNameShortString()
+                            + " is exclusive, but not created on this Connection.");
+                } else if (!body.getPassive() && ((queue.isExclusive()) != body.getExclusive())) {
 
                     throw body.getChannelException(AMQConstant.ALREADY_EXISTS,
-                            "Cannot re-declare queue '" + queue.getNameShortString() + "' with different exclusivity (was: "
-                                    + queue.isExclusive() + " requested " + body.getExclusive() + ")");
-                }
-                else if (!body.getPassive() && body.getExclusive() && !(queue.isDurable() ? String.valueOf(queue.getOwner()).equals(session.getClientID()) : (owningSession == null || owningSession.getConnectionModel() == protocolConnection)))
-                {
-                    throw body.getChannelException(AMQConstant.ALREADY_EXISTS, "Cannot declare queue('" + queueName + "'), "
+                            "Cannot re-declare queue '" + queue.getNameShortString()
+                            + "' with different exclusivity (was: "
+                            + queue.isExclusive() + " requested " + body.getExclusive() + ")");
+                } else if (!body.getPassive() && body.getExclusive()
+                           && !(queue.isDurable() ? String.valueOf(queue.getOwner()).equals(session.getClientID()) : (
+                        null == owningSession || owningSession.getConnectionModel() == protocolConnection))) {
+                    throw body.getChannelException(AMQConstant.ALREADY_EXISTS,
+                            "Cannot declare queue('" + queueName + "'), "
                             + "as exclusive queue with same name "
                             + "declared on another client ID('"
                             + queue.getOwner() + "') your clientID('" + session.getClientID() + "')");
 
-                }
-                else if(!body.getPassive() && queue.isAutoDelete() != body.getAutoDelete())
-                {
+                } else if (!body.getPassive() && queue.isAutoDelete() != body.getAutoDelete()) {
                     throw body.getChannelException(AMQConstant.ALREADY_EXISTS,
-                            "Cannot re-declare queue '" + queue.getNameShortString() + "' with different auto-delete (was: "
-                                    + queue.isAutoDelete() + " requested " + body.getAutoDelete() + ")");
-                }
-                else if(!body.getPassive() && queue.isDurable() != body.getDurable())
-                {
+                            "Cannot re-declare queue '" + queue.getNameShortString()
+                            + "' with different auto-delete (was: "
+                            + queue.isAutoDelete() + " requested " + body.getAutoDelete() + ")");
+                } else if (!body.getPassive() && queue.isDurable() != body.getDurable()) {
                     throw body.getChannelException(AMQConstant.ALREADY_EXISTS,
-                            "Cannot re-declare queue '" + queue.getNameShortString() + "' with different durability (was: "
-                                    + queue.isDurable() + " requested " + body.getDurable() + ")");
+                            "Cannot re-declare queue '" + queue.getNameShortString()
+                            + "' with different durability (was: "
+                            + queue.isDurable() + " requested " + body.getDurable() + ")");
                 }
 
 
                 AMQChannel channel = protocolConnection.getChannel(channelId);
 
-                if (channel == null)
-                {
+                if (null == channel) {
                     throw body.getChannelNotFoundException(channelId);
                 }
 
@@ -196,8 +177,7 @@ public class QueueDeclareHandler implements StateAwareMethodListener<QueueDeclar
                 channel.setDefaultQueue(queue);
             }
 
-            if (!body.getNowait())
-            {
+            if (!body.getNowait()) {
                 MethodRegistry methodRegistry = protocolConnection.getMethodRegistry();
                 QueueDeclareOkBody responseBody =
                         methodRegistry.createQueueDeclareOkBody(queueName,


### PR DESCRIPTION
Addressed the issue https://wso2.org/jira/browse/MB-1497

The issue was originally fixed by https://github.com/wso2/andes/pull/434. But it was reverted since adding shared subscriptions was prohibited by it. 

This PR makes a slight change into that by changing:

catch (AMQException e) {
             queueRegistry.unregisterQueue(queueName);
             throw body.getChannelException(AMQConstant.INTERNAL_ERROR, e.getMessage());
  }
to 
catch (AMQException e) {
            throw body.getChannelException(AMQConstant.INTERNAL_ERROR, e.getMessage());
}

since the previous PR had unregistered the queue created by the other shared subscription. 