### PR TITLE
[MB-1736] Improving Thrift Based Slot Coordination for NATed/Dockerised Environments

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -59,6 +59,20 @@ public enum AndesConfiguration implements ConfigurationProperty {
      */
     COORDINATION_THRIFT_SERVER_PORT
             ("coordination/thriftServerPort", "7611", Integer.class),
+
+    /**
+     * The IP of the Thrift server to be advertised to external. This is used in NAT/containerized
+     * environments which has a local private IP and a routable public IP.
+     */
+    COORDINATION_THRIFT_SERVER_ADVERTISED_HOST
+            ("coordination/thriftServerAdvertisedHost", "", String.class),
+
+    /**
+     * The port of the Thrift server to be advertised to external. This is used in NAT/containerized
+     * environments which has a local private IP and a routable public IP.
+     */
+    COORDINATION_THRIFT_SERVER_ADVERTISED_PORT
+            ("coordination/thriftServerAdvertisedPort", "-1", Integer.class),
             
     /**
      * Socket timeout for thrift connection.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContext.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContext.java
@@ -170,6 +170,24 @@ public class AndesContext {
     }
 
     /**
+     *  get the advertised ip of the thrift server
+     *
+     * @return  thrift server host ip if defined, else empty String
+     */
+    public String getThriftServerAdvertisedHost() {
+        return AndesConfigurationManager.readValue(AndesConfiguration.COORDINATION_THRIFT_SERVER_ADVERTISED_HOST);
+    }
+
+    /**
+     * get the advertised port for thrift server
+     *
+     * @return The port value if defined, else -1
+     */
+    public Integer getThriftServerAdvertisedPort() {
+        return AndesConfigurationManager.readValue(AndesConfiguration.COORDINATION_THRIFT_SERVER_ADVERTISED_PORT);
+    }
+
+    /**
      * Read configuration properties related to persistent stores and construct semantic object
      * for simple reference.
      */

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/CoordinationConfigurableClusterAgent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/CoordinationConfigurableClusterAgent.java
@@ -204,13 +204,45 @@ public class CoordinationConfigurableClusterAgent implements ClusterAgent {
             log.debug("Unique ID generation for message ID generation:" + uniqueIdOfLocalMember);
         }
 
-        String thriftCoordinatorServerIP = AndesContext.getInstance().getThriftServerHost();
-        int thriftCoordinatorServerPort = AndesContext.getInstance().getThriftServerPort();
-        InetSocketAddress thriftAddress = new InetSocketAddress(thriftCoordinatorServerIP, thriftCoordinatorServerPort);
+        InetSocketAddress thriftAddress = new InetSocketAddress(getThriftCoordinatorServerAddress(), getThriftCoordinatorServerPort());
 
         coordinationStrategy.start(this, getLocalNodeIdentifier(), thriftAddress);
 
         networkPartitionDetector.start();
+    }
+
+    /**
+     * Get the advertised port of Thrift Coordinator Server
+     *
+     * @return  IP address for Thrift Coordinator Server
+     */
+    private String getThriftCoordinatorServerAddress() {
+        String thriftCoordinatorServerIP = AndesContext.getInstance().getThriftServerAdvertisedHost();
+        if (!thriftCoordinatorServerIP.isEmpty()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Thrift Coordinator Server bind IP specified as " + thriftCoordinatorServerIP);
+            }
+        } else {
+            thriftCoordinatorServerIP = AndesContext.getInstance().getThriftServerHost();
+        }
+        return thriftCoordinatorServerIP;
+    }
+
+    /**
+     * Get the advertised address of Thrift Coordinator Server
+     *
+     * @return IP address for Thrift Coordinator Server
+     */
+    private int getThriftCoordinatorServerPort() {
+        int thriftCoordinatorServerPort = AndesContext.getInstance().getThriftServerAdvertisedPort();
+        if (thriftCoordinatorServerPort > 0) {
+            if (log.isDebugEnabled()) {
+                log.debug("Thrift Coordinator Server bind port specified as " + thriftCoordinatorServerPort);
+            }
+        } else {
+            thriftCoordinatorServerPort = AndesContext.getInstance().getThriftServerPort();
+        }
+        return thriftCoordinatorServerPort;
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/CoordinationConfigurableClusterAgent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/CoordinationConfigurableClusterAgent.java
@@ -212,34 +212,38 @@ public class CoordinationConfigurableClusterAgent implements ClusterAgent {
     }
 
     /**
-     * Get the advertised port of Thrift Coordinator Server
+     * Get the routable IP address of Thrift Coordinator Server
      *
      * @return  IP address for Thrift Coordinator Server
      */
     private String getThriftCoordinatorServerAddress() {
+        // first check if the advertised routable ip is present
         String thriftCoordinatorServerIP = AndesContext.getInstance().getThriftServerAdvertisedHost();
         if (!thriftCoordinatorServerIP.isEmpty()) {
             if (log.isDebugEnabled()) {
-                log.debug("Thrift Coordinator Server bind IP specified as " + thriftCoordinatorServerIP);
+                log.debug("Thrift Coordinator Server advertised IP specified as " + thriftCoordinatorServerIP);
             }
         } else {
+            // advertised ip is not defined; use the local ip
             thriftCoordinatorServerIP = AndesContext.getInstance().getThriftServerHost();
         }
         return thriftCoordinatorServerIP;
     }
 
     /**
-     * Get the advertised address of Thrift Coordinator Server
+     * Get the routable port of Thrift Coordinator Server
      *
-     * @return IP address for Thrift Coordinator Server
+     * @return Port for Thrift Coordinator Server
      */
     private int getThriftCoordinatorServerPort() {
+        // first check if the advertised port is present
         int thriftCoordinatorServerPort = AndesContext.getInstance().getThriftServerAdvertisedPort();
         if (thriftCoordinatorServerPort > 0) {
             if (log.isDebugEnabled()) {
-                log.debug("Thrift Coordinator Server bind port specified as " + thriftCoordinatorServerPort);
+                log.debug("Thrift Coordinator Server advertised port specified as " + thriftCoordinatorServerPort);
             }
         } else {
+            // advertised ip is not defined; use the local port
             thriftCoordinatorServerPort = AndesContext.getInstance().getThriftServerPort();
         }
         return thriftCoordinatorServerPort;


### PR DESCRIPTION
In MB's clustered deployment [1] Thrift based slot coordination requires TCP point-to-point connections. The IP and Port are read from broker.xml currently. However, in a NATed environment or in some Docker environment without an overlay network, the local IP is not visible to the other instance of MB. Therefore once the Thrift server binds to the local IP, slot coordination communication with other nodes fail. A possible solution is to bind the Thrift to the local IP + port and advertise the public/routable IP + port for the other nodes.

[1]. https://docs.wso2.com/display/CLUSTER44x/Clustering+MB+3.0.0

This PR relates to : https://github.com/wso2/carbon-business-messaging/pull/336
