### PR TITLE
Fixing the connection leak in prepared statements 

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSAndesContextStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSAndesContextStoreImpl.java
@@ -1421,7 +1421,6 @@ public class RDBMSAndesContextStoreImpl implements AndesContextStore {
                 insertQueueToLastAssignedIDPS.executeUpdate();
             }
 
-
             connection.commit();
 
         } catch (SQLException e) {


### PR DESCRIPTION
The most desired option is to enclose the connection/prepared statements between Try-with-Resources. http://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html

This should be reflected in all database operations. Hence it will be tabled for future   