### PR TITLE
Fix for https://wso2.org/jira/browse/MB-1659 and introducing a separate class for client reference counting 

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionDelegate_8_0.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionDelegate_8_0.java
@@ -133,7 +133,14 @@ public class AMQConnectionDelegate_8_0 implements AMQConnectionDelegate
         // this blocks until the connection has been set up or when an error
         // has prevented the connection being set up
 
-        AMQState state = waiter.await();
+        AMQState state = null;
+        try {
+            state = waiter.await();
+        } catch (AMQException e) {
+            //We need to close the network connection to shut down the IOProcessor created by Mina
+            network.close();
+            throw new AMQException("Error occurred while establishing a connection ", e);
+        }
 
         if(state == AMQState.CONNECTION_OPEN)
         {

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/pool/ReferenceCountingClientExecutorService.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/pool/ReferenceCountingClientExecutorService.java
@@ -1,0 +1,195 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.wso2.andes.client.pool;
+
+
+import org.wso2.andes.pool.ReadWriteJobQueue;
+import org.wso2.andes.pool.ReferenceCountingService;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.LinkedBlockingQueue;
+
+
+/**
+ * This class is a replica of org.wso2.andes.pool.ReferenceCountingClientExecutorService in andes-core/common module
+ * Reference class 'ReferenceCountingClientExecutorService' uses Guva library for thread pooling, which cannot be
+ * applied as a dependency for the client module, hence the difference between the following class
+ * ReferenceCountingClientExecutorService and ReferenceCountingClientExecutorService would be the usage of different
+ * thread factories
+ *
+ * @link ReferenceCountingClientExecutorService
+ */
+public class ReferenceCountingClientExecutorService implements ReferenceCountingService {
+
+
+    /**
+     * Defines the smallest thread pool that will be allocated, irrespective of the number of processors.
+     */
+    private static final int MINIMUM_POOL_SIZE = 4;
+
+    /**
+     * Holds the number of processors on the machine.
+     */
+    private static final int NUM_CPUS = Runtime.getRuntime().availableProcessors();
+
+    /**
+     * Defines the thread pool size to use, which is the larger of the number of CPUs or the minimum size.
+     */
+    private static final int DEFAULT_POOL_SIZE = Math.max(NUM_CPUS, MINIMUM_POOL_SIZE);
+
+    /**
+     * Holds the singleton instance of this reference counter. This is only created once, statically, so the
+     * {@link #getInstance()} method does not need to be synchronized.
+     */
+    private static final ReferenceCountingClientExecutorService _instance = new
+            ReferenceCountingClientExecutorService();
+
+    /**
+     * This lock is used to ensure that reference counts are updated atomically with create/destroy operations.
+     */
+    private final Object _lock = new Object();
+
+    /**
+     * The shared executor service that is reference counted.
+     */
+    private ExecutorService _pool;
+
+    /**
+     * Holds the number of references given out to the executor service.
+     */
+    private int _refCount = 0;
+
+    /**
+     * Holds the number of executor threads to create.
+     */
+    private int _poolSize = Integer.getInteger("amqj.read_write_pool_size", DEFAULT_POOL_SIZE);
+
+    /**
+     * Thread Factory used to create Job thread pool.
+     */
+    private ThreadFactory _threadFactory = Executors.defaultThreadFactory();
+
+    private final boolean _useBiasedPool = Boolean.getBoolean("org.apache.qpid.use_write_biased_pool");
+
+    /**
+     * Retrieves the singleton instance of this reference counter.
+     *
+     * @return The singleton instance of this reference counter.
+     */
+    public static ReferenceCountingClientExecutorService getInstance() {
+        return _instance;
+    }
+
+    /**
+     * Private constructor to ensure that only a singleton instance can be created.
+     */
+    private ReferenceCountingClientExecutorService() {
+    }
+
+    /**
+     * Provides a reference to a shared executor service, incrementing the reference count.
+     *
+     * @return An executor service.
+     */
+    public ExecutorService acquireExecutorService() {
+        synchronized (_lock) {
+            if (_refCount++ == 0) {
+                // Use a job queue that biases to writes
+                if (_useBiasedPool) {
+                    _pool = new ThreadPoolExecutor(_poolSize, _poolSize,
+                            0L, TimeUnit.MILLISECONDS,
+                            new ReadWriteJobQueue(),
+                            _threadFactory);
+
+                } else {
+                    _pool = new ThreadPoolExecutor(_poolSize, _poolSize,
+                            0L, TimeUnit.MILLISECONDS,
+                            new LinkedBlockingQueue<Runnable>(),
+                            _threadFactory);
+                }
+
+            }
+
+
+            return _pool;
+        }
+    }
+
+    /**
+     * Releases a reference to a shared executor service, decrementing the reference count. If the reference count falls
+     * to zero, the executor service is shut down.
+     */
+    public void releaseExecutorService() {
+        synchronized (_lock) {
+            if (--_refCount == 0) {
+                _pool.shutdownNow();
+            }
+        }
+    }
+
+    /**
+     * Provides access to the executor service, without touching the reference count.
+     *
+     * @return The shared executor service, or <tt>null</tt> if none has been instantiated yet.
+     */
+    public ExecutorService getPool() {
+        return _pool;
+    }
+
+    /**
+     * Return the ReferenceCount to this ExecutorService
+     *
+     * @return reference count
+     */
+    public int getReferenceCount() {
+        return _refCount;
+    }
+
+    /**
+     * Return the thread factory used by the {@link ThreadPoolExecutor} to create new threads.
+     *
+     * @return thread factory
+     */
+    public ThreadFactory getThreadFactory() {
+        return _threadFactory;
+    }
+
+    /**
+     * Sets the thread factory used by the {@link ThreadPoolExecutor} to create new threads.
+     * <p/>
+     * If the pool has been already created, the change will have no effect until
+     * {@link #getReferenceCount()} reaches zero and the pool recreated.  For this reason,
+     * callers must invoke this method <i>before</i> calling {@link #acquireExecutorService()}.
+     *
+     * @param threadFactory thread factory
+     */
+    public void setThreadFactory(final ThreadFactory threadFactory) {
+        if (threadFactory == null) {
+            throw new NullPointerException("threadFactory cannot be null");
+        }
+        _threadFactory = threadFactory;
+    }
+
+}

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/AMQProtocolHandler.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/AMQProtocolHandler.java
@@ -39,7 +39,6 @@ import org.wso2.andes.client.state.listener.SpecificMethodFrameListener;
 import org.wso2.andes.codec.AMQCodecFactory;
 import org.wso2.andes.framing.*;
 import org.wso2.andes.pool.Job;
-import org.wso2.andes.pool.ReferenceCountingExecutorService;
 import org.wso2.andes.protocol.AMQConstant;
 import org.wso2.andes.protocol.AMQMethodEvent;
 import org.wso2.andes.protocol.AMQMethodListener;
@@ -48,6 +47,7 @@ import org.wso2.andes.thread.Threading;
 import org.wso2.andes.transport.Sender;
 import org.wso2.andes.transport.network.NetworkConnection;
 import org.wso2.andes.transport.network.NetworkTransport;
+import org.wso2.andes.client.pool.ReferenceCountingClientExecutorService;
 
 import java.io.IOException;
 import java.net.SocketAddress;
@@ -164,7 +164,7 @@ public class AMQProtocolHandler implements ProtocolEngine
     private AMQCodecFactory _codecFactory;
     private Job _readJob;
     private Job _writeJob;
-    private ReferenceCountingExecutorService _poolReference = ReferenceCountingExecutorService.getInstance();
+    private ReferenceCountingClientExecutorService _poolReference = ReferenceCountingClientExecutorService.getInstance();
     private ProtocolVersion _suggestedProtocolVersion;
 
     private long _writtenBytes;

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/pool/Job.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/pool/Job.java
@@ -22,6 +22,7 @@ package org.wso2.andes.pool;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.andes.pool.ReferenceCountingService;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
@@ -70,11 +71,11 @@ public class Job implements ReadWriteRunnable
 
     private final boolean _readJob;
 
-    private ReferenceCountingExecutorService _poolReference;
+    private ReferenceCountingService _poolReference;
 
     private final static Logger _logger = LoggerFactory.getLogger(Job.class);
     
-    public Job(ReferenceCountingExecutorService poolReference, int maxEvents, boolean readJob)
+    public Job(ReferenceCountingService poolReference, int maxEvents, boolean readJob)
     {
         _poolReference = poolReference;
         _maxEvents = maxEvents;

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/pool/ReferenceCountingExecutorService.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/pool/ReferenceCountingExecutorService.java
@@ -21,6 +21,7 @@
 package org.wso2.andes.pool;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.wso2.andes.pool.ReferenceCountingService;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -62,7 +63,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  *       here. Could think about adding more state to the lifecycle, to mark ref counted objects as invalid, and have an
  *       isValid method, or could make calling code deal with RejectedExecutionException raised by shutdown executors.
  */
-public class ReferenceCountingExecutorService
+public class ReferenceCountingExecutorService implements ReferenceCountingService
 {
 
 

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/pool/ReferenceCountingService.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/pool/ReferenceCountingService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.pool;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Reference counting will be made by both andes server and the client for each job
+ * The following will provide a generalize interface for both server and the client
+ *
+ * @see ReferenceCountingService, ReferenceCountingClientService
+ */
+public interface ReferenceCountingService {
+    /**
+     * Provides access to the executor service
+     *
+     * @return shared executor service
+     */
+    ExecutorService getPool();
+}


### PR DESCRIPTION
In reference to https://wso2.org/jira/browse/MB-1659, Commit will fix the issue which has a thread leak in SocketConnectorIoProcessor. The PR also fixes the issue of requiring Guava dependency for client side reference counting.