### PR TITLE
Fixed MB-1650 and make the warning log of keystore loading from class path only when ssl is enabled

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionDelegate_8_0.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionDelegate_8_0.java
@@ -114,15 +114,18 @@ public class AMQConnectionDelegate_8_0 implements AMQConnectionDelegate
             settings.setCertAlias(sslConfig.getSslCertAlias());
             settings.setKeyStoreCertType(sslConfig.getCertType());
             settings.setTrustStoreCertType(sslConfig.getCertType());
+            if (settings.getKeyStorePath() == null && settings.getKeyStorePassword() == null &&
+                settings.getTrustStorePath() == null && settings.getTrustStorePassword() == null) {
+                _logger.warn("Loading keystore and truststore from system properties");
+
+                settings.loadSSLConfigFromSysConfig();
+            }
+            if((settings.getKeyStorePath() == null) || (settings.getKeyStorePassword() == null)){
+                settings.setKeyStorePath(sslConfig.getTrustStorePath());
+                settings.setKeyStorePassword(sslConfig.getTrustStorePassword());
+            }
         }
 
-        if (settings.getKeyStorePath() == null && settings.getKeyStorePassword() == null && settings
-                .getTrustStorePath() == null && settings.getTrustStorePassword() == null) {
-
-            _logger.warn("Loading keystore and truststore from system properties");
-
-            settings.loadSSLConfigFromSysConfig();
-        }
 
         OutgoingNetworkTransport transport = Transport.getOutgoingTransportInstance(getProtocolVersion());
         NetworkConnection network = transport.connect(settings,_conn._protocolHandler, null);


### PR DESCRIPTION
jira : https://wso2.org/jira/browse/MB-1650