### PR TITLE
[MB-1830] Fixed issue in shared durable topic failover

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/DurableTopicSubscriber.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/DurableTopicSubscriber.java
@@ -72,7 +72,6 @@ public class DurableTopicSubscriber extends AndesSubscription {
      */
     public void closeConnection(UUID channelID, String nodeID) throws SubscriptionException {
         if (this.isActive) {
-            this.subscriberConnection = null;
             this.isActive = false;
         } else {
             throw new SubscriptionException("Cannot close inactive subscription id= " + getSubscriptionId()


### PR DESCRIPTION
Fixes the issue reported at https://wso2.org/jira/browse/MB-1830

Prevented the connection from being set to null upon connection close.

Related to https://github.com/wso2/andes/pull/718