### PR TITLE
MQTT close previous connection if a new client joined with the same client id

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/server/ServerChannel.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/server/ServerChannel.java
@@ -1,6 +1,9 @@
 package org.dna.mqtt.moquette.server;
 
 import io.netty.channel.Channel;
+
+import java.util.UUID;
+
 /**
  *
  * @author andrea
@@ -18,4 +21,6 @@ public interface ServerChannel {
     void close(boolean immediately);
     
     void write(Object value);
+
+    UUID getUUID();
 }

--- a/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/server/netty/NettyChannel.java
+++ b/modules/andes-core/broker/src/main/java/org/dna/mqtt/moquette/server/netty/NettyChannel.java
@@ -10,6 +10,7 @@ import org.dna.mqtt.moquette.server.ServerChannel;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  *
@@ -26,6 +27,7 @@ public class NettyChannel implements ServerChannel {
     private static final AttributeKey<Object> ATTR_KEY_CLEANSESSION = new AttributeKey<Object>(Constants.CLEAN_SESSION);
     private static final AttributeKey<Object> ATTR_KEY_CLIENTID = new AttributeKey<Object>(Constants.ATTR_CLIENTID);
     public static final AttributeKey<Object> ATTR_KEY_USERNAME = AttributeKey.valueOf(ATTR_USERNAME);
+    private final UUID uuid = UUID.randomUUID();
 
     NettyChannel(ChannelHandlerContext ctx) {
         m_channel = ctx;
@@ -75,5 +77,8 @@ public class NettyChannel implements ServerChannel {
     public void write(Object value) {
         m_channel.writeAndFlush(value);
     }
-    
+
+    public UUID getUUID() {
+        return uuid;
+    }
 }


### PR DESCRIPTION
This pull fixes the issue https://wso2.org/jira/browse/MB-1548.

When a new client joins with a client id that is the same as an already connected client, according to MQTT spec, the existing client should be disconnected and the new client should be connected.

http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718032

"If the ClientId represents a Client already connected to the Server then the Server MUST disconnect the existing Client [MQTT-3.1.4-2]."