### PR TITLE
[MB-1533] Added check to find active subscribers when deleting durabe subscriptions

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPUtils.java
@@ -374,7 +374,7 @@ public class AMQPUtils {
     public static InboundQueueEvent createAndesQueue(AMQQueue amqQueue) {
         return new InboundQueueEvent(amqQueue.getName(),
                 (amqQueue.getOwner() != null) ? amqQueue.getOwner().toString() : "null",
-                amqQueue.isExclusive(), amqQueue.isDurable());
+                amqQueue.isExclusive(), amqQueue.isDurable(), amqQueue.checkIfBoundToTopicExchange());
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
@@ -159,13 +159,15 @@ public class AndesContextInformationManager {
      * Check if queue is deletable
      *
      * @param queueName name of the queue
+     * @param isTopic true if the queue is used to store topic messages
      * @return possibility of deleting queue
      * @throws AndesException
      */
-    public boolean checkIfQueueDeletable(String queueName) throws AndesException {
+    public boolean checkIfQueueDeletable(String queueName, boolean isTopic) throws AndesException {
         boolean queueDeletable = false;
-        Set<AndesSubscription> queueSubscriptions = subscriptionStore.getActiveClusterSubscriptionList(
-                queueName, false, AndesSubscription.SubscriptionType.AMQP);
+
+        Set<AndesSubscription> queueSubscriptions
+                = subscriptionStore.getActiveClusterSubscriptionList(queueName, isTopic);
         if (queueSubscriptions.isEmpty()) {
             queueDeletable = true;
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundQueueEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundQueueEvent.java
@@ -125,6 +125,22 @@ public class InboundQueueEvent extends AndesQueue implements AndesInboundStateEv
     /**
      * create an instance of andes queue
      *
+     * @param queueName   name of the queue
+     * @param queueOwner  owner of the queue (virtual host)
+     * @param isExclusive is queue exclusive
+     * @param isDurable   is queue durable
+     * @param isBoundToTopic is queue bound to topic
+     */
+    public InboundQueueEvent(String queueName, String queueOwner, boolean isExclusive, boolean isDurable, boolean isBoundToTopic) {
+        super(queueName, queueOwner, isExclusive, isDurable);
+        purgedCount = SettableFuture.create();
+        isEventComplete = SettableFuture.create();
+        isTopic = isBoundToTopic;
+    }
+
+    /**
+     * create an instance of andes queue
+     *
      * @param queueAsStr queue information as encoded string
      */
     public InboundQueueEvent(String queueAsStr) {
@@ -165,7 +181,7 @@ public class InboundQueueEvent extends AndesQueue implements AndesInboundStateEv
     private void handleIsQueueDeletableEvent() {
         boolean queueDeletable = false;
         try {
-            queueDeletable = contextInformationManager.checkIfQueueDeletable(queueName);
+            queueDeletable = contextInformationManager.checkIfQueueDeletable(queueName, isTopic);
         } catch (AndesException e) {
             isEventComplete.setException(e);
         } finally {


### PR DESCRIPTION
Addresses the issue reported at https://wso2.org/jira/browse/MB-1533

The issue occurred since the the check for active subscriptions upon a queue delete request was only done for queues but not for topics.