### PR TITLE
Added MBean to expose queue message counts as composite data.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
@@ -268,6 +268,31 @@ public class QueueManagementInformationMBean extends AMQManagedObject implements
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompositeData getMessageCountOfQueuesAsCompositeData() {
+        CompositeDataSupport support;
+        try {
+            Map<String, java.lang.Integer> messageCounts = getAllQueueCounts();
+
+            OpenType[] messageCountAttributeTypes = new OpenType[messageCounts.size()];
+            String[] itemNames = messageCounts.keySet().toArray(new String[0]);
+            String[] itemDescriptions = messageCounts.keySet().toArray(new String[0]);
+            for (int count = 0; count < messageCounts.size(); count++) {
+                messageCountAttributeTypes[count] = SimpleType.INTEGER;
+            }
+            CompositeType messageCountCompositeType = new CompositeType("Message Count of Queues",
+                    "Message count of queues", itemNames, itemDescriptions, messageCountAttributeTypes);
+            support = new CompositeDataSupport(messageCountCompositeType, messageCounts);
+        } catch (OpenDataException e) {
+            log.error("Error in accessing retrieving message count information", e);
+            throw new RuntimeException("Error in accessing retrieving message count information", e);
+        }
+        return support;
+    }
+
+    /**
      * Get names of all durable queues created and registered in broker.
      * @return set of unique names of queues
      */

--- a/modules/andes-core/management/common/src/main/java/org/wso2/andes/management/common/mbeans/QueueManagementInformation.java
+++ b/modules/andes-core/management/common/src/main/java/org/wso2/andes/management/common/mbeans/QueueManagementInformation.java
@@ -72,6 +72,18 @@ public interface QueueManagementInformation {
     @MBeanAttribute(name = "AllQueueCounts", description = "Message counts of all queues")
     Map<String, Integer> getAllQueueCounts();
 
+
+    /**
+     * Retrieve message counts of all queues
+     *
+     * @return Composite data object of format <queueName, queueCount>
+     */
+    @MBeanAttribute(name = "MessageCountOfQueuesAsCompositeData", description = "Message counts of all queues as " +
+            "Composite data")
+    CompositeData getMessageCountOfQueuesAsCompositeData();
+
+
+
     @MBeanAttribute(name = "NamesOfAllDurableQueues", description = "Names of all durable queues")
     Set<String> getNamesOfAllDurableQueues();
 


### PR DESCRIPTION
Fixing: https://wso2.org/jira/browse/MB-1762

As it seems this issue happens because DAS only allows to monitor attributes which returns data types such as string, long, integer, boolean, double or Composite data objects that returns the above types. So any attribute which returns other types of data (ex. java.util.HashMap, string arrays) will not be listed.

Hence, exposed as Composite data