### PR TITLE
Moved HasInterest AMQP Delivery rule to a common rule. 

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPUtils.java
@@ -44,6 +44,7 @@ import org.wso2.andes.server.queue.QueueEntry;
 import org.wso2.andes.server.queue.SimpleQueueEntryList;
 import org.wso2.andes.server.store.MessageMetaDataType;
 import org.wso2.andes.server.store.StorableMessageMetaData;
+import org.wso2.andes.server.store.StoredMessage;
 import org.wso2.andes.server.subscription.Subscription;
 import org.wso2.andes.store.StoredAMQPMessage;
 import org.wso2.andes.subscription.AMQPLocalSubscription;
@@ -132,6 +133,18 @@ public class AMQPUtils {
         StoredAMQPMessage message = new StoredAMQPMessage(messageId, metaData);
         AMQMessage amqMessage = new AMQMessage(message);
         return amqMessage;
+    }
+
+    /**
+     * Create a new AMQMessage out of StoredMessage and content
+     * @param storedMessage StoredMessage object
+     * @return instance of AMQMessage
+     */
+    public static AMQMessage getQueueEntryFromStoredMessage(StoredMessage<MessageMetaData> storedMessage,
+                                                            AndesContent content) {
+        QpidStoredMessage<MessageMetaData> message = new QpidStoredMessage<>(
+                storedMessage, content);
+        return new AMQMessage(message);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageFlusher.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageFlusher.java
@@ -527,6 +527,9 @@ public class MessageFlusher {
 
             ProtocolMessage protocolMessage = message.generateProtocolDeliverableMessage(subscription.getChannelID());
             flusherExecutor.submit(subscription, protocolMessage);
+        } else {
+            log.warn("Common delivery rules failed for message id " + message.getMessageID()
+                    + " Hence not delivered.");
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
@@ -68,16 +68,25 @@ public class SlowestSubscriberTopicMessageDeliveryImpl implements MessageDeliver
                 Collection<LocalSubscription> subscriptions4Queue =
                         subscriptionStore.getActiveLocalSubscribers(destination, message.isTopic());
 
-                //If this is a topic message, we remove all durable topic subscriptions here.
-                //Because durable topic subscriptions will get messages via queue path.
+                //All subscription filtering logic for topics goes here
                 Iterator<LocalSubscription> subscriptionIterator = subscriptions4Queue.iterator();
+
                 while (subscriptionIterator.hasNext()) {
+
                     LocalSubscription subscription = subscriptionIterator.next();
-                    /**
-                     * Here we need to consider the arrival time of the message. Only topic
-                     * subscribers who appeared before publishing this message should receive it
+
+                    /*
+                     * If this is a topic message, remove all durable topic subscriptions here
+                     * because durable topic subscriptions will get messages via queue path.
+                     * Also need to consider the arrival time of the message. Only topic
+                     * subscribers which appeared before publishing this message should receive it
                      */
                     if (subscription.isDurable() || (subscription.getSubscribeTime() > message.getArrivalTime())) {
+                        subscriptionIterator.remove();
+                    }
+
+                    // Avoid sending if the selector of subscriber does not match
+                    if(!subscription.isMessageAcceptedBySelector(message)) {
                         subscriptionIterator.remove();
                     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/MessagePreProcessor.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/MessagePreProcessor.java
@@ -165,6 +165,8 @@ public class MessagePreProcessor implements EventHandler<InboundEventContainer> 
 
             subscriptionList = subscriptionStore.getClusterSubscribersForDestination(messageRoutingKey, true, subscriptionType);
 
+            //We do not consider message selectors here. They will be considered when being delivered
+
             Set<String> alreadyStoredQueueNames = new HashSet<>();
             for (AndesSubscription subscription : subscriptionList) {
                 if (!alreadyStoredQueueNames.contains(subscription.getStorageQueueName())) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
@@ -157,7 +157,7 @@ public class MQTTLocalSubscription implements OutboundSubscription {
      * {@inheritDoc}
      */
     @Override
-    public boolean isMessageAcceptedBySelector(DeliverableAndesMetadata messageMetadata) throws AndesException {
+    public boolean isMessageAcceptedBySelector(AndesMessageMetadata messageMetadata) throws AndesException {
         //always return true as MQTT does not register message selectors
         return true;
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
@@ -157,6 +157,15 @@ public class MQTTLocalSubscription implements OutboundSubscription {
      * {@inheritDoc}
      */
     @Override
+    public boolean isMessageAcceptedBySelector(DeliverableAndesMetadata messageMetadata) throws AndesException {
+        //always return true as MQTT does not register message selectors
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public boolean sendMessageToSubscriber(ProtocolMessage protocolMessage, AndesContent content)
             throws AndesException {
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/AMQPLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/AMQPLocalSubscription.java
@@ -164,8 +164,16 @@ public class AMQPLocalSubscription implements OutboundSubscription {
             throws AndesException {
 
         StoredMessage<MessageMetaData> cachedStoredMessage = storedMessageCache.get(messageMetadata.getMessageID());
-        AMQMessage message = AMQPUtils.getQueueEntryFromStoredMessage(cachedStoredMessage, content);
-        message.setAndesMetadataReference(messageMetadata);
+
+        AMQMessage message;
+
+        if(null != cachedStoredMessage) {
+            message = AMQPUtils.getQueueEntryFromStoredMessage(cachedStoredMessage, content);
+            storedMessageCache.remove(messageMetadata.getMessageID());
+            message.setAndesMetadataReference(messageMetadata);
+        } else {
+            message = AMQPUtils.getAMQMessageForDelivery(messageMetadata, content);
+        }
 
         QueueEntry messageToSend = AMQPUtils.convertAMQMessageToQueueEntry(message, amqQueue);
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/LocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/LocalSubscription.java
@@ -133,6 +133,17 @@ public class LocalSubscription  extends BasicSubscription implements InboundSubs
         return subscription.sendMessageToSubscriber(messageMetadata, content);
     }
 
+    /**
+     * Check if message is accepted by 'selector' set to the subscription.
+     *
+     * @param messageMetadata message to be checked
+     * @return true if message is selected, false otherwise
+     * @throws AndesException on an error
+     */
+    public boolean isMessageAcceptedBySelector(DeliverableAndesMetadata messageMetadata) throws AndesException {
+        return subscription.isMessageAcceptedBySelector(messageMetadata);
+    }
+
 
     /**
      * Get all sent but not acknowledged messages for the subscriber

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/LocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/LocalSubscription.java
@@ -24,6 +24,7 @@ import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
 import org.wso2.andes.kernel.AndesContent;
 import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.kernel.AndesMessageMetadata;
 import org.wso2.andes.kernel.DeliverableAndesMetadata;
 import org.wso2.andes.kernel.MessageStatus;
 import org.wso2.andes.kernel.MessagingEngine;
@@ -140,7 +141,7 @@ public class LocalSubscription  extends BasicSubscription implements InboundSubs
      * @return true if message is selected, false otherwise
      * @throws AndesException on an error
      */
-    public boolean isMessageAcceptedBySelector(DeliverableAndesMetadata messageMetadata) throws AndesException {
+    public boolean isMessageAcceptedBySelector(AndesMessageMetadata messageMetadata) throws AndesException {
         return subscription.isMessageAcceptedBySelector(messageMetadata);
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/OutboundSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/OutboundSubscription.java
@@ -20,6 +20,7 @@ package org.wso2.andes.subscription;
 
 import org.wso2.andes.kernel.AndesContent;
 import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.kernel.DeliverableAndesMetadata;
 import org.wso2.andes.kernel.ProtocolMessage;
 
 import java.util.UUID;
@@ -36,6 +37,16 @@ public interface OutboundSubscription {
      * @throws AndesException
      */
     void forcefullyDisconnect() throws AndesException;
+
+    /**
+     * Check if message is accepted by 'selector' set to the subscription.
+     *
+     * @param messageMetadata message to be checked
+     * @return true if message is selected, false otherwise
+     * @throws AndesException on an error
+     */
+    boolean isMessageAcceptedBySelector(DeliverableAndesMetadata messageMetadata)
+            throws AndesException ;
 
     /**
      * Deliver the message and content to the subscriber

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/OutboundSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/OutboundSubscription.java
@@ -20,6 +20,7 @@ package org.wso2.andes.subscription;
 
 import org.wso2.andes.kernel.AndesContent;
 import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.kernel.AndesMessageMetadata;
 import org.wso2.andes.kernel.DeliverableAndesMetadata;
 import org.wso2.andes.kernel.ProtocolMessage;
 
@@ -45,7 +46,7 @@ public interface OutboundSubscription {
      * @return true if message is selected, false otherwise
      * @throws AndesException on an error
      */
-    boolean isMessageAcceptedBySelector(DeliverableAndesMetadata messageMetadata)
+    boolean isMessageAcceptedBySelector(AndesMessageMetadata messageMetadata)
             throws AndesException ;
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionStore.java
@@ -24,6 +24,7 @@ import org.wso2.andes.amqp.AMQPUtils;
 import org.wso2.andes.kernel.AndesContext;
 import org.wso2.andes.kernel.AndesContextStore;
 import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.kernel.AndesMessageMetadata;
 import org.wso2.andes.kernel.AndesSubscription;
 import org.wso2.andes.kernel.AndesSubscription.SubscriptionType;
 import org.wso2.andes.kernel.DeliverableAndesMetadata;
@@ -1006,7 +1007,7 @@ public class SubscriptionStore {
      * @param message message to evaluate selectors against
      */
     public void filterInterestedSubscriptions(Collection<LocalSubscription> subscriptions4Queue,
-                                              DeliverableAndesMetadata message) throws AndesException{
+                                              AndesMessageMetadata message) throws AndesException{
 
         Iterator<LocalSubscription> subscriptionIterator = subscriptions4Queue.iterator();
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionStore.java
@@ -26,6 +26,7 @@ import org.wso2.andes.kernel.AndesContextStore;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesSubscription;
 import org.wso2.andes.kernel.AndesSubscription.SubscriptionType;
+import org.wso2.andes.kernel.DeliverableAndesMetadata;
 import org.wso2.andes.kernel.SubscriptionListener.SubscriptionChange;
 import org.wso2.andes.metrics.MetricsConstants;
 import org.wso2.andes.mqtt.utils.MQTTUtils;
@@ -34,6 +35,7 @@ import org.wso2.carbon.metrics.manager.Level;
 import org.wso2.carbon.metrics.manager.MetricManager;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -994,6 +996,26 @@ public class SubscriptionStore {
 
         //update all the stored durable subscriptions to be inactive
         andesContextStore.updateDurableSubscriptions(modifiedSubscriptions);
+    }
+
+    /**
+     * Filter out the subscriptions based on the 'selector' set. This modifies the input
+     * collections of subscriptions
+     *
+     * @param subscriptions4Queue collection of subscriptions
+     * @param message message to evaluate selectors against
+     */
+    public void filterInterestedSubscriptions(Collection<LocalSubscription> subscriptions4Queue,
+                                              DeliverableAndesMetadata message) throws AndesException{
+
+        Iterator<LocalSubscription> subscriptionIterator = subscriptions4Queue.iterator();
+
+        while (subscriptionIterator.hasNext()) {
+            LocalSubscription subscription = subscriptionIterator.next();
+            if(!subscription.isMessageAcceptedBySelector(message)) {
+                subscriptionIterator.remove();
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This is done to implement message selectors properly. We need to filter the subscriptions based on selector before we deliver. 

Fixing https://wso2.org/jira/browse/MB-1600