### PR TITLE
Fix for fresh slot deleted before overlapped slot is delivered

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
@@ -134,6 +134,18 @@ public interface MessageStore extends HealthAwareStore{
                                                    long lastMsgID) throws AndesException;
 
     /**
+     * Get number of messages in the queue within the message id range
+     *
+     * @param storageQueueName name of the queue
+     * @param firstMessageId starting message id of the range
+     * @param lastMessageId end message id of the range
+     * @return number of messages for the queue within the provided message id range
+     * @throws AndesException
+     */
+    long getMessageCountForQueueInRange(final String storageQueueName, long firstMessageId, long lastMessageId)
+            throws AndesException;
+
+    /**
      * read  a metadata list from store specifying a starting message id and a count
      *
      * @param storageQueueName name of the queue

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -524,6 +524,20 @@ public class MessagingEngine {
     }
 
     /**
+     * Get number of messages in the queue within the message id range
+     *
+     * @param storageQueueName name of the queue
+     * @param firstMessageId starting message id of the range
+     * @param lastMessageId end message id of the range
+     * @return number of messages for the queue within the provided message id range
+     * @throws AndesException
+     */
+    public long getMessageCountForQueueInRange(final String storageQueueName, long firstMessageId, long lastMessageId)
+            throws AndesException {
+        return messageStore.getMessageCountForQueueInRange(storageQueueName, firstMessageId, lastMessageId);
+    }
+
+    /**
      * Get message count in DLC for a specific queue.
      *
      * @param queueName    name of the storage queue

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/Slot.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/Slot.java
@@ -371,7 +371,7 @@ public class Slot implements Serializable, Comparable<Slot> {
         if (messageCount == 0) {
 
             if (log.isDebugEnabled()) {
-                log.debug("Slot has no pending messages. Now re-checking slot for messages");
+                log.debug("Slot has no pending messages. Now re-checking slot for messages. " + this.toString());
             }
             setSlotInActive();
             SlotDeletionExecutor.getInstance().executeSlotDeletion(this);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeletionExecutor.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeletionExecutor.java
@@ -21,6 +21,7 @@ package org.wso2.andes.kernel.slot;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.MessagingEngine;
 
 import java.util.concurrent.ExecutorService;
@@ -85,34 +86,36 @@ public class SlotDeletionExecutor {
         public void run() {
             while (!Thread.currentThread().isInterrupted()) {
                 try {
-                    //Slot to attempt current deletion
-                    Slot deletionAttempt;
-                    if (previouslyAttemptedSlot != null) {
-                        //Previous attempt to deletion is not success. Therefore try again to delete by assign it to
-                        //deletionAttempt
-                        deletionAttempt = previouslyAttemptedSlot;
-                        previouslyAttemptedSlot = null;
-                    } else {
-                        //Previous attempt to delete slot is success, therefore taking next slot from queue
-                        deletionAttempt = slotsToDelete.poll(1, TimeUnit.SECONDS);
-                    }
-                    //check current slot to delete is not null
-                    if (deletionAttempt != null) {
-                        //invoke coordinator to delete slot
-                        boolean deleteSuccess = deleteSlotAtCoordinator(deletionAttempt);
-                        if (!deleteSuccess) {
-                            //delete attempt not success, therefore reassign current deletion attempted slot to previous slot
-                            previouslyAttemptedSlot = deletionAttempt;
+                    // Slot to attempt current deletion
+                    Slot slot = slotsToDelete.poll(1, TimeUnit.SECONDS);
+
+                    // Check current slot to delete is not null
+                    if (slot != null) {
+
+                        // Check DB for any remaining messages. (JIRA FIX: MB-1612)
+                        // If there are any remaining messages wait till overlapped slot delivers the messages
+                        if (MessagingEngine.getInstance().getMessageCountForQueueInRange(
+                                slot.getStorageQueueName(), slot.getStartMessageId(), slot.getEndMessageId()) == 0) {
+                            // Invoke coordinator to delete slot
+                            boolean deleteSuccess = deleteSlotAtCoordinator(slot);
+                            if (!deleteSuccess) {
+                                // Delete attempt not success, therefore adding slot to the queue
+                                slotsToDelete.put(slot);
+                            } else {
+                                SlotDeliveryWorker slotWorker = SlotDeliveryWorkerManager.getInstance()
+                                        .getSlotWorker(slot.getStorageQueueName());
+                                slotWorker.deleteSlot(slot);
+                            }
                         } else {
-                            SlotDeliveryWorker slotWorker = SlotDeliveryWorkerManager.getInstance()
-                                                                                     .getSlotWorker(deletionAttempt.getStorageQueueName());
-                            slotWorker.deleteSlot(deletionAttempt);
+                            slotsToDelete.put(slot); // Not deleted. Hence puttng back in queue
                         }
                     }
 
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    log.error("Error while trying to delete the slot.");
+                    log.error("Error occurred while trying to delete the slot.", e);
+                } catch (AndesException e) {
+                    log.error("Error occurred while trying to delete the slot.", e);
                 }
             }
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
@@ -208,7 +208,19 @@ public class FailureObservingMessageStore implements MessageStore {
         }
     }
 
-    
+    /**
+     * {@inheritDoc}
+     */
+    public long getMessageCountForQueueInRange(final String storageQueueName, long firstMessageId, long lastMessageId)
+            throws AndesException {
+        try {
+            return wrappedInstance.getMessageCountForQueueInRange(storageQueueName, firstMessageId, lastMessageId);
+        } catch (AndesStoreUnavailableException exception) {
+            notifyFailures(exception);
+            throw exception;
+        }
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -194,6 +194,16 @@ public class RDBMSConstants {
             + " WHERE " + QUEUE_ID + "=?"
             + " AND " + DLC_QUEUE_ID + "=-1";
 
+    /**
+     * Prepared statement to retrieve message count within a message id range for a queue.
+     */
+    protected static final String PS_SELECT_RANGED_QUEUE_MESSAGE_COUNT =
+            "SELECT COUNT(" + MESSAGE_ID + ") AS " + PS_ALIAS_FOR_COUNT
+            + " FROM " + METADATA_TABLE
+            + " WHERE " + QUEUE_ID + "=?"
+            + " AND " + MESSAGE_ID + " BETWEEN ? AND ?"
+            + " AND " + DLC_QUEUE_ID + "=-1";
+
     protected static final String ALIAS_FOR_QUEUES = "QUEUE_COUNT";
 
     /**
@@ -812,11 +822,6 @@ public class RDBMSConstants {
             + " SET " + DLC_QUEUE_ID + "=?"
             + " WHERE " + MESSAGE_ID + "=?";
 
-
-    
-    
-    
-    
     // Message Store related jdbc tasks executed
     protected static final String TASK_STORING_MESSAGE_PARTS = "storing message parts.";
     protected static final String TASK_DELETING_MESSAGE_PARTS = "deleting message parts.";
@@ -832,6 +837,7 @@ public class RDBMSConstants {
     protected static final String TASK_ADDING_METADATA_TO_QUEUE = "adding metadata to destination. ";
     protected static final String TASK_ADDING_METADATA_LIST_TO_QUEUE = "adding metadata list to destination. ";
     protected static final String TASK_RETRIEVING_ALL_QUEUE_MSG_COUNT = "retrieving message counts for all queues. ";
+    protected static final String TASK_RETRIEVING_RANGED_QUEUE_MSG_COUNT = "retrieving ranged message count for queue. ";
     protected static final String TASK_RETRIEVING_QUEUE_MSG_COUNT = "retrieving message count for queue. ";
     protected static final String TASK_RETRIEVING_QUEUE_MSG_COUNT_IN_DLC = "retrieving message count in DLC for"
                                                                            + " queue. ";

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSMessageStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSMessageStoreImpl.java
@@ -803,7 +803,49 @@ public class RDBMSMessageStoreImpl implements MessageStore {
         }
         return metadataList;
     }
-    
+
+    /**
+     * Get number of messages in the queue withing the message id range
+     *
+     * @param storageQueueName name of the queue
+     * @param firstMessageId starting message id of the range
+     * @param lastMessageId end message id of the range
+     * @return number of messages in queue withing the message id range
+     * @throws AndesException
+     */
+    public long getMessageCountForQueueInRange(final String storageQueueName, long firstMessageId, long lastMessageId)
+                                                                                                throws AndesException {
+
+        Connection connection = null;
+        PreparedStatement preparedStatement = null;
+        ResultSet resultSet = null;
+        long messageCount = 0;
+        Context contextRead = MetricManager.timer(Level.INFO, MetricsConstants.DB_READ).start();
+        try {
+            connection = getConnection();
+            preparedStatement = connection.prepareStatement(RDBMSConstants.PS_SELECT_RANGED_QUEUE_MESSAGE_COUNT);
+            preparedStatement.setInt(1, getCachedQueueID(storageQueueName));
+            preparedStatement.setLong(2, firstMessageId);
+            preparedStatement.setLong(3, lastMessageId);
+
+            resultSet = preparedStatement.executeQuery();
+
+            if (resultSet.next()) {
+                messageCount = resultSet.getInt(RDBMSConstants.PS_ALIAS_FOR_COUNT);
+            }
+
+        } catch (SQLException e) {
+            throw rdbmsStoreUtils.convertSQLException("Error occurred while retrieving ranged message count for " +
+                    "message ids between " + firstMessageId + " and " + lastMessageId + " from queue "
+                    + storageQueueName, e);
+        } finally {
+            contextRead.stop();
+            close(connection, preparedStatement, resultSet, RDBMSConstants.TASK_RETRIEVING_RANGED_QUEUE_MSG_COUNT);
+        }
+        return messageCount;
+
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
Additional check added for slot deletion executor to check whether there are messages in database before trying to delete a slot.

There is a scenario where a slot scheduled to delete, becoming overlapped and then assigned to a
node after some time. Then coordinator will allow to delete the slot while overlapped slot messages
are in delivery path (race condition). To avoid this a DB message count check is added before querying
coordinator for a slot deletion. This guarantees that slots are not deleted until messages in overlapped
slots are successfully delivered.

JIRA: https://wso2.org/jira/browse/MB-1612