### PR TITLE
[MB-1751] Fix unable to add normal topics with modified node id

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesUtils.java
@@ -143,13 +143,13 @@ public class AndesUtils {
         //as topic
         if (AMQPUtils.TOPIC_EXCHANGE_NAME.equals(messageRouterName)) {
             if (!isQueueDurable) {
-                storageQueueName = AMQP_TOPIC_STORAGE_QUEUE_PREFIX + "|" + routingKey + "|" + nodeID;
+                storageQueueName = AMQP_TOPIC_STORAGE_QUEUE_PREFIX + "_" + routingKey + "_" + nodeID;
             } else {
                 storageQueueName = queueName;
             }
         } else if(MQTTUtils.MQTT_EXCHANGE_NAME.equals(messageRouterName)) {
             if (!isQueueDurable) {
-                storageQueueName = MQTT_TOPIC_STORAGE_QUEUE_PREFIX + "|" + routingKey + "|" + nodeID;
+                storageQueueName = MQTT_TOPIC_STORAGE_QUEUE_PREFIX + "_" + routingKey + "_" + nodeID;
             } else {
                 storageQueueName = queueName;
             }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/CoordinationConfigurableClusterAgent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/CoordinationConfigurableClusterAgent.java
@@ -280,7 +280,8 @@ public class CoordinationConfigurableClusterAgent implements ClusterAgent {
         // If the config value is "default" we must generate the ID
         if (AndesConfiguration.COORDINATION_NODE_ID.get().getDefaultValue().equals(nodeId)) {
             Member localMember = hazelcastInstance.getCluster().getLocalMember();
-            nodeId = CoordinationConstants.NODE_NAME_PREFIX + localMember.getSocketAddress();
+            nodeId = CoordinationConstants.NODE_NAME_PREFIX + localMember.getSocketAddress().getHostName()
+                    + CoordinationConstants.HOSTNAME_PORT_SEPARATOR + localMember.getSocketAddress().getPort();
         }
 
         return nodeId;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/CoordinationConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/CoordinationConstants.java
@@ -64,7 +64,12 @@ public final class CoordinationConstants {
     /**
      * Prefix to generate node ID
      */
-    public static String NODE_NAME_PREFIX = "NODE";
+    public static String NODE_NAME_PREFIX = "NODE:";
+
+    /**
+     * Separator for hostname and port 
+     */
+    public static String HOSTNAME_PORT_SEPARATOR = ":";
 
     /**
      * Hazelcast ID generator name to generate an unique ID for each node.


### PR DESCRIPTION
As per spec special characters including pipe "|" has not allowed in topic names.
When adding normal topic subscriptions, topic name[1] is created internally by appending node id. By default, there's a forward slash in default node id(NODE/192.168.1.1:4000). When using modified node id without a forward slash topic subscriptions can't be added due to topic naming validation failed.

**Reason :** When there's a forward slash it will separate topic name from forward slash resulting identifying topic name as  192.168.1.1:4000 in default case.
In modified node id scenario, if no forward slash separators it will identify whole name[2] as topic name. This will result in topic name validation failed due to "|" pipe characters.

With this PR pipe "|" has been replaced by underscore, and forward slash in default node id has been removed. 

**New default node id :** NODE:192.168.1.1:4000
**New sample normal topic name :** AMQP_Topic_myTopic1_NODE:192.168.1.1:4000

[1] AMQP_Topic|myTopic1|NODE/192.168.1.1:4000
[2] AMQP_Topic|myTopic1|notDeafult 

Jira : https://wso2.org/jira/browse/MB-1751

