### PR TITLE
[MB-1378] [MQTT] Tenants can create topics without tenant domain as the prefix

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/messaging/spi/impl/ProtocolProcessor.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/messaging/spi/impl/ProtocolProcessor.java
@@ -810,8 +810,8 @@ public class ProtocolProcessor implements EventHandler<ValueEvent>, PubAckHandle
                     SubAckMessage response = new SubAckMessage();
                     response.setreturnCode(SubAckMessage.FORBIDDEN_SUBSCRIPTION);
                     session.write(response);
-                    return;
                 }
+                continue;
             }
 
             AbstractMessage.QOSType qos = AbstractMessage.QOSType.values()[req.getQos()];


### PR DESCRIPTION
Previously the subscription was accepted even though authorization
fails when MQTT version is not equal to 3.1.1

https://wso2.org/jira/browse/MB-1378