### PR TITLE
[MB-1482] Fix condition to distinguish redeliveries

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/BasicMessageConsumer.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/BasicMessageConsumer.java
@@ -1019,11 +1019,13 @@ public abstract class BasicMessageConsumer<U> extends Closeable implements Messa
                 if (o instanceof AbstractJMSMessage)
                 {
                     try {
-                        if ((lastRollbackedMessageTimestamp > 0) && ((AbstractJMSMessage)o).getJMSRedelivered() && (lastRollbackedMessageTimestamp >= ((AbstractJMSMessage) o).getJMSTimestamp())) {
+                        if ((lastRollbackedMessageTimestamp > 0) && ((AbstractJMSMessage) o).getJMSRedelivered() &&
+                                (lastRollbackedMessageTimestamp >= ((AbstractJMSMessage) o).getJMSTimestamp())) {
                             if (_logger.isDebugEnabled())
                             {
                                 if (o instanceof TextMessage) {
-                                    _logger.debug("Did not remove message " + ((TextMessage)o).getText() +" since its new relative to the rollback point.");
+                                    _logger.debug("Did not remove message " + ((TextMessage) o).getText() + " since its new relative to " +
+                                            "the rollback point.");
                                 }
                             }
                         } else {

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/BasicMessageConsumer.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/BasicMessageConsumer.java
@@ -1019,7 +1019,7 @@ public abstract class BasicMessageConsumer<U> extends Closeable implements Messa
                 if (o instanceof AbstractJMSMessage)
                 {
                     try {
-                        if ((lastRollbackedMessageTimestamp > 0) && (lastRollbackedMessageTimestamp >= ((AbstractJMSMessage) o).getJMSTimestamp())) {
+                        if ((lastRollbackedMessageTimestamp > 0) && ((AbstractJMSMessage)o).getJMSRedelivered() && (lastRollbackedMessageTimestamp >= ((AbstractJMSMessage) o).getJMSTimestamp())) {
                             if (_logger.isDebugEnabled())
                             {
                                 if (o instanceof TextMessage) {


### PR DESCRIPTION
JMS transactions sometimes resulted in loss of message order. The reason was that multiple messages were being published on the same exact timestamp, and the below condition could not handle it. 

Added a new factor to the condition as a fix. 