### PR TITLE
Revert "Wait for SlotDeliveryWorker to stop it's running thread before completing stop delivery"

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorker.java
@@ -71,7 +71,6 @@ public class SlotDeliveryWorker extends Thread implements StoreHealthListener, N
      * This map contains slotId to slot hash map against queue name
      */
     private volatile boolean running;
-    private volatile boolean threadCompleted;
     private MessageFlusher messageFlusher;
     private SlotCoordinator slotCoordinator;
 
@@ -128,7 +127,6 @@ public class SlotDeliveryWorker extends Thread implements StoreHealthListener, N
          * deliver them
          */
         running = true;
-        threadCompleted = false;
         while (running) {
 
             //Iterate through all the queues registered in this thread
@@ -244,8 +242,6 @@ public class SlotDeliveryWorker extends Thread implements StoreHealthListener, N
         }
 
         log.info("SlotDeliveryWorker stopped. Thread name " + Thread.currentThread().getName() + " with Thread Id : " + this.getId());
-
-        threadCompleted = true;
     }
 
     /**
@@ -446,27 +442,6 @@ public class SlotDeliveryWorker extends Thread implements StoreHealthListener, N
      */
     public void setRunning(boolean running) {
         this.running = running;
-
-        /* If running is false, we have to wait until thread finishes
-
-          Below function works similar to thread.join() but due to following reason we cannot use thread.join() here.
-
-          1. Since this thread is invoked from a thread pool executor, this.join() will not invoke the real running
-              threads' join() method. For this we have to get Thread.currentThread() from inside run method and
-              keep a reference to allow access from outside.
-          2. Although we can get the thread reference as above, threadReference.join() will wait indefinitely since
-             thread pool executor does not terminate the threads when the processing is finished, it keeps the threads
-             in WAITING state to be executed again if asked to.
-         */
-        if (!running) {
-            while (!threadCompleted) {
-                try {
-                    Thread.sleep(100L);
-                } catch (InterruptedException e) {
-                    log.warn("Error waiting for SlotDeliveryWorker to complete", e);
-                }
-            }
-        }
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorkerManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeliveryWorkerManager.java
@@ -154,13 +154,7 @@ public class SlotDeliveryWorkerManager {
                 log.debug("Stopping delivery for storage queue " + storageQueueName +
                         " with SlotDeliveryWorker : " + slotWorker.getId());
             }
-
-            /* synchronizing so that while stopDelivery is completing, startDelivery will be waiting if called.
-              If, stop delivery is to stop the delivery worker since no subscribers, it has to be completed
-              before calling the start delivery again for the same SlotDeliveryWorker */
-            synchronized (this) {
-                slotWorker.stopDeliveryForQueue(storageQueueName);
-            }
+            slotWorker.stopDeliveryForQueue(storageQueueName);
         }
     }
 


### PR DESCRIPTION
Reverts wso2/andes#603 due to deadlock issue[1] introduced by changes in SlotDeliveryWorker.setRunning().

This will reopens the MB-1671 issue fixed by wso2/andes#603.

[1] https://wso2.org/jira/browse/MB-1696
[2] https://wso2.org/jira/browse/MB-1671