### PR TITLE
[MB-1814] Fixed issue with filtering subscriptions to close when a member leaves in cluster.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionManager.java
@@ -150,8 +150,8 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
     }
 
     /**
-     * Register a subscription lister
-     * It will be notified when a subscription change happened
+     * Register a subscription lister.
+     * It will be notified when a subscription change happened.
      *
      * @param listener subscription listener
      */
@@ -238,7 +238,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
     /**
      * Remove local subscription. Unbind subscription from queue,
      * remove from registry, notify local subscription listeners and notify
-     * cluster on subscription close
+     * cluster on subscription close.
      *
      * @param subscription AndesSubscription to close
      * @throws AndesException
@@ -266,7 +266,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
     }
 
     /**
-     * Get mock subscribers representing inactive durable topic subscriptions on broker
+     * Get mock subscribers representing inactive durable topic subscriptions on broker.
      *
      * @return List of inactive
      */
@@ -345,7 +345,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
     }
 
     /**
-     * Get active subscriptions filtered by identifier pattern and exact binding key
+     * Get active subscriptions filtered by identifier pattern and exact binding key.
      *
      * @param isDurable true if searching for durable subscriptions
      * @param protocolType protocol of the subscription
@@ -380,7 +380,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
     }
 
     /**
-     * Get inactive subscriptions filtered by identifier pattern and exact binding key
+     * Get inactive subscriptions filtered by identifier pattern and exact binding key.
      *
      * @param bindingKeyPattern regex to match with binding key of subscriber
      * @return Set of subscriptions filtered according to search criteria
@@ -544,7 +544,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
 
 
     /**
-     * Remove the subscription from subscriptionRegistry
+     * Remove the subscription from subscriptionRegistry.
      *
      * @param channelID protocol channel ID
      * @param nodeID    ID of the node subscription bound to
@@ -591,11 +591,12 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
     }
 
     /**
-     * Get the AndesSubscription by subscription ID
+     * Get the AndesSubscription by subscription ID.
+     *
      * @param subscriptionId subscription ID to query
      * @return matching subscription
      */
-    public AndesSubscription getSubscriptionById(String  subscriptionId) {
+    public AndesSubscription getSubscriptionById(String subscriptionId) {
         Query<AndesSubscription> subscriptionQuery = equal(AndesSubscription.SUB_ID, subscriptionId);
         Iterable<AndesSubscription> subscriptions = subscriptionRegistry.exucuteQuery(subscriptionQuery);
         Iterator<AndesSubscription> subIterator = subscriptions.iterator();
@@ -608,7 +609,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
     }
 
     /**
-     * Get all subscriptions connected to given node
+     * Get all subscriptions connected to given node.
      *
      * @param nodeId Id of the node
      * @return Iterable over matching subscriptions
@@ -750,7 +751,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
     }
 
     /**
-     * Get Number of subscriptions cluster-wide by queue name
+     * Get Number of subscriptions cluster-wide by queue name.
      *
      * @param queueName    name of the queue
      * @param protocolType ProtocolType (AMQP/MQTT)
@@ -936,7 +937,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
     }
 
     /**
-     * Gauge will return total number of queue subscriptions for current node
+     * Gauge will return total number of queue subscriptions for current node.
      */
     private class QueueSubscriberGauge implements Gauge<Integer> {
         @Override
@@ -951,7 +952,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
     }
 
     /**
-     * Gauge will return total number of topic subscriptions current node
+     * Gauge will return total number of topic subscriptions current node.
      */
     private class TopicSubscriberGauge implements Gauge {
         @Override


### PR DESCRIPTION
Fixing: https://wso2.org/jira/browse/MB-1814

This fix may affect failover scenarios as well. When one member leaves the cluster coordinator node will go and clean up subscriptions made to that node. Only local subscriptions can be closed. 