### PR TITLE
[OnHold] Implementing delivery delay for requeued messages.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -68,6 +68,20 @@ public enum AndesConfiguration implements ConfigurationProperty {
     COORDINATION_NODE_ID("coordination/nodeID", "default", String.class),
 
     /**
+     * By default, when a message is rejected, MB will resend the message with 0ms delay.
+     * This delay value can be configured by the following value. The configuration applied for all requeued messages.
+     * Value is in milliseconds.
+     */
+    MESSAGE_REDELIVERY_DELAY("redeliveryDelay/messageRedeliveryDelay", "0", Long.class),
+
+    /**
+     * This value will only be taken into account when "redeliveryDelay/messageRedeliveryDelay" value is greater
+     * than 0ms. This time interval represents the interval between the tasks of redelivering requeued messages.
+     * Value is in milliseconds.
+     */
+    MESSAGE_REDELIVERY_EXECUTION_INTERVAL("redeliveryDelay/executionInterval", "100", Long.class),
+
+    /**
      * The IP address to which mqtt/amqp channels should be bound.
      */
     TRANSPORTS_BIND_ADDRESS("transports/bindAddress", "*", String.class),

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DelayedDeliveryTask.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DelayedDeliveryTask.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.subscription.LocalSubscription;
+import org.wso2.andes.tools.utils.MessageTracer;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+/**
+ * Delayed delivery task will deliver rejected messages from a delayed queue which is inside a subscription.
+ */
+public class DelayedDeliveryTask implements Runnable {
+    private static final Log log = LogFactory.getLog(DelayedDeliveryTask.class);
+    Set<LocalSubscription> subscriptionsWithRejectedMessages = new ConcurrentSkipListSet<>();
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     *     Each subscription is taken iteratively and a rejected message is then delivered. If a subscription
+     * </p>
+     */
+    @Override
+    public void run() {
+        try {
+            Iterator<LocalSubscription> subscriptionIterator = subscriptionsWithRejectedMessages.iterator();
+            while (subscriptionIterator.hasNext()) {
+                LocalSubscription subscription = subscriptionIterator.next();
+                BlockingQueue<RejectedMessage> rejectedMessages = subscription.getRejectedMessages();
+                if (!rejectedMessages.isEmpty()) {
+                    List<RejectedMessage> rejectedMessageList = new ArrayList<>();
+                    // Get all expired messages to a list of a specific subscriber.
+                    rejectedMessages.drainTo(rejectedMessageList);
+                    for (RejectedMessage message : rejectedMessageList) {
+                        MessageFlusher.getInstance().scheduleMessageForSubscription(subscription,
+                                                                                message.getDeliverableAndesMetadata());
+                        //Tracing message activity
+                        MessageTracer.trace(message.getDeliverableAndesMetadata(),
+                                                                            MessageTracer.MESSAGE_REQUEUED_SUBSCRIBER);
+                    }
+                } else {
+                    // Remove the subscription from the subscription list as there are no more requeued messages.
+                    subscriptionIterator.remove();
+                }
+            }
+        } catch (AndesException e) {
+            log.error("Error occurred while scheduling messages to subscription by delayed delivery task.", e);
+        }
+    }
+
+    /**
+     * Adds new subscription which has rejected messages.
+     *
+     * @param localSubscription The subscription.
+     */
+    public void addSubscription(LocalSubscription localSubscription) {
+        subscriptionsWithRejectedMessages.add(localSubscription);
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/RejectedMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/RejectedMessage.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A wrapper class for rejected messages which supports delayed delivery.
+ */
+public class RejectedMessage implements Delayed {
+    /**
+     * Time at which the rejected message was created. This is required to make the calculation of the delay when popped
+     * from the queue.
+     */
+    private final long timeOfRejectedMessageCreated;
+
+    /**
+     * The delay to be hold by the broker.
+     */
+    private final long deliveryDelay;
+
+    /**
+     * The andes message metadata.
+     */
+    private final DeliverableAndesMetadata deliverableAndesMetadata;
+
+    /**
+     * Created new instance of a rejected message.
+     *
+     * @param deliveryDelay            The delay at which the rejected message should be held upon.
+     * @param deliverableAndesMetadata The message metadata.
+     */
+    public RejectedMessage(long deliveryDelay, DeliverableAndesMetadata deliverableAndesMetadata) {
+        this.timeOfRejectedMessageCreated = System.currentTimeMillis();
+        this.deliveryDelay = deliveryDelay;
+        this.deliverableAndesMetadata = deliverableAndesMetadata;
+    }
+
+    public DeliverableAndesMetadata getDeliverableAndesMetadata() {
+        return deliverableAndesMetadata;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getDelay(TimeUnit timeUnit) {
+        return timeUnit.convert(deliveryDelay - (System.currentTimeMillis() - timeOfRejectedMessageCreated),
+                TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int compareTo(Delayed rejectedMessage) {
+        if (this == rejectedMessage) {
+            return 0;
+        }
+
+        if (rejectedMessage instanceof RejectedMessage) {
+            return new Long(deliveryDelay - ((RejectedMessage) rejectedMessage).deliveryDelay).intValue();
+        }
+
+        return new Long(getDelay(TimeUnit.MILLISECONDS) - rejectedMessage.getDelay(TimeUnit.MILLISECONDS)).intValue();
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/tools/utils/MessageTracer.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/tools/utils/MessageTracer.java
@@ -44,6 +44,7 @@ public class MessageTracer {
     public static final String DISPATCHED_TO_PROTOCOL ="dispatched to protocol level for delivery";
     public static final String MESSAGE_REJECTED = "message rejected";
     public static final String MESSAGE_REQUEUED_SUBSCRIBER = "message re-queued to subscriber";
+    public static final String MESSAGE_DELAYED_FOR_DELIVERY = "message sent to delayed delivery scheduler,delay: %dms.";
     public static final String MOVED_TO_DLC = "message moved to DLC";
     public static final String MESSAGE_DELETED = "message deleted";
     public static final String ACK_RECEIVED_FROM_PROTOCOL = "ACK received from protocol";


### PR DESCRIPTION
Currently when a message is being rejected by a subscriber client, the client is able to delay returning the message to the server. This is done by setting the "AndesAckWaitTimeOut" system property. 

But the message cannot be delayed from the server side. I.E when a message rejected is received, the message is requeued straight away to the subscriber client.

A delay should be able to added from the server side allowing the clients not being pushed with rejected messages.

Solution is to have a configurable value in the broker.xml which applies a delay for each rejected message before being requeued.

Each subscription(LocalSubscription) will have a delayed queue[1] which will store the rejected messages with the configuration value in broker.xml. When a rejected message is received, accepting new messages will be stopped from getting delivered to the client by using the LocalSubscription#hasRoomToAcceptMessages() method. New messages will only be accepted only when these rejected messages are accepted by the client or sent to the DLC.

There will be a separate scheduled task which consists of subscriptions that has rejected messages. The scheduler will go through each of those subscriptions and deliver the messages to the outbound disruptor. 

![delayeddelivery 1](https://cloud.githubusercontent.com/assets/4398820/16609139/0602f2ec-436f-11e6-92fe-9302d42cd5fc.png)

[1] - https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/DelayQueue.html