### PR TITLE
Fixing message status dump functionality 

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageHandler.java
@@ -403,7 +403,7 @@ public class MessageHandler {
 
         FileWriter information = null;
         try {
-            information = new FileWriter(fileToWrite);
+            information = new FileWriter(fileToWrite, true);
             for (Slot slot : slotsRead.values()) {
                 List<DeliverableAndesMetadata> messagesOfSlot = slot.getAllMessagesOfSlot();
                 if (!messagesOfSlot.isEmpty()) {


### PR DESCRIPTION
This fix tells fileWriter to append instead of replace. 
