### PR TITLE
Fix MB-1678

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlManager.java
@@ -93,7 +93,8 @@ public class FlowControlManager  implements StoreHealthListener, NetworkPartitio
     /**
      * Set to true if there are global level error(s) occurred 
      */
-    private boolean globalErrorBasedFlowControlEnabled;
+    private volatile boolean globalErrorBasedFlowControlEnabled;
+
     /**
      * Global flow control time out task
      */
@@ -132,7 +133,7 @@ public class FlowControlManager  implements StoreHealthListener, NetworkPartitio
 
         FailureObservingStoreManager.registerStoreHealthListener(this);
         if ( AndesContext.getInstance().isClusteringEnabled()){ // network partition detection works only when clustered.
-            AndesContext.getInstance().getClusterAgent().addNetworkPartitionListener(this);
+            AndesContext.getInstance().getClusterAgent().addNetworkPartitionListener(20, this);
         }
         // Initialize executor service for state validity checking
         ThreadFactory namedThreadFactory = new ThreadFactoryBuilder().setNameFormat("AndesScheduledTaskManager-FlowControl")

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotCoordinatorCluster.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotCoordinatorCluster.java
@@ -37,7 +37,7 @@ public class SlotCoordinatorCluster implements SlotCoordinator, NetworkPartition
     public SlotCoordinatorCluster(){
         nodeId = AndesContext.getInstance().getClusterAgent().getLocalNodeIdentifier();
         instance = new ThriftSlotCoordinator();
-        AndesContext.getInstance().getClusterAgent().addNetworkPartitionListener(this);
+        AndesContext.getInstance().getClusterAgent().addNetworkPartitionListener(30, this);
     }
 
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeletionExecutor.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeletionExecutor.java
@@ -18,19 +18,18 @@
 
 package org.wso2.andes.kernel.slot;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.kernel.AndesContext;
 import org.wso2.andes.kernel.MessagingEngine;
 import org.wso2.andes.server.cluster.error.detection.NetworkPartitionListener;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This class is responsible for deleting slots and scheduling slot deletions.
@@ -76,7 +75,7 @@ public class SlotDeletionExecutor implements NetworkPartitionListener{
     public void init() {
         
         if ( AndesContext.getInstance().isClusteringEnabled()){ // network partition detection works only when clustered.
-            AndesContext.getInstance().getClusterAgent().addNetworkPartitionListener(this);
+            AndesContext.getInstance().getClusterAgent().addNetworkPartitionListener(40, this);
         }
         
         this.slotDeletionExecutorService = Executors.newSingleThreadExecutor(namedThreadFactory);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/ClusterAgent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/ClusterAgent.java
@@ -87,8 +87,9 @@ public interface ClusterAgent {
      * Allows to register a listeners when there are network partitions. Hence
      * any implementation of Cluster Agent should provide a mechanism
      * to detect network partitions (if allowed via configuration)
-     * 
-     * @param listner any party required act on a network partition.
+     *
+     * @param priority listener priority (lower value has higher priority)
+     * @param listener any party required act on a network partition.
      */
-    void addNetworkPartitionListener(NetworkPartitionListener listner);
+    void addNetworkPartitionListener(int priority, NetworkPartitionListener listener);
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/HazelcastClusterAgent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/HazelcastClusterAgent.java
@@ -18,10 +18,10 @@
 
 package org.wso2.andes.server.cluster;
 
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.IdGenerator;
+import com.hazelcast.core.Member;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -41,10 +41,11 @@ import org.wso2.andes.server.cluster.error.detection.HazelcastBasedNetworkPartit
 import org.wso2.andes.server.cluster.error.detection.NetworkPartitionDetector;
 import org.wso2.andes.server.cluster.error.detection.NetworkPartitionListener;
 
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-import com.hazelcast.core.IdGenerator;
-import com.hazelcast.core.Member;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Hazelcast based cluster agent implementation
@@ -390,8 +391,11 @@ public class HazelcastClusterAgent implements ClusterAgent {
         return addresses;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public void addNetworkPartitionListener(NetworkPartitionListener listner) {
-        networkPartitionDetector.addNetworkPartitionListener(listner);
+    public void addNetworkPartitionListener(int priority, NetworkPartitionListener listener) {
+        networkPartitionDetector.addNetworkPartitionListener(priority, listener);
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/error/detection/DisabledNetworkPartitionDetector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/error/detection/DisabledNetworkPartitionDetector.java
@@ -60,7 +60,7 @@ public class DisabledNetworkPartitionDetector implements NetworkPartitionDetecto
      * {@inheritDoc}
      */
     @Override
-    public void addNetworkPartitionListener(NetworkPartitionListener listner) {
+    public void addNetworkPartitionListener(int priority, NetworkPartitionListener listner) {
         // Do nothing
 
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/error/detection/NetworkPartitionDetector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/error/detection/NetworkPartitionDetector.java
@@ -60,8 +60,9 @@ public interface NetworkPartitionDetector {
 
     /**
      * Registers a {@link NetworkPartitionListener} with the scheme.
-     * 
-     * @param listner
+     *
+     * @param listener
+     * @param priority
      */
-    void addNetworkPartitionListener(NetworkPartitionListener listner);
+    void addNetworkPartitionListener(int priority, NetworkPartitionListener listener);
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/protocol/AMQProtocolEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/protocol/AMQProtocolEngine.java
@@ -641,7 +641,7 @@ public class AMQProtocolEngine implements ProtocolEngine, Managable, AMQProtocol
         final AMQChannel channel = getChannel(channelId);
         if (channel == null)
         {
-            throw new IllegalArgumentException("Unknown channel id");
+            throw new AMQException("Unknown channel id " + channelId);
         }
         else
         {
@@ -1221,8 +1221,7 @@ public class AMQProtocolEngine implements ProtocolEngine, Managable, AMQProtocol
         }
     }
 
-    public void mgmtCloseChannel(int channelId)
-    {
+    public void mgmtCloseChannel(int channelId) throws AMQException {
         MethodRegistry methodRegistry = getMethodRegistry();
         ChannelCloseBody responseBody =
                 methodRegistry.createChannelCloseBody(
@@ -1245,14 +1244,7 @@ public class AMQProtocolEngine implements ProtocolEngine, Managable, AMQProtocol
         {
             writeFrame(responseBody.generateFrame(channelId));
 
-            try
-            {
-                closeChannel(channelId);
-            }
-            catch (AMQException ex)
-            {
-                throw new RuntimeException(ex);
-            }
+            closeChannel(channelId);
         }
         finally
         {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/protocol/AMQProtocolSession.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/protocol/AMQProtocolSession.java
@@ -227,5 +227,5 @@ public interface AMQProtocolSession extends AMQVersionAwareProtocolSession, Auth
 
     List<AMQChannel> getChannels();
 
-    void mgmtCloseChannel(int channelId);
+    void mgmtCloseChannel(int channelId) throws AMQException;
 }


### PR DESCRIPTION
- Make globalErrorBasedFlowControlEnabled variable volatile
- Throw AMQException instead of a Runtime exception when channel ID
  is not found. This done to continue network partition listener
  processing
- Process networkn partition listeners in order. A pririority level
  is introduced for each network partition listener. Additionally a
  network flag partition flag was introduced on AndesSubscription
  manager to block all subscription additions after a network
  partition was detected.