### PR TITLE
[MB-1694] Modified partition listener to get the number of cluster members through membership event fired by memberAdded and memberRemoved method.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/HazelcastLifecycleListener.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/HazelcastLifecycleListener.java
@@ -26,9 +26,7 @@ import org.wso2.andes.server.ClusterResourceHolder;
 import org.wso2.andes.server.cluster.coordination.hazelcast.HazelcastAgent;
 import org.wso2.andes.server.cluster.error.detection.NetworkPartitionDetector;
 
-import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleEvent.LifecycleState;
-import com.hazelcast.core.LifecycleListener;
 
 /**
  * Hazelcast Lifecycle events are monitored through this listener. MB state and Hazelcast data structures are updated
@@ -78,13 +76,13 @@ public class HazelcastLifecycleListener implements LifecycleListener {
                 }
                 
                 // Notify that network partition has occurred.
-                networkPartitionDetector.networkPatitionMerged();
-                
+                networkPartitionDetector.networkPartitionMerged();
+
             } else if (lifecycleEvent.getState() == LifecycleState.SHUTDOWN){
-                networkPartitionDetector.clusterOutageOccured();
+                networkPartitionDetector.clusterOutageOccurred();
             }
-            
-            
+
+
         } catch (Throwable e) {
             log.error("Error occurred while handling Hazelcast state change event " + lifecycleEvent.getState(), e);
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/HazelcastClusterAgent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/HazelcastClusterAgent.java
@@ -144,9 +144,10 @@ public class HazelcastClusterAgent implements ClusterAgent {
      *
      * @param member
      *            New member
+     * @param clusterSize The number of members in the cluster.
      */
-    public void memberAdded(Member member) {
-        networkPartitionDetector.memberAdded(member);
+    public void memberAdded(Member member, int clusterSize) {
+        networkPartitionDetector.memberAdded(member, clusterSize);
         checkAndNotifyCoordinatorChange();
         manager.memberAdded(CoordinationConstants.NODE_NAME_PREFIX + member.getSocketAddress());
     }
@@ -156,17 +157,18 @@ public class HazelcastClusterAgent implements ClusterAgent {
      *
      * @param member
      *            member who left
+     * @param clusterSize The number of members in the cluster.
      * @throws AndesException
      */
-    public void memberRemoved(Member member) throws AndesException {
-        networkPartitionDetector.memberRemoved(member);
+    public void memberRemoved(Member member, int clusterSize) throws AndesException {
+        networkPartitionDetector.memberRemoved(member, clusterSize);
         checkAndNotifyCoordinatorChange();
         manager.memberRemoved(getIdOfNode(member));
     }
 
     
     public void networkPatitionMerged(){
-    	networkPartitionDetector.networkPatitionMerged();
+    	networkPartitionDetector.networkPartitionMerged();
     }
     
     /**
@@ -230,7 +232,7 @@ public class HazelcastClusterAgent implements ClusterAgent {
         }
 
         networkPartitionDetector.start();
-        memberAdded(hazelcastInstance.getCluster().getLocalMember());
+        memberAdded(hazelcastInstance.getCluster().getLocalMember(), hazelcastInstance.getCluster().getMembers().size());
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/AndesMembershipListener.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/AndesMembershipListener.java
@@ -59,7 +59,7 @@ public class AndesMembershipListener implements MembershipListener {
         log.info("Handling cluster gossip: New member joined to the cluster. Member Socket Address:"
                  + member.getSocketAddress() + " UUID:" + member.getUuid());
 
-        hazelcastAgent.memberAdded(membershipEvent.getMember());
+        hazelcastAgent.memberAdded(membershipEvent.getMember(), membershipEvent.getMembers().size());
     }
 
     /**
@@ -86,7 +86,7 @@ public class AndesMembershipListener implements MembershipListener {
                  + member.getSocketAddress() + " UUID:" + member.getUuid());
 
         try {
-            hazelcastAgent.memberRemoved(member);
+            hazelcastAgent.memberRemoved(member, membershipEvent.getMembers().size());
         } catch (Exception e) {
             log.error("Error while handling node removal, NodeID:" + hazelcastAgent.getIdOfNode(member), e);
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/error/detection/DisabledNetworkPartitionDetector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/error/detection/DisabledNetworkPartitionDetector.java
@@ -36,7 +36,7 @@ public class DisabledNetworkPartitionDetector implements NetworkPartitionDetecto
      * {@inheritDoc}
      */
     @Override
-    public void memberAdded(Object member) {
+    public void memberAdded(Object member, int clusterSize) {
         // Do nothing
     }
 
@@ -44,7 +44,7 @@ public class DisabledNetworkPartitionDetector implements NetworkPartitionDetecto
      * {@inheritDoc}
      */
     @Override
-    public void memberRemoved(Object member) {
+    public void memberRemoved(Object member, int clusterSize) {
         // Do nothing
     }
 
@@ -52,7 +52,7 @@ public class DisabledNetworkPartitionDetector implements NetworkPartitionDetecto
      * {@inheritDoc}
      */
     @Override
-    public void networkPatitionMerged() {
+    public void networkPartitionMerged() {
         // Do nothing
     }
 
@@ -69,7 +69,7 @@ public class DisabledNetworkPartitionDetector implements NetworkPartitionDetecto
      * {@inheritDoc}
      */
     @Override
-    public void clusterOutageOccured() {
+    public void clusterOutageOccurred() {
      // Do nothing
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/error/detection/NetworkPartitionDetector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/error/detection/NetworkPartitionDetector.java
@@ -34,27 +34,29 @@ public interface NetworkPartitionDetector {
      * 
      * @param member
      *            information about newly added node.
+     * @param clusterSize The number of members after member has been added.
      */
-    void memberAdded(Object member);
+    void memberAdded(Object member, int clusterSize);
 
     /**
      * Invoked when a member/node leaves the cluster.
-     * 
+     *
      * @param member
      *            information about disconnected node.
+     * @param clusterSize The number of members after member has been removed.
      */
-    void memberRemoved(Object member);
+    void memberRemoved(Object member, int clusterSize);
 
     /**
      * Invoked when clustering mechanism ( / library, i.e. Hazelcast) detects
      * that network partition(s) have been resolved.
      */
-    void networkPatitionMerged();
+    void networkPartitionMerged();
 
     /**
      * Invoked when clustering framework shutdown or encountered a fatal error.
      */
-    void clusterOutageOccured();
+    void clusterOutageOccurred();
 
     /**
      * Registers a {@link NetworkPartitionListener} with the scheme.
@@ -62,5 +64,4 @@ public interface NetworkPartitionDetector {
      * @param listner
      */
     void addNetworkPartitionListener(NetworkPartitionListener listner);
-    
 }


### PR DESCRIPTION
Instead of getting the number of members through hazelcast agent, the number of member will be taken from the membershipEvent that occurs on memberAdded and memberRemoved.