### PR TITLE
Fix pool job closing issue before sending Close-OK

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/ConnectionCloseMethodHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/ConnectionCloseMethodHandler.java
@@ -19,11 +19,9 @@ package org.wso2.andes.server.handler;
 
 import org.apache.log4j.Logger;
 import org.wso2.andes.AMQException;
-import org.wso2.andes.framing.AMQFrame;
 import org.wso2.andes.framing.ConnectionCloseBody;
 import org.wso2.andes.framing.ConnectionCloseOkBody;
 import org.wso2.andes.framing.MethodRegistry;
-import org.wso2.andes.protocol.AMQMethodEvent;
 import org.wso2.andes.server.protocol.AMQProtocolSession;
 import org.wso2.andes.server.state.AMQStateManager;
 import org.wso2.andes.server.state.StateAwareMethodListener;
@@ -63,7 +61,7 @@ public class ConnectionCloseMethodHandler implements StateAwareMethodListener<Co
 
         MethodRegistry methodRegistry = session.getMethodRegistry();
         ConnectionCloseOkBody responseBody = methodRegistry.createConnectionCloseOkBody();
-        session.writeFrame(responseBody.generateFrame(channelId));
+        session.writeFrameSynchronously(responseBody.generateFrame(channelId));
 
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/protocol/AMQProtocolEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/protocol/AMQProtocolEngine.java
@@ -506,6 +506,20 @@ public class AMQProtocolEngine implements ProtocolEngine, Managable, AMQProtocol
         });
     }
 
+    /**
+     * Method that writes a frame to the protocol session synchronously.
+     *
+     * @param frame the frame to write
+     */
+    public void writeFrameSynchronously(AMQDataBlock frame)
+    {
+        _lastSent = frame;
+        final ByteBuffer buf = frame.toNioByteBuffer();
+        _lastIoTime = System.currentTimeMillis();
+        _writtenBytes += buf.remaining();
+        _sender.send(buf);
+    }
+
     public AMQShortString getContextKey()
     {
         return _contextKey;

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/AMQProtocolSession.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/AMQProtocolSession.java
@@ -311,6 +311,16 @@ public class AMQProtocolSession implements AMQVersionAwareProtocolSession
         _protocolHandler.writeFrame(frame);
     }
 
+    /**
+     * Method that writes a frame to the protocol session synchronously.
+     *
+     * @param frame the frame to write
+     */
+    public void writeFrameSynchronously(AMQDataBlock frame)
+    {
+        _protocolHandler.writeFrame(frame, true);
+    }
+
     public void writeFrame(AMQDataBlock frame, boolean wait)
     {
         _protocolHandler.writeFrame(frame, wait);

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/pool/ReferenceCountingExecutorService.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/pool/ReferenceCountingExecutorService.java
@@ -22,15 +22,12 @@ package org.wso2.andes.pool;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.wso2.andes.pool.ReferenceCountingService;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.LinkedBlockingQueue;
 
 
 /**

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/protocol/AMQProtocolWriter.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/protocol/AMQProtocolWriter.java
@@ -35,9 +35,17 @@ import org.wso2.andes.framing.AMQDataBlock;
 public interface AMQProtocolWriter
 {
     /**
-     * Writes a frame to the wire, encoding it as necessary, for example, into a sequence of bytes.
+     * Writes a frame to the wire asynchronously, encoding it as necessary, for example, into a sequence of bytes.
      *
      * @param frame The frame to be encoded and written.
      */
     public void writeFrame(AMQDataBlock frame);
+
+    /**
+     * Writes a frame to the wire synchronously, encoding it as necessary, for example, into a sequence of bytes.
+     *
+     * @param frame The frame to be encoded and written.
+     */
+    public void writeFrameSynchronously(AMQDataBlock frame);
+
 }


### PR DESCRIPTION
Add a synchronous method to write the Close-OK frame to client since
in session.closeSession() we shutdown the pool job if no consumers
are left.