### PR TITLE
 Messages requed after sending Recover-OK

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -38,6 +38,7 @@ import org.wso2.andes.subscription.LocalSubscription;
 import org.wso2.andes.subscription.SubscriptionEngine;
 import org.wso2.andes.tools.utils.MessageTracer;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -134,6 +135,19 @@ public class Andes {
         MAX_TX_BATCH_SIZE = AndesConfigurationManager.
                 readValue(AndesConfiguration.MAX_TRANSACTION_BATCH_SIZE);
         TX_EVENT_TIMEOUT = AndesConfigurationManager.readValue(AndesConfiguration.MAX_TRANSACTION_WAIT_TIMEOUT);
+    }
+
+    /**
+     * Recover message
+     *
+     * @param recoverMsg
+     *         message to be recovered
+     * @param subscription
+     *         channel id
+     * @throws AndesException
+     */
+    public void recoverMessage(List<DeliverableAndesMetadata> recoverMsg, LocalSubscription subscription) throws AndesException {
+        MessagingEngine.getInstance().recoverMessage(recoverMsg, subscription);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -95,6 +95,21 @@ public class MessagingEngine {
     private MessagingEngine() {
     }
 
+    /**
+     * Recover message
+     *
+     * @param andesMetadataList
+     *         message to be recovered
+     * @param subToResend
+     *         Subscription to send
+     * @throws AndesException
+     */
+    public void recoverMessage(List<DeliverableAndesMetadata> andesMetadataList, LocalSubscription subToResend) throws AndesException {
+        for (DeliverableAndesMetadata andesMetadata : andesMetadataList) {
+            reQueueMessageToSubscriber(andesMetadata, subToResend);
+        }
+    }
+
     static {
         log = Logger.getLogger(MessagingEngine.class);
         messagingEngine = new MessagingEngine();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRecoverMethodHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRecoverMethodHandler.java
@@ -19,16 +19,17 @@ package org.wso2.andes.server.handler;
 
 import org.apache.log4j.Logger;
 import org.wso2.andes.AMQException;
-import org.wso2.andes.framing.BasicRecoverBody;
-import org.wso2.andes.framing.BasicRecoverOkBody;
-import org.wso2.andes.framing.ProtocolVersion;
 import org.wso2.andes.framing.AMQMethodBody;
+import org.wso2.andes.framing.BasicRecoverBody;
+import org.wso2.andes.framing.ProtocolVersion;
 import org.wso2.andes.framing.amqp_8_0.MethodRegistry_8_0;
-import org.wso2.andes.protocol.AMQMethodEvent;
 import org.wso2.andes.server.AMQChannel;
 import org.wso2.andes.server.protocol.AMQProtocolSession;
+import org.wso2.andes.server.queue.QueueEntry;
 import org.wso2.andes.server.state.AMQStateManager;
 import org.wso2.andes.server.state.StateAwareMethodListener;
+
+import java.util.Map;
 
 public class BasicRecoverMethodHandler implements StateAwareMethodListener<BasicRecoverBody>
 {
@@ -54,7 +55,7 @@ public class BasicRecoverMethodHandler implements StateAwareMethodListener<Basic
             throw body.getChannelNotFoundException(channelId);
         }
 
-        channel.resend(body.getRequeue());
+        Map<Long, QueueEntry> recoveredMsgs = channel.recoverMessages(body.getRequeue());
 
         // Qpid 0-8 hacks a synchronous -ok onto recover.
         // In Qpid 0-9 we create a separate sync-recover, sync-recover-ok pair to be "more" compliant
@@ -66,5 +67,6 @@ public class BasicRecoverMethodHandler implements StateAwareMethodListener<Basic
 
         }
 
+        channel.resendRecoveredMessages(recoveredMsgs);
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRecoverSyncMethodHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRecoverSyncMethodHandler.java
@@ -20,19 +20,19 @@ package org.wso2.andes.server.handler;
 
 
 import org.apache.log4j.Logger;
-
-import org.wso2.andes.framing.BasicRecoverBody;
-import org.wso2.andes.framing.ProtocolVersion;
+import org.wso2.andes.AMQException;
 import org.wso2.andes.framing.AMQMethodBody;
 import org.wso2.andes.framing.BasicRecoverSyncBody;
-import org.wso2.andes.framing.amqp_0_91.MethodRegistry_0_91;
+import org.wso2.andes.framing.ProtocolVersion;
 import org.wso2.andes.framing.amqp_0_9.MethodRegistry_0_9;
-import org.wso2.andes.framing.amqp_8_0.MethodRegistry_8_0;
-import org.wso2.andes.server.state.StateAwareMethodListener;
-import org.wso2.andes.server.state.AMQStateManager;
-import org.wso2.andes.server.protocol.AMQProtocolSession;
+import org.wso2.andes.framing.amqp_0_91.MethodRegistry_0_91;
 import org.wso2.andes.server.AMQChannel;
-import org.wso2.andes.AMQException;
+import org.wso2.andes.server.protocol.AMQProtocolSession;
+import org.wso2.andes.server.queue.QueueEntry;
+import org.wso2.andes.server.state.AMQStateManager;
+import org.wso2.andes.server.state.StateAwareMethodListener;
+
+import java.util.Map;
 
 public class BasicRecoverSyncMethodHandler implements StateAwareMethodListener<BasicRecoverSyncBody>
 {
@@ -58,7 +58,7 @@ public class BasicRecoverSyncMethodHandler implements StateAwareMethodListener<B
             throw body.getChannelNotFoundException(channelId);
         }
 
-        channel.resend(body.getRequeue());
+        Map<Long, QueueEntry> recoveredMsgs = channel.recoverMessages(body.getRequeue());
 
         // Qpid 0-8 hacks a synchronous -ok onto recover.
         // In Qpid 0-9 we create a separate sync-recover, sync-recover-ok pair to be "more" compliant
@@ -77,5 +77,6 @@ public class BasicRecoverSyncMethodHandler implements StateAwareMethodListener<B
 
         }
 
+        channel.resendRecoveredMessages(recoveredMsgs);
     }
 }


### PR DESCRIPTION
This is done to avoid messages being redelivered before Recover-OK
is sent to the client.