### PR TITLE
[MB-1831] npe in slot deletion executor

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -586,20 +586,6 @@ public class Andes {
     }
 
     /**
-     * Get message metadata from queue between two message id values.
-     *
-     * @param queueName  queue name
-     * @param firstMsgId id of the starting id
-     * @param lastMsgID  id of the last id
-     * @return List of message metadata
-     * @throws AndesException
-     */
-    public List<DeliverableAndesMetadata> getMetaDataList(Slot slot, final String queueName, long firstMsgId,
-            long lastMsgID) throws AndesException {
-        return MessagingEngine.getInstance().getMetaDataList(slot, queueName, firstMsgId, lastMsgID);
-    }
-
-    /**
      * Get message metadata from queue starting from given id up a given
      * message count.
      *

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/MessageDeliveryTask.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/MessageDeliveryTask.java
@@ -73,7 +73,7 @@ final class MessageDeliveryTask extends Task {
 
             // Get a slot from coordinator.
             Slot currentSlot = requestSlot(storageQueueName);
-
+            currentSlot.setStorageQueue(storageQueue);
             // If the slot is empty
             if (0 == currentSlot.getEndMessageId()) {
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/Slot.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/Slot.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.DeliverableAndesMetadata;
+import org.wso2.andes.kernel.subscription.StorageQueue;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -62,6 +63,11 @@ public class Slot implements Serializable, Comparable<Slot> {
      * QueueName which the slot belongs to. This is set when the slot is assigned to a subscriber
      */
     private String storageQueueName;
+
+    /**
+     * Storage queue for which the slot belongs to. This is set when the slot is assigned to a subscriber.
+     */
+    private StorageQueue storageQueue;
 
     /**
      * Keep if slot is active, if not it is eligible to be removed
@@ -110,6 +116,24 @@ public class Slot implements Serializable, Comparable<Slot> {
 
     public void setStorageQueueName(String storageQueueName) {
         this.storageQueueName = storageQueueName;
+    }
+
+    /**
+     * Set the storage queue name.
+     *
+     * @param storageQueue
+     */
+    public void setStorageQueue(StorageQueue storageQueue) {
+        this.storageQueue = storageQueue;
+    }
+
+    /**
+     * Get the storage queue for which the slot belongs to.
+     *
+     * @return {@link StorageQueue}
+     */
+    public StorageQueue getStorageQueue() {
+        return storageQueue;
     }
 
     public String getStorageQueueName() {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeletionExecutor.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeletionExecutor.java
@@ -121,10 +121,8 @@ public class SlotDeletionExecutor implements NetworkPartitionListener {
                                 // Delete attempt not success, therefore adding slot to the queue
                                 slotsToDelete.put(slot);
                             } else {
-                                StorageQueue storageQueue = AndesContext.getInstance().getStorageQueueRegistry()
-                                        .getStorageQueue(slot.getStorageQueueName());
+                                StorageQueue storageQueue = slot.getStorageQueue();
                                 storageQueue.deleteSlot(slot);
-
                             }
                         } else {
                             slotsToDelete.put(slot); // Not deleted. Hence putting back in queue


### PR DESCRIPTION
Addresses the issue reported at https://wso2.org/jira/browse/MB-1831

The issues was caused when slots for a storage queue are being deleted after the queue is removed. 