### PR TITLE
Fixing MB-1635. 

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/HeartbeatDiagnostics.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/HeartbeatDiagnostics.java
@@ -62,7 +62,7 @@ class HeartbeatDiagnostics
         private final String[] messages = new String[50];
         private int i;
 
-        private void save(String msg)
+        private synchronized void save(String msg)
         {
             messages[i++] = msg;
             if(i >= messages.length){


### PR DESCRIPTION
Avoid concurrent access on Heartbeat Diagnostics to fix ArrayIndexOutofBoundsException.