### PR TITLE
Delete Queue mapping

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -278,7 +278,6 @@ public enum AndesConfiguration implements ConfigurationProperty {
      * Indicates weather print cache related statistics in 2 minutes interval in carbon log.
      */
     PERSISTENCE_CACHE_PRINT_STATS("persistence/cache/printStats", "false", Boolean.class),
-
     
     /**
      * The ID generation class that is used to maintain unique IDs for each message that arrives at the server.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AMQPConstructStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AMQPConstructStore.java
@@ -122,16 +122,27 @@ public class AMQPConstructStore {
      * remove a queue
      *
      * @param queueName name of the queue to be removed
-     * @param isLocal   is this a local change
      * @throws AndesException
      */
-    public void removeQueue(String queueName, boolean isLocal) throws AndesException {
-        if (isLocal) {
-            andesContextStore.deleteQueueInformation(queueName);
-            //create the space created to keep message counter on this queue
-            messageStore.removeQueue(queueName);
-        }
+    public void removeQueue(String queueName) throws AndesException {
+
+        // Remove the queue from internal maps
+        removeLocalQueueData(queueName);
+
+        // Remove queue information from database
+        andesContextStore.deleteQueueInformation(queueName);
+        messageStore.removeQueue(queueName);
+    }
+
+    /**
+     * remove a queue from local maps
+     *
+     * @param queueName name of the queue to be removed
+     * @throws AndesException
+     */
+    public void removeLocalQueueData(String queueName) throws AndesException {
         andesQueues.remove(queueName);
+        messageStore.removeLocalQueueData(queueName);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
@@ -200,7 +200,7 @@ public class AndesContextInformationManager {
         MessagingEngine.getInstance().purgeMessages(queueName, null, false);
 
         // delete queue from construct store
-        constructStore.removeQueue(queueName, true);
+        constructStore.removeQueue(queueName);
 
         //Notify cluster to delete queue
         notifyQueueListeners(queueToDelete, QueueListener.QueueEvent.DELETED);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
@@ -68,44 +68,10 @@ public interface MessageStore extends HealthAwareStore{
     Map<Long, List<AndesMessagePart>> getContent(List<Long> messageIDList) throws AndesException;
 
     /**
-     * store mata data of messages
-     *
-     * @param metadataList metadata list to store
-     * @throws AndesException
-     */
-    void addMetadata(List<AndesMessageMetadata> metadataList) throws AndesException;
-
-    /**
-     * store metadata of a single message
-     *
-     * @param metadata metadata to store
-     * @throws AndesException
-     */
-    void addMetadata(AndesMessageMetadata metadata) throws AndesException;
-
-    /**
      * Store messages into database.
      * @param messageList messages to be stored
      */
     void storeMessages(List<AndesMessage> messageList) throws AndesException;
-
-    /**
-     * store metadata specifically under a queue
-     *
-     * @param queueName name of the queue to store metadata
-     * @param metadata metadata to store
-     * @throws AndesException
-     */
-    void addMetadataToQueue(final String queueName, AndesMessageMetadata metadata) throws AndesException;
-
-    /**
-     * store metadata list specifically under a queue
-     *
-     * @param queueName name of the queue to store metadata
-     * @param metadata metadata list to store
-     * @throws AndesException
-     */
-    void addMetadataToQueue(final String queueName, List<AndesMessageMetadata> metadata) throws AndesException;
 
     /**
      * Store a message in a different Queue without altering the meta data.
@@ -358,6 +324,13 @@ public interface MessageStore extends HealthAwareStore{
      * @param storageQueueName name of the queue actually stored in DB
      */
     void removeQueue(String storageQueueName) throws AndesException;
+
+    /**
+     * Remove queue entry from the queue mapping cache
+     *
+     * @param storageQueueName the name of the queue to be removed
+     */
+    void removeLocalQueueData(String storageQueueName);
 
     /**
      * Increment message counter for a queue by a given incrementBy value

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/virtualhost/VirtualHostConfigSynchronizer.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/virtualhost/VirtualHostConfigSynchronizer.java
@@ -121,7 +121,7 @@ public class VirtualHostConfigSynchronizer implements
         try {
             log.info("Queue removal request received queue= " + queue.queueName);
             removeQueue(queue.queueName);
-            AndesContext.getInstance().getAMQPConstructStore().removeQueue(queue.queueName, false);
+            AndesContext.getInstance().getAMQPConstructStore().removeLocalQueueData(queue.queueName);
         } catch (Exception e) {
             log.error("could not remove cluster queue", e);
             throw new AndesException("could not remove cluster queue : " + queue.toString(), e);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
@@ -116,62 +116,10 @@ public class FailureObservingMessageStore implements MessageStore {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void addMetadata(List<AndesMessageMetadata> metadataList) throws AndesException {
-        try {
-            wrappedInstance.addMetadata(metadataList);
-        } catch (AndesStoreUnavailableException exception) {
-            notifyFailures(exception);
-            throw exception;
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void addMetadata(AndesMessageMetadata metadata) throws AndesException {
-        try {
-            wrappedInstance.addMetadata(metadata);
-        } catch (AndesStoreUnavailableException exception) {
-            notifyFailures(exception);
-            throw exception;
-        }
-    }
-
     @Override
     public void storeMessages(List<AndesMessage> messageList) throws AndesException {
         try {
             wrappedInstance.storeMessages(messageList);
-        } catch (AndesStoreUnavailableException exception) {
-            notifyFailures(exception);
-            throw exception;
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void addMetadataToQueue(String queueName, AndesMessageMetadata metadata) throws AndesException {
-        try {
-            wrappedInstance.addMetadataToQueue(queueName, metadata);
-        } catch (AndesStoreUnavailableException exception) {
-            notifyFailures(exception);
-            throw exception;
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void addMetadataToQueue(String queueName, List<AndesMessageMetadata> metadata) throws AndesException {
-        try {
-            wrappedInstance.addMetadataToQueue(queueName, metadata);
         } catch (AndesStoreUnavailableException exception) {
             notifyFailures(exception);
             throw exception;
@@ -525,6 +473,14 @@ public class FailureObservingMessageStore implements MessageStore {
             notifyFailures(exception);
             throw exception;
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeLocalQueueData(String storageQueueName) {
+        wrappedInstance.removeLocalQueueData(storageQueueName);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -178,9 +178,13 @@ public class RDBMSConstants {
             + " VALUES ( ?,?,? )";
 
     protected static final String PS_INSERT_QUEUE =
-            "INSERT INTO " + RDBMSConstants.QUEUES_TABLE + " ("
+            "INSERT INTO " + QUEUES_TABLE + " ("
             + RDBMSConstants.QUEUE_NAME + ")"
             + "  VALUES (?)";
+
+    protected static final String PS_DELETE_QUEUE =
+                        "DELETE FROM " + QUEUES_TABLE
+                        + " WHERE " + QUEUE_NAME + "=?";
 
     protected static final String PS_ALIAS_FOR_COUNT = "count";
 
@@ -814,6 +818,7 @@ public class RDBMSConstants {
     protected static final String TASK_RETRIEVING_CONTENT_FOR_MESSAGES = "retrieving content for multiple messages";
     protected static final String TASK_ADDING_METADATA_LIST = "adding metadata list.";
     protected static final String TASK_ADDING_METADATA = "adding metadata.";
+    protected static final String TASK_ADDING_MESSAGE = "adding message.";
     protected static final String TASK_ADDING_MESSAGES = "adding messages";
     protected static final String TASK_DELETING_MESSAGES = "deleting messages";
     protected static final String TASK_MOVING_METADATA_TO_DLC = "moving message metadata to dlc.";
@@ -869,6 +874,7 @@ public class RDBMSConstants {
     protected static final String TASK_STORING_QUEUE_INFO = "storing queue information ";
     protected static final String TASK_RETRIEVING_ALL_QUEUE_INFO = "retrieving all queue information. ";
     protected static final String TASK_DELETING_QUEUE_INFO = "deleting queue information. ";
+    protected static final String TASK_DELETE_QUEUE_MAPPING = "deleting queue mapping";
     protected static final String TASK_STORING_BINDING = "storing binding information. ";
     protected static final String TASK_RETRIEVING_BINDING_INFO = "retrieving binding information.";
     protected static final String TASK_DELETING_BINDING = "deleting binding information. ";


### PR DESCRIPTION
Applied the changes in https://github.com/wso2/andes/pull/377 with fixes for deleting the queue mapping entries from in-memory maps upon the receipt of a cluster queue delete notification.

Also, the Hashmap for storing queue mapping was removed and a guava cache was used in place. 