### PR TITLE
Publish to a non existing queue

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPUtils.java
@@ -71,6 +71,8 @@ public class AMQPUtils {
 
     public static String DEFAULT_EXCHANGE_NAME = "<<default>>";
 
+    public static String DEFAULT_ANDES_CHANNEL_IDENTIFIER = "AMQP-Unknown";
+
     /**
      * Max chunk size of the stored content in Andes;
      */

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -278,7 +278,6 @@ public enum AndesConfiguration implements ConfigurationProperty {
      * Indicates weather print cache related statistics in 2 minutes interval in carbon log.
      */
     PERSISTENCE_CACHE_PRINT_STATS("persistence/cache/printStats", "false", Boolean.class),
-
     
     /**
      * The ID generation class that is used to maintain unique IDs for each message that arrives at the server.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AMQPConstructStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AMQPConstructStore.java
@@ -122,16 +122,27 @@ public class AMQPConstructStore {
      * remove a queue
      *
      * @param queueName name of the queue to be removed
-     * @param isLocal   is this a local change
      * @throws AndesException
      */
-    public void removeQueue(String queueName, boolean isLocal) throws AndesException {
-        if (isLocal) {
-            andesContextStore.deleteQueueInformation(queueName);
-            //create the space created to keep message counter on this queue
-            messageStore.removeQueue(queueName);
-        }
+    public void removeQueue(String queueName) throws AndesException {
+
+        // Remove the queue from internal maps
+        removeLocalQueueData(queueName);
+
+        // Remove queue information from database
+        andesContextStore.deleteQueueInformation(queueName);
+        messageStore.removeQueue(queueName);
+    }
+
+    /**
+     * remove a queue from local maps
+     *
+     * @param queueName name of the queue to be removed
+     * @throws AndesException
+     */
+    public void removeLocalQueueData(String queueName) throws AndesException {
         andesQueues.remove(queueName);
+        messageStore.removeLocalQueueData(queueName);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -619,6 +619,17 @@ public class Andes {
     }
 
     /**
+     * Create a new Andes channel for a new local channel.
+     *
+     * @param listener Local flow control listener
+     * @param channelId the channel id
+     * @return AndesChannel
+     */
+    public AndesChannel createChannel(String channelId, FlowControlListener listener) {
+        return flowControlManager.createChannel(channelId, listener);
+    }
+
+    /**
      * Remove Andes channel from tracking.
      *
      * @param channel Andes channel

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesChannel.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesChannel.java
@@ -118,6 +118,7 @@ public class AndesChannel {
      * 
      * @param flowControlManager
      *            - instance of the flow control manage to be used
+     * @param channelId the channel identifier which is a combination of the ip address and the port of the channel
      * @param listener
      *            - an implementation of {@link FlowControlListener} which should
      *            originate from a concrete channel implementation.
@@ -128,7 +129,7 @@ public class AndesChannel {
      *            Indicates that global error based flow control is enabled at
      *            the time of this channel is created.
      */
-    public AndesChannel(FlowControlManager flowControlManager, FlowControlListener listener,
+    public AndesChannel(FlowControlManager flowControlManager, String channelId, FlowControlListener listener,
                         boolean globalBufferBasedFlowControlEnabled, 
                         boolean globalErrBasedFlowControlEnabled) {
         this.flowControlManager = flowControlManager;
@@ -142,11 +143,31 @@ public class AndesChannel {
         this.flowControlLowLimit = flowControlManager.getChannelLowLimit();
         this.flowControlHighLimit = flowControlManager.getChannelHighLimit();
 
+        this.identifier = channelId;
         this.id = idGenerator.incrementAndGet();
         this.messagesOnBuffer = new AtomicInteger(0);
         this.flowControlEnabled = false;
+        log.info("Channel created (ID: " + getIdentifier() + ")");
+    }
 
-        log.info("Channel created (ID: " + getId() + ")");
+    /**
+     * Instantiates a new andes channel
+     *
+     * @param flowControlManager                  Instance of the flow control manage to be used
+     * @param listener                            an implementation of {@link FlowControlListener} which should
+     *                                            originate from a concrete channel
+     *                                            implementation.
+     * @param globalBufferBasedFlowControlEnabled Indicates that global buffer based flow control is enabled at the
+     *                                            time of this channel is created.
+     * @param globalErrBasedFlowControlEnabled    Indicates that global error based flow control is enabled at the
+     *                                            time of this channel is created.
+     */
+    public AndesChannel(FlowControlManager flowControlManager, FlowControlListener listener,
+            boolean globalBufferBasedFlowControlEnabled,
+            boolean globalErrBasedFlowControlEnabled) {
+
+        this(flowControlManager, "Internel_channel", listener,
+                globalBufferBasedFlowControlEnabled, globalErrBasedFlowControlEnabled);
     }
 
     /**
@@ -310,14 +331,6 @@ public class AndesChannel {
 	 */
 	public String getIdentifier() {
 		return identifier;
-	}
-
-	/**
-	 * Set channel identifier
-	 * @param identifier client identifier
-	 */
-	public void setIdentifier(String identifier) {
-		this.identifier = identifier;
 	}
 
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
@@ -200,7 +200,7 @@ public class AndesContextInformationManager {
         MessagingEngine.getInstance().purgeMessages(queueName, null, false);
 
         // delete queue from construct store
-        constructStore.removeQueue(queueName, true);
+        constructStore.removeQueue(queueName);
 
         //Notify cluster to delete queue
         notifyQueueListeners(queueToDelete, QueueListener.QueueEvent.DELETED);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlManager.java
@@ -142,13 +142,27 @@ public class FlowControlManager  implements StoreHealthListener {
     /**
      * Create a new Andes channel for a new local channel.
      *
+     * @param listener Local flow control listener
+     * @param channelId the identifier of the channel
+     * @return AndesChannel
+     */
+    public synchronized AndesChannel createChannel(String channelId, FlowControlListener listener) {
+        AndesChannel channel = new AndesChannel(this, channelId, listener, globalBufferBasedFlowControlEnabled,
+                                                      globalErrorBasedFlowControlEnabled);
+        channels.add(channel);
+        return channel;
+    }
+
+    /**
+     * Create a new Andes channel for a new local channel.
+     *
      * @param listener
      *         Local flow control listener
      * @return AndesChannel
      */
     public synchronized AndesChannel createChannel(FlowControlListener listener) {
-        AndesChannel channel = new AndesChannel(this, listener, globalBufferBasedFlowControlEnabled, 
-                                                      globalErrorBasedFlowControlEnabled);
+        AndesChannel channel = new AndesChannel(this, listener, globalBufferBasedFlowControlEnabled,
+                globalErrorBasedFlowControlEnabled);
         channels.add(channel);
         return channel;
     }
@@ -285,7 +299,7 @@ public class FlowControlManager  implements StoreHealthListener {
     public synchronized void deleteChannel(AndesChannel channel) {
         channels.remove(channel);
 
-        log.info("Channel removed (ID: " + channel.getId() + ")");
+        log.info("Channel removed (ID: " + channel.getIdentifier() + ")");
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
@@ -68,44 +68,10 @@ public interface MessageStore extends HealthAwareStore{
     Map<Long, List<AndesMessagePart>> getContent(List<Long> messageIDList) throws AndesException;
 
     /**
-     * store mata data of messages
-     *
-     * @param metadataList metadata list to store
-     * @throws AndesException
-     */
-    void addMetadata(List<AndesMessageMetadata> metadataList) throws AndesException;
-
-    /**
-     * store metadata of a single message
-     *
-     * @param metadata metadata to store
-     * @throws AndesException
-     */
-    void addMetadata(AndesMessageMetadata metadata) throws AndesException;
-
-    /**
      * Store messages into database.
      * @param messageList messages to be stored
      */
     void storeMessages(List<AndesMessage> messageList) throws AndesException;
-
-    /**
-     * store metadata specifically under a queue
-     *
-     * @param queueName name of the queue to store metadata
-     * @param metadata metadata to store
-     * @throws AndesException
-     */
-    void addMetadataToQueue(final String queueName, AndesMessageMetadata metadata) throws AndesException;
-
-    /**
-     * store metadata list specifically under a queue
-     *
-     * @param queueName name of the queue to store metadata
-     * @param metadata metadata list to store
-     * @throws AndesException
-     */
-    void addMetadataToQueue(final String queueName, List<AndesMessageMetadata> metadata) throws AndesException;
 
     /**
      * Store a message in a different Queue without altering the meta data.
@@ -358,6 +324,13 @@ public interface MessageStore extends HealthAwareStore{
      * @param storageQueueName name of the queue actually stored in DB
      */
     void removeQueue(String storageQueueName) throws AndesException;
+
+    /**
+     * Remove queue entry from the queue mapping cache
+     *
+     * @param storageQueueName the name of the queue to be removed
+     */
+    void removeLocalQueueData(String storageQueueName);
 
     /**
      * Increment message counter for a queue by a given incrementBy value

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/PersistenceStoreConnector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/PersistenceStoreConnector.java
@@ -101,15 +101,15 @@ public class PersistenceStoreConnector implements MQTTConnector {
                 publisher = new MQTTPublisherChannel(messageContext.getChannel());
                 publisherTopicCorrelate.put(messageContext.getPublisherID(), publisher);
                 //Finally will register the publisher channel for flow controlling
-                AndesChannel publisherChannel = Andes.getInstance().createChannel(publisher);
+
+                String andesChannelId = MQTTUtils.DEFAULT_ANDES_CHANNEL_IDENTIFIER;
+                if (null != messageContext.getChannel()) {
+                    andesChannelId = messageContext.getChannel().remoteAddress().toString().substring(1);
+                }
+
+                AndesChannel publisherChannel = Andes.getInstance().createChannel(andesChannelId, publisher);
                 //Set channel details
                 //Substring to remove leading slash character from remote address
-                if (null != messageContext.getChannel()) {
-                    publisherChannel.setIdentifier(
-                            messageContext.getChannel().remoteAddress().toString().substring(1));
-                } else {
-                    publisherChannel.setIdentifier("MQTT-Unknown");
-                }
                 publisherChannel.setDestination(messageContext.getTopic());
                 publisher.setChannel(publisherChannel);
             }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/utils/MQTTUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/utils/MQTTUtils.java
@@ -58,6 +58,7 @@ public class MQTTUtils {
     public static final String SINGLE_LEVEL_WILDCARD = "+";
     public static final String MULTI_LEVEL_WILDCARD = "#";
 
+    public static final String DEFAULT_ANDES_CHANNEL_IDENTIFIER = "MQTT-Unknown";
     /**
      * MQTT Publisher ID
      */

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/virtualhost/VirtualHostConfigSynchronizer.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/virtualhost/VirtualHostConfigSynchronizer.java
@@ -121,7 +121,7 @@ public class VirtualHostConfigSynchronizer implements
         try {
             log.info("Queue removal request received queue= " + queue.queueName);
             removeQueue(queue.queueName);
-            AndesContext.getInstance().getAMQPConstructStore().removeQueue(queue.queueName, false);
+            AndesContext.getInstance().getAMQPConstructStore().removeLocalQueueData(queue.queueName);
         } catch (Exception e) {
             log.error("could not remove cluster queue", e);
             throw new AndesException("could not remove cluster queue : " + queue.toString(), e);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
@@ -116,62 +116,10 @@ public class FailureObservingMessageStore implements MessageStore {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void addMetadata(List<AndesMessageMetadata> metadataList) throws AndesException {
-        try {
-            wrappedInstance.addMetadata(metadataList);
-        } catch (AndesStoreUnavailableException exception) {
-            notifyFailures(exception);
-            throw exception;
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void addMetadata(AndesMessageMetadata metadata) throws AndesException {
-        try {
-            wrappedInstance.addMetadata(metadata);
-        } catch (AndesStoreUnavailableException exception) {
-            notifyFailures(exception);
-            throw exception;
-        }
-    }
-
     @Override
     public void storeMessages(List<AndesMessage> messageList) throws AndesException {
         try {
             wrappedInstance.storeMessages(messageList);
-        } catch (AndesStoreUnavailableException exception) {
-            notifyFailures(exception);
-            throw exception;
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void addMetadataToQueue(String queueName, AndesMessageMetadata metadata) throws AndesException {
-        try {
-            wrappedInstance.addMetadataToQueue(queueName, metadata);
-        } catch (AndesStoreUnavailableException exception) {
-            notifyFailures(exception);
-            throw exception;
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void addMetadataToQueue(String queueName, List<AndesMessageMetadata> metadata) throws AndesException {
-        try {
-            wrappedInstance.addMetadataToQueue(queueName, metadata);
         } catch (AndesStoreUnavailableException exception) {
             notifyFailures(exception);
             throw exception;
@@ -525,6 +473,14 @@ public class FailureObservingMessageStore implements MessageStore {
             notifyFailures(exception);
             throw exception;
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeLocalQueueData(String storageQueueName) {
+        wrappedInstance.removeLocalQueueData(storageQueueName);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -178,9 +178,13 @@ public class RDBMSConstants {
             + " VALUES ( ?,?,? )";
 
     protected static final String PS_INSERT_QUEUE =
-            "INSERT INTO " + RDBMSConstants.QUEUES_TABLE + " ("
+            "INSERT INTO " + QUEUES_TABLE + " ("
             + RDBMSConstants.QUEUE_NAME + ")"
             + "  VALUES (?)";
+
+    protected static final String PS_DELETE_QUEUE =
+                        "DELETE FROM " + QUEUES_TABLE
+                        + " WHERE " + QUEUE_NAME + "=?";
 
     protected static final String PS_ALIAS_FOR_COUNT = "count";
 
@@ -814,6 +818,7 @@ public class RDBMSConstants {
     protected static final String TASK_RETRIEVING_CONTENT_FOR_MESSAGES = "retrieving content for multiple messages";
     protected static final String TASK_ADDING_METADATA_LIST = "adding metadata list.";
     protected static final String TASK_ADDING_METADATA = "adding metadata.";
+    protected static final String TASK_ADDING_MESSAGE = "adding message.";
     protected static final String TASK_ADDING_MESSAGES = "adding messages";
     protected static final String TASK_DELETING_MESSAGES = "deleting messages";
     protected static final String TASK_MOVING_METADATA_TO_DLC = "moving message metadata to dlc.";
@@ -869,6 +874,7 @@ public class RDBMSConstants {
     protected static final String TASK_STORING_QUEUE_INFO = "storing queue information ";
     protected static final String TASK_RETRIEVING_ALL_QUEUE_INFO = "retrieving all queue information. ";
     protected static final String TASK_DELETING_QUEUE_INFO = "deleting queue information. ";
+    protected static final String TASK_DELETE_QUEUE_MAPPING = "deleting queue mapping";
     protected static final String TASK_STORING_BINDING = "storing binding information. ";
     protected static final String TASK_RETRIEVING_BINDING_INFO = "retrieving binding information.";
     protected static final String TASK_DELETING_BINDING = "deleting binding information. ";

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession.java
@@ -2695,18 +2695,8 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
                         long producerId = getNextProducerId();
                         P producer = createMessageProducer(destination, mandatory,
                                                            immediate, waitUntilSent, producerId);
-                        try {
-                            registerProducer(producerId, producer);
-                        } catch (AMQException e) {
-                            if (e instanceof AMQChannelClosedException) {
-                                close(-1, false);
-                            }
+                        registerProducer(producerId, producer);
 
-                            JMSException ex = new JMSException("Error registering producer: " + e);
-                            ex.setLinkedException(e);
-                            ex.initCause(e);
-                            throw ex;
-                        }
                         return producer;
                     }
                 }, _connection).execute();
@@ -3002,32 +2992,9 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
     public abstract void handleAddressBasedDestination(AMQDestination dest, 
                                                        boolean isConsumer,
                                                        boolean noWait) throws AMQException;
-
-    /**
-     * Creates a queue, adds binding for the producer. Also adds the given producer to the collection of producers
-     * created by this session.
-     *
-     * @param producerId unique id for the producer
-     * @param producer   the producer to be registered
-     * @throws AMQException
-     * @throws JMSException
-     */
-    private void registerProducer(long producerId, P producer) throws AMQException, JMSException {
-        AMQDestination amqDestination = producer.getDestination();
-        AMQProtocolHandler protocolHandler = getProtocolHandler();
-        boolean noWait = false;
-
-        if (producer._destination.isQueue()) {
-            if (DECLARE_EXCHANGES) {
-                declareExchange(amqDestination, protocolHandler, noWait);
-            }
-            if (DECLARE_QUEUES || amqDestination.isNameRequired()) {
-                declareQueue(amqDestination, protocolHandler, false, noWait);
-            }
-            bindQueue(amqDestination.getAMQQueueName(), amqDestination.getRoutingKey(), FieldTableFactory
-                    .newFieldTable(), amqDestination.getExchangeName(), amqDestination, noWait);
-        }
-
+    
+    private void registerProducer(long producerId, MessageProducer producer)
+    {
         _producers.put(new Long(producerId), producer);
     }
 

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/BasicMessageProducer.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/BasicMessageProducer.java
@@ -38,7 +38,6 @@ import org.wso2.andes.AMQException;
 import org.wso2.andes.client.message.AbstractJMSMessage;
 import org.wso2.andes.client.message.MessageConverter;
 import org.wso2.andes.client.protocol.AMQProtocolHandler;
-import org.wso2.andes.framing.AMQShortString;
 import org.wso2.andes.framing.ContentBody;
 import org.wso2.andes.util.UUIDGen;
 import org.wso2.andes.util.UUIDs;
@@ -104,11 +103,6 @@ public abstract class BasicMessageProducer extends Closeable implements org.wso2
      * a client that happens to hold onto a producer reference will get an error if he tries to use it subsequently).
      */
     private long _producerId;
-
-    /**
-     * Used to store the queue name
-     */
-    private AMQShortString _queuename;
 
     /**
      * The session used to create this producer
@@ -179,10 +173,6 @@ public abstract class BasicMessageProducer extends Closeable implements org.wso2
         {
             declareDestination(_destination);
         }
-    }
-
-    public void setQueuename(AMQShortString queuename) {
-        this._queuename = queuename;
     }
 
     abstract void declareDestination(AMQDestination destination) throws AMQException;
@@ -269,9 +259,10 @@ public abstract class BasicMessageProducer extends Closeable implements org.wso2
         return _timeToLive;
     }
 
-    public AMQDestination getDestination() throws JMSException
+    public Destination getDestination() throws JMSException
     {
         checkNotClosed();
+
         return _destination;
     }
 


### PR DESCRIPTION
Applied the changes in #377 with fixes for deleting the queue mapping entries from in-memory maps upon the receipt of a cluster queue delete notification.

Also, the Hashmap for storing queue mapping was removed and a guava cache was used in place.

In addition, https://github.com/wso2/andes/pull/418 ([MB-1433] Create queue when publishing) was reverted and a message published to a non-existing queue was dropped.
