### PR TITLE
In Andes client, reject available messages before sending a close event

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession.java
@@ -3526,11 +3526,6 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
                         }
                     }
                 }
-                // Don't reject if we're already closing
-                if (!_closed.get())
-                {
-                    rejectMessage(message, true);
-                }
             }
             else
             {

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/BasicMessageConsumer.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/BasicMessageConsumer.java
@@ -593,6 +593,7 @@ public abstract class BasicMessageConsumer<U> extends Closeable implements Messa
                         // no point otherwise as the connection will be gone
                         if (!_session.isClosed() || _session.isClosing())
                         {
+                            _session._dispatcher.rejectPending(this);
                             sendCancel();
                             cleanupQueue();
                         }


### PR DESCRIPTION
This pull fixes the issue - https://wso2.org/jira/browse/MB-1640.