### PR TITLE
Use AMQP 0_91 version instead of 0_80 by default for published messages

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessageMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessageMetadata.java
@@ -82,6 +82,7 @@ public class AndesMessageMetadata implements Comparable<AndesMessageMetadata> {
     /**
      * The meta data type which specify which protocol this meta data belongs to``
      */
+    // TODO: Need to remove this type and use ProtocolType instead
     private MessageMetaDataType metaDataType;
 
     private boolean isCompressed;
@@ -302,7 +303,7 @@ public class AndesMessageMetadata implements Comparable<AndesMessageMetadata> {
         StorableMessageMetaData mdt = type.getFactory()
                 .createMetaData(buf);
         //todo need to discuss on making the flow more generic
-        if (type.equals(MessageMetaDataType.META_DATA_0_10) || type.equals(MessageMetaDataType.META_DATA_0_8)) {
+        if (type.equals(MessageMetaDataType.META_DATA_0_10) || type.equals(MessageMetaDataType.META_DATA_0_91)) {
             isPersistent = mdt.isPersistent();
             expirationTime = ((MessageMetaData) mdt).getMessageHeader().getExpiration();
             arrivalTime = mdt.getArrivalTime();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesUtils.java
@@ -244,8 +244,8 @@ public class AndesUtils {
         } else if (MessageMetaDataType.META_DATA_0_10 == metaDataType){
             // We set AMQP as the default
             protocolType = createProtocolType(ProtocolVersion.v0_10);
-        } else if (MessageMetaDataType.META_DATA_0_8 == metaDataType) {
-            protocolType = createProtocolType(ProtocolVersion.v8_0);
+        } else if (MessageMetaDataType.META_DATA_0_91 == metaDataType) {
+            protocolType = createProtocolType(ProtocolVersion.v0_91);
         } else {
             protocolType = createProtocolType(ProtocolVersion.defaultProtocolVersion());
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/message/MessageMetaData.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/message/MessageMetaData.java
@@ -158,7 +158,9 @@ public class MessageMetaData implements StorableMessageMetaData
 
     public MessageMetaDataType getType()
     {
-        return MessageMetaDataType.META_DATA_0_8;
+        /* TODO: Need to pick the correct information from ProtocolVersion class which can be referenced from the
+           channel this publishes messages and use ProtocolType here */
+        return MessageMetaDataType.META_DATA_0_91;
     }
 
     public boolean isCompressed() {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/store/MessageMetaDataType.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/store/MessageMetaDataType.java
@@ -24,8 +24,10 @@ import org.wso2.andes.server.message.MessageMetaData_0_10;
 import java.nio.ByteBuffer;
 
 public enum MessageMetaDataType
+    /* TODO: Need to remove this class and implement this using the ProtocolType and separate database columns
+       for each property instead of handling bytes */
 {
-    META_DATA_0_8  {   public Factory<MessageMetaData> getFactory() { return MessageMetaData.FACTORY; } },
+    META_DATA_0_91 {   public Factory<MessageMetaData> getFactory() { return MessageMetaData.FACTORY; } },
     META_DATA_0_10 {   public Factory<MessageMetaData_0_10> getFactory() { return MessageMetaData_0_10.FACTORY; } },
     META_DATA_MQTT {   public Factory<MQTTMessageMetaData> getFactory() { return MQTTMessageMetaData.FACTORY; } };
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/virtualhost/VirtualHostConfigRecoveryHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/virtualhost/VirtualHostConfigRecoveryHandler.java
@@ -158,7 +158,7 @@ public class VirtualHostConfigRecoveryHandler implements ConfigurationRecoveryHa
         ServerMessage serverMessage;
         switch(message.getMetaData().getType())
         {
-            case META_DATA_0_8:
+            case META_DATA_0_91:
                 serverMessage = new AMQMessage(message);
                 break;
             case META_DATA_0_10:


### PR DESCRIPTION
Use AMQP version 0_91 by default instead of 0_80 for published messages for resolving the correct subscription store.

The TODO's added here should get rectified when re-structuring the message meta data due for c5 which ultimately removes the hard coded version.