### PR TITLE
[MB-1682] Fixed issue of subscriptions being removed when nodes merge after split brain

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextStore.java
@@ -77,9 +77,17 @@ public interface AndesContextStore extends HealthAwareStore{
      *
      * @param subscription The subscriptoin object to update
      * @throws AndesException
+     * @return If a subscription was updated return 1, else return 0
      */
-    void updateDurableSubscription(AndesSubscription subscription)
-		    throws AndesException;
+    int updateDurableSubscription(AndesSubscription subscription) throws AndesException;
+
+    /**
+     * Update already the store if there is a matching subscription. Else, insert the subscription.
+     *
+     * @param subscription The subscriptoin object to update
+     * @throws AndesException
+     */
+    void updateOrInsertDurableSubscription(AndesSubscription subscription) throws AndesException;
 
     /**
      * Updates a List of subscriptions with a given subscriptionId and given subscription information.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesRecoveryTask.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesRecoveryTask.java
@@ -26,9 +26,12 @@ import org.wso2.andes.server.cluster.coordination.hazelcast.HazelcastAgent;
 import org.wso2.andes.store.FailureObservingStoreManager;
 import org.wso2.andes.store.HealthAwareStore;
 import org.wso2.andes.store.StoreHealthListener;
+import org.wso2.andes.subscription.SubscriptionEngine;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -42,10 +45,11 @@ public class AndesRecoveryTask implements Runnable, StoreHealthListener {
 	private List<ExchangeListener> exchangeListeners = new ArrayList<>();
 	private List<BindingListener> bindingListeners = new ArrayList<>();
 
-	AndesContextStore andesContextStore;
-	AMQPConstructStore amqpConstructStore;
+	private AndesContextStore andesContextStore;
+	private AMQPConstructStore amqpConstructStore;
+	private SubscriptionEngine subscriptionEngine;
 
-    AtomicBoolean isRunning;
+    private AtomicBoolean isRunning;
 
 	// set storeOperational to true since it can be assumed that the store is operational at startup
 	// if it is non-operational, the value will be updated immediately
@@ -62,6 +66,7 @@ public class AndesRecoveryTask implements Runnable, StoreHealthListener {
 		exchangeListeners.add(new ClusterCoordinationHandler(HazelcastAgent.getInstance()));
 		bindingListeners.add(new ClusterCoordinationHandler(HazelcastAgent.getInstance()));
 
+		subscriptionEngine = AndesContext.getInstance().getSubscriptionEngine();
 		andesContextStore = AndesContext.getInstance().getAndesContextStore();
 		amqpConstructStore = AndesContext.getInstance().getAMQPConstructStore();
         isRunning = new AtomicBoolean(false);
@@ -103,12 +108,28 @@ public class AndesRecoveryTask implements Runnable, StoreHealthListener {
 	 */
 	public void recoverExchangesQueuesBindingsSubscriptions() throws AndesException {
 		if (isContextStoreOperational.get()) {
+
+			Set<AndesSubscription> subList = subscriptionEngine.getActiveLocalSubscribersForNode();
+			notifyLocalSubscriptionListToMembers(subList);
 			reloadExchangesFromDB();
 			reloadQueuesFromDB();
 			reloadBindingsFromDB();
 			reloadSubscriptions();
 		} else {
 			log.warn("AndesRecoveryTask was paused due to non-operational context store.");
+		}
+	}
+
+	/**
+	 * Notify cluster members a merge
+	 *
+	 * @param subscriptionList
+	 * @throws AndesException
+	 */
+	private void notifyLocalSubscriptionListToMembers(Collection<AndesSubscription> subscriptionList)
+			throws AndesException {
+		for (AndesSubscription localSubscription : subscriptionList) {
+			andesContextStore.updateOrInsertDurableSubscription(localSubscription);
 		}
 	}
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesSubscriptionManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesSubscriptionManager.java
@@ -460,21 +460,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener {
      * @throws AndesException
      */
     public void updateSubscriptionsAfterClusterMerge() throws AndesException {
-        Set<AndesSubscription> subList = subscriptionEngine.getActiveLocalSubscribersForNode();
-        notifyLocalSubscriptionListToMembers(subList);
         HazelcastAgent.getInstance().notifyDBSyncEvent(new ClusterNotification("", "", ""));
-    }
-
-    /**
-     * Notify cluster members a merge
-     * @param subscriptionList
-     * @throws AndesException
-     */
-    private void notifyLocalSubscriptionListToMembers(Collection<AndesSubscription> subscriptionList)
-            throws AndesException{
-        for (AndesSubscription localSubscription: subscriptionList) {
-            AndesContext.getInstance().getAndesContextStore().updateDurableSubscription(localSubscription);
-        }
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingAndesContextStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingAndesContextStore.java
@@ -134,9 +134,22 @@ public class FailureObservingAndesContextStore implements AndesContextStore {
      * {@inheritDoc}
      */
     @Override
-    public void updateDurableSubscription(AndesSubscription subscription) throws AndesException {
+    public int updateDurableSubscription(AndesSubscription subscription) throws AndesException {
         try {
-            wrappedAndesContextStoreInstance.updateDurableSubscription(subscription);
+            return wrappedAndesContextStoreInstance.updateDurableSubscription(subscription);
+        } catch (AndesStoreUnavailableException exception) {
+            notifyFailures(exception);
+            throw exception;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void updateOrInsertDurableSubscription(AndesSubscription subscription) throws AndesException {
+        try {
+            wrappedAndesContextStoreInstance.updateOrInsertDurableSubscription(subscription);
         } catch (AndesStoreUnavailableException exception) {
             notifyFailures(exception);
             throw exception;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSAndesContextStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSAndesContextStoreImpl.java
@@ -232,7 +232,7 @@ public class RDBMSAndesContextStoreImpl implements AndesContextStore {
      * {@inheritDoc}
      */
     @Override
-    public void updateDurableSubscription(AndesSubscription subscription) throws AndesException {
+    public int updateDurableSubscription(AndesSubscription subscription) throws AndesException {
         Connection connection = null;
         PreparedStatement preparedStatement = null;
         Context contextWrite = MetricManager.timer(Level.INFO, MetricsConstants.DB_WRITE).start();
@@ -249,9 +249,10 @@ public class RDBMSAndesContextStoreImpl implements AndesContextStore {
             preparedStatement.setString(1, subscription.encodeAsStr());
             preparedStatement.setString(2, destinationIdentifier);
             preparedStatement.setString(3, subscriptionID);
-            preparedStatement.executeUpdate();
 
+            int updateCount = preparedStatement.executeUpdate();
             connection.commit();
+            return updateCount;
 
         } catch (SQLException e) {
             rollback(connection, RDBMSConstants.TASK_UPDATING_DURABLE_SUBSCRIPTION);
@@ -261,6 +262,17 @@ public class RDBMSAndesContextStoreImpl implements AndesContextStore {
             contextWrite.stop();
             close(preparedStatement, RDBMSConstants.TASK_UPDATING_DURABLE_SUBSCRIPTION);
             close(connection, RDBMSConstants.TASK_UPDATING_DURABLE_SUBSCRIPTION);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void updateOrInsertDurableSubscription(AndesSubscription subscription) throws AndesException {
+        int updateCount = updateDurableSubscription(subscription);
+        if (0 == updateCount) {
+            storeDurableSubscription(subscription);
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/subscription/SubscriptionEngine.java
@@ -328,6 +328,20 @@ public class SubscriptionEngine {
     }
 
     /**
+     * Update the subscription in the database with the give subscription. If such a subscription is not present in the
+     * database, add the subscription.
+     *
+     * @param subscription
+     * @throws AndesException
+     */
+    public void updateOrInsertLocalSubscriptionInDB(LocalSubscription subscription) throws AndesException {
+        int updatedCount = andesContextStore.updateDurableSubscription(subscription);
+        if (0 == updatedCount) {
+            andesContextStore.storeDurableSubscription(subscription);
+        }
+    }
+
+    /**
      * Directly remove a subscription from store
      *
      * @param subscriptionToRemove subscription to remove


### PR DESCRIPTION
Addresses the issue reported at https://wso2.org/jira/browse/MB-1682

The solution for this was to modify the db sync task so that the database get first updated with the entries in the local subscriptions map, then update the cluster map according to what's in the database. This will prioritize the local subscription map over the db thus the cluster subscriptions map will be consistent with the local subscriptions map.
