### PR TITLE
[MB-1611] and fixing an issue at the SlotDeletionExecutor

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
@@ -426,7 +426,7 @@ public class SlotDeliveryWorker extends Thread implements StoreHealthListener{
         if (null != slotsOfQueue) {
             slotsOfQueue.remove(slot.getId());
         } else {
-            log.warn("Slot has been deleted by the SlotDeliveryWorker before the executor can get to it. Slot : " + slot);
+            log.warn("Slot has been deleted by the SlotDeliveryWorker before the SlotDeletionExecutor can get to it. Slot : " + slot);
         }
 
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
@@ -422,8 +422,9 @@ public class SlotDeliveryWorker extends Thread implements StoreHealthListener{
         }
         slot.deleteAllMessagesInSlot();
 
-        if (storageQueueToSlotTracker.containsKey(slot.getStorageQueueName())) {
-            storageQueueToSlotTracker.get(slot.getStorageQueueName()).remove(slot.getId());
+        Map<String, Slot> slotsOfQueue = storageQueueToSlotTracker.get(slot.getStorageQueueName());
+        if (null != slotsOfQueue) {
+            slotsOfQueue.remove(slot.getId());
         } else {
             log.warn("Slot has been deleted by the SlotDeliveryWorker before the executor can get to it. Slot : " + slot);
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
@@ -421,7 +421,13 @@ public class SlotDeliveryWorker extends Thread implements StoreHealthListener{
             log.debug("Releasing tracking of messages for slot " + slot.toString());
         }
         slot.deleteAllMessagesInSlot();
-        storageQueueToSlotTracker.get(slot.getStorageQueueName()).remove(slot.getId());
+
+        if (storageQueueToSlotTracker.containsKey(slot.getStorageQueueName())) {
+            storageQueueToSlotTracker.get(slot.getStorageQueueName()).remove(slot.getId());
+        } else {
+            log.warn("Slot has been deleted by the SlotDeliveryWorker before the executor can get to it. Slot : " + slot);
+        }
+
     }
 
     /**


### PR DESCRIPTION
1. Revert node-wise safe zone to slots that are still filling up to avoid deleting slots before completion.
2. Fix SlotDeletionTask while loop and adding error logs for context.