### PR TITLE
[MB-1699] Added custom property for message to store original destination.

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/BasicMessageProducer_0_8.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/BasicMessageProducer_0_8.java
@@ -33,7 +33,6 @@ import org.wso2.andes.client.message.AbstractJMSMessage;
 import org.wso2.andes.client.message.AMQMessageDelegate_0_8;
 import org.wso2.andes.client.protocol.AMQProtocolHandler;
 import org.wso2.andes.framing.AMQFrame;
-import org.wso2.andes.framing.BasicConsumeBody;
 import org.wso2.andes.framing.BasicContentHeaderProperties;
 import org.wso2.andes.framing.BasicPublishBody;
 import org.wso2.andes.framing.CompositeAMQDataBlock;
@@ -107,6 +106,11 @@ public class BasicMessageProducer_0_8 extends BasicMessageProducer
 
         //Set JMS_QPID_DESTTYPE
         delegate.getContentHeaderProperties().getHeaders().setInteger(CustomJMSXProperty.JMS_QPID_DESTTYPE.getShortStringName(), type);
+        //Set JMS_ANDES_ROUTING_KEY
+        if (null != System.getProperty("AndesSetRoutingKey")) {
+            delegate.getContentHeaderProperties().getHeaders().setString(
+                CustomJMSXProperty.JMS_ANDES_ROUTING_KEY.getShortStringName(), destination.getRoutingKey().asString());
+        }
 
         if (!_disableTimestamps)
         {

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/CustomJMSXProperty.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/CustomJMSXProperty.java
@@ -33,7 +33,8 @@ public enum CustomJMSXProperty
     JMS_QPID_DESTTYPE,
     JMSXGroupID,
     JMSXGroupSeq,
-    JMSXUserID;
+    JMSXUserID,
+    JMS_ANDES_ROUTING_KEY;
 
     private static List<String> _names;
 


### PR DESCRIPTION
This PR contains a feature which adds a routing key as a JMS message property for messages. 
To activate this feature, set any value to "AndesSetRoutingKey" system property from publisher client side.

JIRA - https://wso2.org/jira/browse/MB-1699