### PR TITLE
Separate message delivery info for destination type

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/CommonDeliveryRule.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/CommonDeliveryRule.java
@@ -27,11 +27,14 @@ public interface CommonDeliveryRule {
     /**
      * Evaluate delivery rule. This returns true if the rule is passed. Should be called in kernel
      * before message is dispatched to the protocol. If failed message should not be sent and
-     * necessary actions should be taken
+     * necessary actions should be taken.
      *
-     * @param message message to evaluate rules
-     * @return true if rule is passed
+     * @param message Message to evaluate rules
+     * @param protocolType The protocol type of the message
+     * @param destinationType The destination type of the message
+     * @return True if rule is passed
      * @throws AndesException
      */
-    boolean evaluate(DeliverableAndesMetadata message) throws AndesException;
+    boolean evaluate(DeliverableAndesMetadata message, ProtocolType protocolType, DestinationType destinationType)
+            throws AndesException;
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageDeliveryInfo.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageDeliveryInfo.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+import org.wso2.andes.subscription.LocalSubscription;
+import org.wso2.andes.tools.utils.MessageTracer;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+/**
+ * Class to keep track of message delivery information used for delivery.
+ */
+public class MessageDeliveryInfo {
+
+    private MessageFlusher messageFlusher;
+    /**
+     * Destination of the messages (not storage queue name). For durable topics
+     * this is the internal queue name with subscription id.
+     */
+    private String destination;
+
+    /**
+     * Subscription iterator
+     */
+    private Iterator<LocalSubscription> iterator;
+
+    /**
+     * In-memory message list scheduled to be delivered. These messages will be flushed
+     * to subscriber
+     */
+    private Set<DeliverableAndesMetadata> readButUndeliveredMessages = new
+            ConcurrentSkipListSet<>();
+
+    /***
+     * In case of a purge, we must store the timestamp when the purge was called.
+     * This way we can identify messages received before that timestamp that fail and ignore them.
+     */
+    private Long lastPurgedTimestamp;
+
+    /**
+     * The destination type of the messages in the buffer
+     */
+    private DestinationType destinationType;
+
+    /**
+     * The protocol type of the messages in the buffer.
+     */
+    private ProtocolType protocolType;
+
+    /***
+     * Constructor
+     * initialize lastPurgedTimestamp to 0.
+     */
+    public MessageDeliveryInfo(MessageFlusher messageFlusher) {
+        this.messageFlusher = messageFlusher;
+        lastPurgedTimestamp = 0l;
+    }
+
+    /**
+     * Buffer messages to be delivered
+     *
+     * @param message message metadata to buffer
+     */
+    public void bufferMessage(DeliverableAndesMetadata message) {
+        readButUndeliveredMessages.add(message);
+        message.markAsBuffered();
+        //Tracing message
+        MessageTracer.trace(message, MessageTracer.METADATA_BUFFERED_FOR_DELIVERY);
+
+    }
+
+    /**
+     * Check if message buffer for destination is empty
+     *
+     * @return true if empty
+     */
+    public boolean isMessageBufferEmpty() {
+        return readButUndeliveredMessages.isEmpty();
+    }
+
+    /**
+     * Get the number of messages buffered for the destination to be delivered
+     *
+     * @return number of messages buffered
+     */
+    public int getSizeOfMessageBuffer() {
+        return readButUndeliveredMessages.size();
+    }
+
+    /**
+     * Returns boolean variable saying whether this destination has room or not
+     *
+     * @return whether this destination has room or not
+     */
+    public boolean messageBufferHasRoom() {
+        boolean hasRoom = true;
+        if (readButUndeliveredMessages.size() >= messageFlusher.getMaxNumberOfReadButUndeliveredMessages()) {
+            hasRoom = false;
+        }
+        return hasRoom;
+    }
+
+    /***
+     * Clear the read-but-undelivered collection of messages of the given queue from memory
+     * @return Number of messages that was in the read-but-undelivered buffer
+     */
+    public int clearReadButUndeliveredMessages() {
+
+        int messageCount = readButUndeliveredMessages.size();
+
+        readButUndeliveredMessages.clear();
+
+        return messageCount;
+    }
+
+    /***
+     * @return Last purged timestamp of queue.
+     */
+    public Long getLastPurgedTimestamp() {
+        return lastPurgedTimestamp;
+    }
+
+    /**
+     * set last purged timestamp for queue.
+     * @param lastPurgedTimestamp the time stamp of the message message which was purged most recently
+     */
+    public void setLastPurgedTimestamp(Long lastPurgedTimestamp) {
+        this.lastPurgedTimestamp = lastPurgedTimestamp;
+    }
+
+    public String getDestination() {
+        return destination;
+    }
+
+    public void setDestination(String destination) {
+        this.destination = destination;
+    }
+
+    public Set<DeliverableAndesMetadata> getReadButUndeliveredMessages() {
+        return readButUndeliveredMessages;
+    }
+
+    public Iterator<LocalSubscription> getIterator() {
+        return iterator;
+    }
+
+    public void setIterator(Iterator<LocalSubscription> iterator) {
+        this.iterator = iterator;
+    }
+
+    public DestinationType getDestinationType() {
+        return destinationType;
+    }
+
+    public void setDestinationType(DestinationType destinationType) {
+        this.destinationType = destinationType;
+    }
+
+    public ProtocolType getProtocolType() {
+        return protocolType;
+    }
+
+    public void setProtocolType(ProtocolType protocolType) {
+        this.protocolType = protocolType;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageDeliveryStrategy.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageDeliveryStrategy.java
@@ -19,8 +19,6 @@
 package org.wso2.andes.kernel;
 
 
-import java.util.Set;
-
 /**
  * This interface defines the structure of a message delivery strategy
  */
@@ -29,12 +27,11 @@ public interface MessageDeliveryStrategy {
     /**
      * Deliver message. It will find current subscriptions to deliver by the destination of the message
      * and send the messages accordingly
-     * @param destination destination of messages
-     * @param messages messages to be sent
-     * @param destinationType The destination type of the subscriptions to send
+     *
+     * @param messageDeliveryInfo The message delivery information holder
+     *
      * @return number of messages sent
      * @throws AndesException in case of a delivery failure
      */
-    public int deliverMessageToSubscriptions(String destination, Set<DeliverableAndesMetadata> messages
-            , DestinationType destinationType) throws AndesException;
+    public int deliverMessageToSubscriptions(MessageDeliveryInfo messageDeliveryInfo) throws AndesException;
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageExpiredRule.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageExpiredRule.java
@@ -33,7 +33,8 @@ public class MessageExpiredRule implements CommonDeliveryRule {
      * @return isOKToDelivery
      */
     @Override
-    public boolean evaluate(DeliverableAndesMetadata message) {
+    public boolean evaluate(DeliverableAndesMetadata message, ProtocolType protocolType,
+                            DestinationType destinationType) {
         long messageID = message.getMessageID();
         //Check if destination entry has expired. Any expired message will not be delivered
         if (message.isExpired()) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagePurgeRule.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagePurgeRule.java
@@ -34,19 +34,13 @@ public class MessagePurgeRule implements CommonDeliveryRule{
      * @throws AndesException
      */
     @Override
-    public boolean evaluate(DeliverableAndesMetadata message) throws AndesException {
+    public boolean evaluate(DeliverableAndesMetadata message, ProtocolType protocolType, DestinationType destinationType) throws AndesException {
         long messageID = message.getMessageID();
-        DestinationType destinationType;
 
-        if (message.isTopic()) {
-            destinationType = DestinationType.TOPIC;
-        } else {
-            destinationType = DestinationType.QUEUE;
-        }
         // Get last purged timestamp of the destination queue.
         long lastPurgedTimestampOfQueue =
-                MessageFlusher.getInstance().getMessageDeliveryInfo(message.getDestination(),
-                        AndesUtils.getProtocolTypeForMetaDataType(message.getMetaDataType()), destinationType)
+                MessageFlusher.getInstance().getMessageDeliveryInfo(message.getDestination(), protocolType,
+                        destinationType)
                         .getLastPurgedTimestamp();
 
         if (message.getArrivalTime() <= lastPurgedTimestampOfQueue) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -230,11 +230,12 @@ public class MessagingEngine {
      * any eligible subscriber to receive later. This also check message status before
      * re-schedule
      * @param messageMetadata message to reschedule
+     * @param destinationType the destination type of the messages
      * @throws AndesException in case of an error
      */
-    public void reQueueMessage(DeliverableAndesMetadata messageMetadata) throws AndesException {
+    public void reQueueMessage(DeliverableAndesMetadata messageMetadata, DestinationType destinationType) throws AndesException {
         if(!messageMetadata.isOKToDispose()) {
-            MessageFlusher.getInstance().reQueueMessage(messageMetadata);
+            MessageFlusher.getInstance().reQueueMessage(messageMetadata, destinationType);
             //Tracing Message
             MessageTracer.trace(messageMetadata.getMessageID(), messageMetadata.getDestination(),
                     MessageTracer.MESSAGE_REQUEUED_BUFFER);
@@ -278,7 +279,7 @@ public class MessagingEngine {
                                               DestinationType destinationType) throws AndesException {
 
         MessageFlusher messageFlusher = MessageFlusher.getInstance();
-        MessageFlusher.MessageDeliveryInfo messageDeliveryInfo =
+        MessageDeliveryInfo messageDeliveryInfo =
                 messageFlusher.getMessageDeliveryInfo(destination, protocolType, destinationType);
         messageDeliveryInfo.setLastPurgedTimestamp(purgedTimestamp);
         return messageDeliveryInfo.clearReadButUndeliveredMessages();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
@@ -43,9 +43,9 @@ public class SlowestSubscriberTopicMessageDeliveryImpl implements MessageDeliver
      * {@inheritDoc}
      */
     @Override
-    public int deliverMessageToSubscriptions(String destination, Set<DeliverableAndesMetadata> messages,
-                                             DestinationType destinationType) throws AndesException {
+    public int deliverMessageToSubscriptions(MessageDeliveryInfo messageDeliveryInfo) throws AndesException {
 
+        Set<DeliverableAndesMetadata> messages = messageDeliveryInfo.getReadButUndeliveredMessages();
         int sentMessageCount = 0;
         Iterator<DeliverableAndesMetadata> iterator = messages.iterator();
         List<DeliverableAndesMetadata> droppedTopicMessagesList = new ArrayList<>();
@@ -67,7 +67,7 @@ public class SlowestSubscriberTopicMessageDeliveryImpl implements MessageDeliver
                 Collection<LocalSubscription> subscriptions4Queue =
                         subscriptionEngine.getActiveLocalSubscribers(message.getDestination(),
                                 AndesUtils.getProtocolTypeForMetaDataType(message.getMetaDataType()),
-                                destinationType);
+                                messageDeliveryInfo.getDestinationType());
 
                 //All subscription filtering logic for topics goes here
                 Iterator<LocalSubscription> subscriptionIterator = subscriptions4Queue.iterator();
@@ -128,8 +128,8 @@ public class SlowestSubscriberTopicMessageDeliveryImpl implements MessageDeliver
                     sentMessageCount++;
                 } else {
                     if (log.isDebugEnabled()) {
-                        log.debug("Some subscriptions for destination " + destination + " have max unacked " +
-                                "messages " + message.getDestination());
+                        log.debug("Some subscriptions for destination " + messageDeliveryInfo.getDestination()
+                                + " have max unacked messages " + message.getDestination());
                     }
                     //if we continue message order will break
                     break;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
@@ -156,7 +156,7 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
             throws AndesException {
         if (subscription.isDurable()) {
             //re-queue message to andes core so that it can find other subscriber to deliver
-            MessagingEngine.getInstance().reQueueMessage(message);
+            MessagingEngine.getInstance().reQueueMessage(message, subscription.getDestinationType());
         } else {
             if (!message.isOKToDispose()) {
                 log.warn("Cannot send message id= " + message.getMessageID() + " as subscriber is closed");


### PR DESCRIPTION
Move MessageDeliveryInfo class to a separate file instead of an inner class.
Then forward MessageDeliveryInfo objects from SlotDeliveryWorker to MessageFlusher to delivery messages instead of sending parameters separately and selecting the MessageDeliveryInfo class from within MessageFlusher.