### PR TITLE
Implementing dynamic discovery

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -163,6 +163,12 @@ public enum AndesConfiguration implements ConfigurationProperty {
             "true", Boolean.class),
 
     /**
+     * OSGI service register this implementation to get dynamic discovery details.
+     */
+    DYNAMIC_DISCOVERY("transports/amqp/dynamicDiscovery","org.wso2.carbon.andes.discovery.LocalCluster",
+            String.class),
+
+    /**
      * Enable this to support lightweight messaging with the MQTT protocol.
      */
     TRANSPORTS_MQTT_ENABLED("transports/mqtt/@enabled", "true", Boolean.class),

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContext.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContext.java
@@ -26,6 +26,7 @@ import org.wso2.andes.kernel.registry.MessageRouterRegistry;
 import org.wso2.andes.kernel.registry.StorageQueueRegistry;
 import org.wso2.andes.kernel.subscription.AndesSubscriptionManager;
 import org.wso2.andes.server.cluster.ClusterAgent;
+import org.wso2.andes.server.cluster.IpAddressRetriever;
 import org.wso2.andes.server.cluster.coordination.ClusterNotificationListenerManager;
 
 
@@ -45,6 +46,7 @@ public class AndesContext {
     private static AndesContext instance = new AndesContext();
     private MessageStore messageStore;
     private int deliveryTimeoutForMessage;
+    private IpAddressRetriever addressRetriever;
 
     /**
      * This is mainly used by Cluster Manager to manger cluster communication
@@ -354,5 +356,21 @@ public class AndesContext {
     public void setClusterNotificationListenerManager(ClusterNotificationListenerManager
                                                               clusterNotificationListenerManager) {
         this.clusterNotificationListenerManager = clusterNotificationListenerManager;
+    }
+
+    /**
+     * Set IpAddressRetriver
+     * @param ipAddressRetriever ipAddressRetriever object.
+     */
+    public void setAddressRetriever(IpAddressRetriever ipAddressRetriever){
+        this.addressRetriever=ipAddressRetriever;
+    }
+
+    /**
+     * Get the IpAddressRetriever object.
+     * @return addressRetriever
+     */
+    public IpAddressRetriever getAddressRetriever(){
+        return addressRetriever;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextStore.java
@@ -27,8 +27,9 @@ import org.wso2.andes.kernel.slot.SlotState;
 import org.wso2.andes.kernel.subscription.AndesSubscription;
 import org.wso2.andes.kernel.subscription.StorageQueue;
 import org.wso2.andes.server.cluster.NodeHeartBeatData;
-import org.wso2.andes.server.cluster.coordination.rdbms.MembershipEvent;
+import org.wso2.andes.server.cluster.TransportData;
 import org.wso2.andes.server.cluster.coordination.ClusterNotification;
+import org.wso2.andes.server.cluster.coordination.rdbms.MembershipEvent;
 import org.wso2.andes.store.HealthAwareStore;
 
 import java.net.InetSocketAddress;
@@ -651,5 +652,38 @@ public interface AndesContextStore extends HealthAwareStore {
      * @throws AndesException
      */
     void clearClusterNotifications(String nodeID) throws AndesException;
+
+    /**
+     * Add AMQP node Ip and the AMQP port
+     * @param amqpPort AMQP Port
+     * @param nodeIdentifier Node details
+     * @throws AndesException
+     */
+    void addAmqpAddress(String nodeIdentifier, int amqpPort, int sslAmqpPort)
+            throws
+            AndesException;
+
+    /**
+     * Add Address details to table
+     * @param nodeIdentifier Node detail
+     * @param interfaceDetail Interface name
+     * @param ipAddress Ip Address relavant to interface
+     * @throws AndesException
+     */
+    void addAddressDetails(String nodeIdentifier, String interfaceDetail, String ipAddress) throws AndesException;
+
+    /**
+     * Remove Node when Host go down.
+     * @param nodeID Node identifier
+     * @throws AndesException
+     */
+    void removeAmqpAddress(String nodeID) throws AndesException;
+
+    /**
+     * Get the all AMQP details
+     * @return List of TransportData objects which contains AMQP Host and AMQP Port
+     * @throws AndesException
+     */
+    List<TransportData> getAllTransportDetails() throws AndesException;
 
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
@@ -18,7 +18,6 @@
 
 package org.wso2.andes.kernel;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.configuration.AndesConfigurationManager;
@@ -39,6 +38,7 @@ import org.wso2.andes.server.ClusterResourceHolder;
 import org.wso2.andes.server.cluster.ClusterAgent;
 import org.wso2.andes.server.cluster.ClusterManagementInformationMBean;
 import org.wso2.andes.server.cluster.ClusterManager;
+import org.wso2.andes.server.cluster.DiscoveryInformation;
 import org.wso2.andes.server.cluster.coordination.ClusterNotificationListenerManager;
 import org.wso2.andes.server.cluster.coordination.CoordinationComponentFactory;
 import org.wso2.andes.server.cluster.coordination.hazelcast.HazelcastAgent;
@@ -54,6 +54,7 @@ import org.wso2.andes.thrift.MBThriftServer;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.user.api.UserStoreException;
 
+import javax.management.JMException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -61,9 +62,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import javax.management.JMException;
+
 
 /**
  * Andes kernel startup/shutdown related work is done through this class.
@@ -375,6 +375,16 @@ public class AndesKernelBoot {
     }
 
     /**
+     * Activate Dynamic Discovery
+     * @throws AndesException
+     */
+    private static void activeDynamicDiscovery() throws AndesException {
+
+        DiscoveryInformation discoveryInformation = new DiscoveryInformation();
+        discoveryInformation.getDiscoveryInformation();
+    }
+
+    /**
      * Starts the andes cluster.
      */
     public static void startAndesCluster() throws Exception {
@@ -390,6 +400,9 @@ public class AndesKernelBoot {
 
         //Start components such as the subscription manager, subscription engine, messaging engine, etc.
         startAndesComponents();
+
+        //Active dynamic discovery.
+        activeDynamicDiscovery();
 
     }
 
@@ -511,8 +524,7 @@ public class AndesKernelBoot {
     }
 
     /**
-     * Start manager to join node to the cluster and register
-     * node in the cluster
+     * Start manager to join node to the cluster and register node in the cluster.
      *
      * @throws AndesException
      */

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ClusterNotificationListener.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ClusterNotificationListener.java
@@ -34,7 +34,8 @@ public interface ClusterNotificationListener {
         Binding,
         Queue,
         Subscription,
-        DBUpdate
+        DBUpdate,
+        DynamicDiscoveryUpdate
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/ClusterManagementInformationMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/ClusterManagementInformationMBean.java
@@ -19,24 +19,42 @@ package org.wso2.andes.server.cluster;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.wso2.andes.kernel.AndesContext;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.management.common.mbeans.ClusterManagementInformation;
 import org.wso2.andes.management.common.mbeans.annotations.MBeanConstructor;
 import org.wso2.andes.server.management.AMQManagedObject;
 
-import java.util.List;
 import javax.management.JMException;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * <code>ClusterManagementInformationMBean</code> The the JMS MBean that expose cluster management information
  * Exposes the Cluster Management related information using MBeans
  */
 public class ClusterManagementInformationMBean extends AMQManagedObject implements ClusterManagementInformation {
+
     /**
      * Class logger
      */
     private static final Log logger = LogFactory.getLog(ClusterManagementInformationMBean.class);
+
+    /**
+     * Use for separate IP address and interface name.
+     */
+    private static final String separator = "=";
 
     /**
      * ClusterManager instance to get the information to expose
@@ -99,4 +117,86 @@ public class ClusterManagementInformationMBean extends AMQManagedObject implemen
     public boolean getStoreHealth() {
         return this.clusterManager.getStoreHealth();
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public synchronized String getBrokerDetail() throws JMException {
+        try {
+
+            List<TransportData> transportDataList = DiscoveryInformation.getTransportDataList();
+            Collections.rotate(transportDataList, -1);
+            Document document = makeXml(transportDataList);
+
+            // write the content into xml file
+            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            Transformer transformer = transformerFactory.newTransformer();
+            DOMSource source = new DOMSource(document);
+
+            //Convert DOM object to string
+            StringWriter writer = new StringWriter();
+            StreamResult result = new StreamResult(writer);
+            transformer.transform(source, result);
+            return writer.toString();
+
+        } catch (TransformerException | ParserConfigurationException e) {
+            logger.error("Error occurred while retrieving live broker details", e);
+            throw new JMException("Error occurred while retrieving broker live details"+e.toString());
+        }
+    }
+
+    /**
+     * Making xml document.
+     * @param transportDataList List of transport data objects.
+     * @return Document.
+     * @throws ParserConfigurationException
+     */
+    private Document makeXml(List<TransportData> transportDataList) throws ParserConfigurationException {
+
+        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+        // root elements
+        Document document = docBuilder.newDocument();
+
+        String IP_LIST = "IpList";
+        Element rootElement = document.createElement(IP_LIST);
+        document.appendChild(rootElement);
+        List<String> allIpList;
+
+        for (TransportData transportDataObject : transportDataList) {
+
+            String NODE = "Node";
+            Element node = document.createElement(NODE);
+            rootElement.appendChild(node);
+
+            String ADDRESSES = "Addresses";
+            Element addresses = document.createElement(ADDRESSES);
+            node.appendChild(addresses);
+
+            /*String aTransportDataListAmqpHost = transportDataObject.getAmqpHost();
+            StringTokenizer stringTokenizer = new StringTokenizer(aTransportDataListAmqpHost, ",");*/
+
+                for (int w = 0; w<transportDataObject.getMultipleAddressDetails().size(); w++) {
+
+                    String ID = "id";
+                    node.setAttribute(ID, transportDataObject.getNodeIdentifier());
+                    String ADDRESS = "Address";
+                    Element address = document.createElement(ADDRESS);
+                    addresses.appendChild(address);
+                    String IP = "ip";
+                    address.setAttribute(IP,transportDataObject.getMultipleAddressDetails().get(w).getIpAddress() );
+                    String PORT = "port";
+                    address.setAttribute(PORT, String.valueOf(transportDataObject.getAmqpPort()));
+                    String SSL_PORT = "ssl-port";
+                    address.setAttribute(SSL_PORT, String.valueOf(transportDataObject.getSslAmqpPort()));
+                    String INTERFACE_NAME = "interface-name";
+                    address.setAttribute(INTERFACE_NAME, transportDataObject.getMultipleAddressDetails().get(w).getInterfaceDetail());
+                }
+
+            }
+
+
+        return document;
+    }
+
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/DiscoveryInformation.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/DiscoveryInformation.java
@@ -1,0 +1,186 @@
+/*
+* Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.andes.server.cluster;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.andes.configuration.AndesConfigurationManager;
+import org.wso2.andes.configuration.enums.AndesConfiguration;
+import org.wso2.andes.kernel.AndesContext;
+import org.wso2.andes.kernel.AndesContextStore;
+import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.server.cluster.coordination.ClusterNotificationAgent;
+import org.wso2.andes.server.cluster.coordination.CoordinationComponentFactory;
+
+import java.util.List;
+
+
+public class DiscoveryInformation {
+
+    /**
+     * Transport data object list.
+     */
+    public static List<TransportData> transportDataList;
+    /**
+     * Class logger
+     */
+    protected final Logger logger = LoggerFactory.getLogger(DiscoveryInformation.class);
+
+    /**
+     * Creating Coordination Component Factory.
+     */
+    private CoordinationComponentFactory coordinationComponentFactory;
+
+    /**
+     * This constructor.
+     */
+    public DiscoveryInformation() {
+        this.coordinationComponentFactory = new CoordinationComponentFactory();
+    }
+
+    /**
+     * Getter for transport data list.
+     *
+     * @return transport data object list (node identifier,IP addresses, AMQP port, AMQP SSL port).
+     */
+    public static List<TransportData> getTransportDataList() {
+
+        return transportDataList;
+    }
+
+    /**
+     * Setter for transport data list.
+     *
+     * @param transportData contains transport data objects.
+     */
+    public static void setTransportDataList(List<TransportData> transportData) {
+
+        transportDataList = transportData;
+    }
+
+    /**
+     * Get Discovery Information (IP list, AMQP port, AMQP SSL port and Node Identifier).
+     */
+    public void getDiscoveryInformation() throws AndesException {
+
+        if (AndesContext.getInstance().isClusteringEnabled()) {
+
+            IpAddressRetriever ipAddressRetriever = AndesContext.getInstance().getAddressRetriever();
+            AndesContextStore andesContextStore = AndesContext.getInstance().getAndesContextStore();
+            ClusterAgent clusterAgent = AndesContext.getInstance().getClusterAgent();
+            ClusterNotificationAgent clusterNotificationAgent = coordinationComponentFactory.createClusterNotificationAgent();
+            //noinspection ConstantConditions
+            int amqpPort = AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_DEFAULT_CONNECTION_PORT);
+            //noinspection ConstantConditions
+            int amqpSslPort = AndesConfigurationManager.readValue(AndesConfiguration.TRANSPORTS_AMQP_SSL_CONNECTION_PORT);
+            String nodeIdentifier = clusterAgent.getLocalNodeIdentifier();
+            //add amqp host and the port
+            andesContextStore.addAmqpAddress(nodeIdentifier, amqpPort, amqpSslPort);
+
+            String configuredAdpAddress = AndesConfigurationManager.readValue(AndesConfiguration
+                    .TRANSPORTS_AMQP_BIND_ADDRESS);
+
+            if (configuredAdpAddress.equals("0.0.0.0")) {
+
+                List<MultipleAddressDetails> addressDetailsList = ipAddressRetriever.getLocalAddress();
+                for (MultipleAddressDetails anAddressDetailsList : addressDetailsList) {
+                    andesContextStore.addAddressDetails(nodeIdentifier, anAddressDetailsList.getInterfaceDetail(),
+                            anAddressDetailsList.getIpAddress());
+                }
+            } else {
+                andesContextStore.addAddressDetails(nodeIdentifier, "configure", configuredAdpAddress);
+            }
+            DiscoveryInformation.setTransportDataList(andesContextStore.getAllTransportDetails());
+            clusterNotificationAgent.publishDyanamicDiscovery();
+        }
+    }
+
+    /**
+     * Add transport data to list and send hazelcast notification
+     *
+     * @throws AndesException
+     */
+    void addTransportData(String addedNodeId) throws AndesException {
+
+        AndesContextStore andesContextStore = AndesContext.getInstance().getAndesContextStore();
+        List<TransportData> checkListTransportdata = andesContextStore.getAllTransportDetails();
+
+        for (TransportData aCheckListTransportdata : checkListTransportdata) {
+            if (aCheckListTransportdata.getNodeIdentifier().equals(addedNodeId)) {
+                transportDataList.add(aCheckListTransportdata);
+            }
+
+        }
+
+    }
+
+    /**
+     * Update Transport data list.
+     *
+     * @param deletedNodeId Node Identifier.
+     */
+    public void updateTransportData(String deletedNodeId) {
+
+        for (int listIncreaser = 0; listIncreaser < transportDataList.size(); ) {
+
+            if (transportDataList.get(listIncreaser).getNodeIdentifier().equals(deletedNodeId)) {
+                transportDataList.remove(listIncreaser);
+                listIncreaser++;
+            } else {
+                listIncreaser++;
+            }
+        }
+    }
+
+    /**
+     * Remove Node details form all the list and database.
+     *
+     * @param nodeId Node identifier.
+     * @throws AndesException
+     */
+    public void deleteTransportData(String nodeId) throws AndesException {
+
+        if (AndesContext.getInstance().isClusteringEnabled()) {
+
+            for (int listIncreaser = 0; listIncreaser < transportDataList.size(); ) {
+                if (transportDataList.get(listIncreaser).getNodeIdentifier().equals(nodeId)) {
+                    transportDataList.remove(listIncreaser);
+                    listIncreaser++;
+                } else {
+                    listIncreaser++;
+                }
+            }
+            //Remove node details when shutdown
+            clearAmqpHostAddress(nodeId);
+        }
+    }
+
+    /**
+     * Clear AMQP details when node is going to shutdown.
+     *
+     * @param nodeID Node identifier
+     * @throws AndesException
+     */
+    private void clearAmqpHostAddress(String nodeID) throws AndesException {
+        logger.info("Clearing the Node with ID " + nodeID);
+        AndesContextStore andesContextStore = AndesContext.getInstance().getAndesContextStore();
+        //remove node from nodes list
+        andesContextStore.removeAmqpAddress(nodeID);
+    }
+}
+

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/IpAddressRetriever.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/IpAddressRetriever.java
@@ -1,0 +1,33 @@
+/*
+* Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.andes.server.cluster;
+
+import java.util.List;
+
+/**
+ *This is responsible for handling IP address and interface.
+ */
+public interface IpAddressRetriever {
+
+    /**
+     * Get the List of IP address and relevant to interface of the node.
+     * @return IP address
+     */
+    List<MultipleAddressDetails> getLocalAddress();
+
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/MultipleAddressDetails.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/MultipleAddressDetails.java
@@ -1,0 +1,73 @@
+/*
+* Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.andes.server.cluster;
+
+/**
+ * This class responsible for handling multiple interface details and IP addresses.
+ */
+
+public class MultipleAddressDetails {
+
+    //Network interface name
+    private String interfaceDetail;
+
+    //Ip address relevant to interface
+    private String ipAddress;
+
+    /**
+     * This constructor set these parameters.
+     * @param interfaceDetail network interface name.
+     * @param ipAddress IP address related to interface.
+     */
+    public MultipleAddressDetails(String interfaceDetail, String ipAddress) {
+        this.interfaceDetail = interfaceDetail;
+        this.ipAddress = ipAddress;
+    }
+
+    /**
+     * Get Network Interface details.
+     * @return Interface name.
+     */
+    public String getInterfaceDetail() {
+        return interfaceDetail;
+    }
+
+    /**
+     * Set Network interface details.
+     * @param interfaceDetail Interface name.
+     */
+    public void setInterfaceDetail(String interfaceDetail) {
+        this.interfaceDetail = interfaceDetail;
+    }
+
+    /**
+     * Get IP address relevant to network interface.
+     * @return
+     */
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    /**
+     * Set IP address.
+     * @param ipAddress IP Address.
+     */
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/TransportData.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/TransportData.java
@@ -1,0 +1,77 @@
+/*
+* Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.andes.server.cluster;
+
+import java.util.List;
+
+/**
+ * Class that contains getters and setters of transport data.
+ */
+public class TransportData {
+
+    private String nodeIdentifier;
+    private List<MultipleAddressDetails> multipleAddressDetails;
+    private int amqpPort;
+    private int sslAmqpPort;
+
+    /**
+     * This constructor set these parameters
+     * @param nodeIdentifier Node details
+     * @param multipleAddressDetailses AMQP host address
+     * @param amqpPort AMQP port
+     * @param sslAmqpPort AMQP SSL port
+     */
+    public TransportData(String nodeIdentifier, List<MultipleAddressDetails> multipleAddressDetailses, int amqpPort, int sslAmqpPort) {
+        this.nodeIdentifier=nodeIdentifier;
+        this.multipleAddressDetails = multipleAddressDetailses;
+        this.amqpPort = amqpPort;
+        this.sslAmqpPort = sslAmqpPort;
+    }
+
+    public String getNodeIdentifier() {
+        return nodeIdentifier;
+    }
+
+    public void setNodeIdentifier(String nodeIdentifier) {
+        this.nodeIdentifier = nodeIdentifier;
+    }
+
+    public List<MultipleAddressDetails> getMultipleAddressDetails() {
+        return multipleAddressDetails;
+    }
+
+    public void setMultipleAddressDetails(List<MultipleAddressDetails> multipleAddressDetails) {
+        this.multipleAddressDetails = multipleAddressDetails;
+    }
+
+    public int getAmqpPort() {
+        return amqpPort;
+    }
+
+    public void setAmqpPort(int amqpPort) {
+        this.amqpPort = amqpPort;
+    }
+
+    public int getSslAmqpPort() {
+        return sslAmqpPort;
+    }
+
+    public void setSslAmqpPort(int sslAmqpPort) {
+        this.sslAmqpPort = sslAmqpPort;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/ClusterNotificationAgent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/ClusterNotificationAgent.java
@@ -77,4 +77,11 @@ public interface ClusterNotificationAgent {
      */
     void notifyAnyDBChange() throws AndesException;
 
+
+    /**
+     * Notofy Dynamically Changes of nodes
+     * @throws AndesException
+     */
+    void publishDyanamicDiscovery() throws AndesException;
+
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/CoordinationComponentFactory.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/CoordinationComponentFactory.java
@@ -90,7 +90,7 @@ public class CoordinationComponentFactory {
                 if (null != hazelcastBasedListener) {
                     clusterNotificationAgent = new HazelcastBasedNotificationAgentImpl(
                             hazelcastBasedListener.getClusterNotificationChannel(),
-                            hazelcastBasedListener.getDBSyncNotificationChannel());
+                            hazelcastBasedListener.getDBSyncNotificationChannel(),hazelcastBasedListener.getDynamicDiscoveryNotificationChannel());
                 } else {
                     throw new AndesException("Cannot create HazelcastBasedNotificationAgentImpl. Create " +
                             "HazelcastClusterNotificationListenerImpl first to register Hazelcast topics");

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/CoordinationConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/CoordinationConstants.java
@@ -57,6 +57,11 @@ public final class CoordinationConstants {
     public static String HAZELCAST_CLUSTER_EVENT_NOTIFIER_TOPIC_NAME = "CLUSTER_EVENT";
 
     /**
+     * Hazelcast distributed topic name to send Dynamic discovery details.
+     */
+    public static String HAZELCAST_CLUSTER_DYNAMIC_DISCOVERY_NOTIFIER_TOPIC_NAME = "DYNAMIC_DISCOVERY_EVENT";
+
+    /**
      * Distributed lock name used to initialize the slot map
      */
     public static final String INITIALIZATION_LOCK = "InitializationLock";

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/StandaloneMockNotificationAgent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/StandaloneMockNotificationAgent.java
@@ -72,4 +72,12 @@ public class StandaloneMockNotificationAgent implements ClusterNotificationAgent
     public void notifyAnyDBChange() throws AndesException {
 
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void publishDyanamicDiscovery() throws AndesException {
+
+    }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HazelcastBasedNotificationAgentImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HazelcastBasedNotificationAgentImpl.java
@@ -46,6 +46,11 @@ public class HazelcastBasedNotificationAgentImpl implements ClusterNotificationA
     private ITopic<ClusterNotification> dbSyncNotificationChannel;
 
     /**
+     * This channel is used for dynamic discovery events.
+     */
+    private ITopic<ClusterNotification> dynamicDiscoveryNotificationChannel;
+
+    /**
      * ID of the local node
      */
     private String localNodeID;
@@ -57,12 +62,14 @@ public class HazelcastBasedNotificationAgentImpl implements ClusterNotificationA
      *                                   queue, binding, message router, subscription changes
      * @param dbSyncNotificationChannel  the channel that is used to publish and
      *                                   subscribe db sync events.
+     * @param dynamicDiscoveryChannel the channel that is used to publish dynamic discovery message.
      */
     public HazelcastBasedNotificationAgentImpl(ITopic<ClusterNotification> clusterNotificationChannel,
-            ITopic<ClusterNotification> dbSyncNotificationChannel) {
+            ITopic<ClusterNotification> dbSyncNotificationChannel, ITopic<ClusterNotification> dynamicDiscoveryChannel) {
         this.localNodeID = ClusterResourceHolder.getInstance().getClusterManager().getMyNodeID();
         this.clusterNotificationChannel = clusterNotificationChannel;
         this.dbSyncNotificationChannel = dbSyncNotificationChannel;
+        this.dynamicDiscoveryNotificationChannel = dynamicDiscoveryChannel;
     }
 
 
@@ -199,5 +206,16 @@ public class HazelcastBasedNotificationAgentImpl implements ClusterNotificationA
             throw new AndesException("Error while sending db sync notification"
                     + clusterNotification.getEncodedObjectAsString(), e);
         }
+    }
+
+    /**
+     * Publish message to dynamic discovery channel. This method call by dynamic discovery OSGI component.
+     */
+    public void publishDyanamicDiscovery() throws AndesException{
+
+        ClusterNotification clusterNotification = new ClusterNotification("", ClusterNotificationListener
+                .NotifiedArtifact.DynamicDiscoveryUpdate.toString(), "", "DynamicDiscoveryEvent", "");
+        dynamicDiscoveryNotificationChannel.publish(clusterNotification);
+
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HazelcastClusterNotificationListenerImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HazelcastClusterNotificationListenerImpl.java
@@ -46,11 +46,14 @@ public class HazelcastClusterNotificationListenerImpl implements ClusterNotifica
      */
     private ITopic<ClusterNotification> clusterNotifierChannel;
 
+    private ITopic<ClusterNotification> dynamicDiscoveryNotifierChannel;
+
     /**
      * IDs of subscribers registered for Hazelcast topics
      */
     private String dbSyncNotificationListenerId;
     private String clusterEventListenerId;
+    private String dynamicDiscoveryEventListenerId;
 
     /**
      * Hazelcast agent for forwarding HZ related requests
@@ -144,6 +147,11 @@ public class HazelcastClusterNotificationListenerImpl implements ClusterNotifica
                 ENABLE_STATISTICS, HAZELCAST_RELIABLE_TOPIC_READ_BACH_SIZE, HAZELCAST_RING_BUFFER_CAPACITY,
                 hazelcastRingBufferTTL);
 
+        this.dynamicDiscoveryNotifierChannel = hazelcastAgent.createReliableTopic(
+                CoordinationConstants.HAZELCAST_CLUSTER_DYNAMIC_DISCOVERY_NOTIFIER_TOPIC_NAME,
+                ENABLE_STATISTICS, HAZELCAST_RELIABLE_TOPIC_READ_BACH_SIZE, HAZELCAST_RING_BUFFER_CAPACITY,
+                hazelcastRingBufferTTL);
+
     }
 
     private void addTopicListeners(InboundEventManager inboundEventManager,
@@ -172,6 +180,13 @@ public class HazelcastClusterNotificationListenerImpl implements ClusterNotifica
 
         dbSyncNotificationListenerId = checkAndRegisterListerToTopic(dbSyncNotifierChannel,
                 HZBasedDatabaseSyncNotificationListener, dbSyncNotificationListenerId);
+
+
+     HzBasedDynamicDiscoveryListener hzBasedDynamicDiscoveryListener = new HzBasedDynamicDiscoveryListener();
+
+        dynamicDiscoveryEventListenerId = checkAndRegisterListerToTopic(dynamicDiscoveryNotifierChannel,
+                hzBasedDynamicDiscoveryListener, dynamicDiscoveryEventListenerId);
+
     }
 
     /**
@@ -209,5 +224,10 @@ public class HazelcastClusterNotificationListenerImpl implements ClusterNotifica
      */
     public ITopic<ClusterNotification> getDBSyncNotificationChannel() {
         return dbSyncNotifierChannel;
+    }
+
+
+    public ITopic<ClusterNotification> getDynamicDiscoveryNotificationChannel() {
+        return dynamicDiscoveryNotifierChannel;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HzBasedDynamicDiscoveryListener.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HzBasedDynamicDiscoveryListener.java
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.andes.server.cluster.coordination.hazelcast;
+
+import com.hazelcast.core.Message;
+import com.hazelcast.core.MessageListener;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.AndesContext;
+import org.wso2.andes.kernel.AndesContextStore;
+import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.server.cluster.DiscoveryInformation;
+
+/**
+ * The following listener will receive notification through {@link com.hazelcast.core.ITopic} to write node details
+ * to database.
+ */
+public class HzBasedDynamicDiscoveryListener implements MessageListener {
+
+
+    private static Log log = LogFactory.getLog(HzBasedDynamicDiscoveryListener.class);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onMessage(Message message) {
+
+        AndesContextStore andesContextStore = AndesContext.getInstance().getAndesContextStore();
+        try {
+            DiscoveryInformation.setTransportDataList(andesContextStore.getAllTransportDetails());
+        } catch (AndesException e) {
+            log.info("Error occurred while on message ",e);
+        }
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/rdbms/RDBMSBasedNotificationAgentImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/rdbms/RDBMSBasedNotificationAgentImpl.java
@@ -149,6 +149,15 @@ public class RDBMSBasedNotificationAgentImpl implements ClusterNotificationAgent
         publishNotificationToDB(clusterNotification);
     }
 
+    @Override
+    public void publishDyanamicDiscovery() throws AndesException {
+
+        ClusterNotification clusterNotification = new ClusterNotification("", ClusterNotificationListener
+                .NotifiedArtifact.DynamicDiscoveryUpdate.toString(), "", "DynamicDiscoveryEvent", "");
+        publishNotificationToDB(clusterNotification);
+
+    }
+
     /**
      * Store notification in the DB. Duplicate the cluster notification for all nodes in
      * the cluster and store them destined to the respective  to each node.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingAndesContextStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingAndesContextStore.java
@@ -27,11 +27,12 @@ import org.wso2.andes.kernel.DurableStoreConnection;
 import org.wso2.andes.kernel.router.AndesMessageRouter;
 import org.wso2.andes.kernel.slot.Slot;
 import org.wso2.andes.kernel.slot.SlotState;
-import org.wso2.andes.server.cluster.coordination.rdbms.MembershipEvent;
-import org.wso2.andes.server.cluster.NodeHeartBeatData;
-import org.wso2.andes.server.cluster.coordination.ClusterNotification;
 import org.wso2.andes.kernel.subscription.AndesSubscription;
 import org.wso2.andes.kernel.subscription.StorageQueue;
+import org.wso2.andes.server.cluster.NodeHeartBeatData;
+import org.wso2.andes.server.cluster.TransportData;
+import org.wso2.andes.server.cluster.coordination.ClusterNotification;
+import org.wso2.andes.server.cluster.coordination.rdbms.MembershipEvent;
 
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -1151,5 +1152,42 @@ public class FailureObservingAndesContextStore implements AndesContextStore {
             notifyFailures(exception);
             throw exception;
         }
+    }
+
+
+    /**
+     * Add AMQP details.
+     * @param amqpPort AMQP Port
+     * @throws AndesException
+     */
+    @Override
+    public void addAmqpAddress(String nodeIdentifiers, int amqpPort, int sslAmqpPort)
+            throws AndesException {
+        wrappedAndesContextStoreInstance.addAmqpAddress(nodeIdentifiers,amqpPort, sslAmqpPort);
+    }
+
+    @Override
+    public void addAddressDetails(String nodeIdentifier, String interfaceDetail, String ipAddress) throws AndesException {
+        wrappedAndesContextStoreInstance.addAddressDetails(nodeIdentifier,interfaceDetail,ipAddress);
+    }
+
+    /**
+     * Clear AMQP details when node down.
+     * @param nodeIdentifier  Host
+     * @throws AndesException
+     */
+    @Override
+    public void removeAmqpAddress(String nodeIdentifier) throws AndesException {
+        wrappedAndesContextStoreInstance.removeAmqpAddress(nodeIdentifier);
+    }
+
+    /**
+     * Get list of transport details.
+     * @return TransportData list.
+     * @throws AndesException
+     */
+    @Override
+    public List<TransportData> getAllTransportDetails() throws AndesException {
+        return wrappedAndesContextStoreInstance.getAllTransportDetails();
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -85,6 +85,12 @@ public class RDBMSConstants {
     protected static final String MSG_STORE_STATUS_TABLE = "MB_MSG_STORE_STATUS";
     protected static final String RETAINED_METADATA_TABLE = "MB_RETAINED_METADATA";
     protected static final String RETAINED_CONTENT_TABLE = "MB_RETAINED_CONTENT";
+
+    //Node details table
+    protected static final String NODE_DETAIL_TABLE = "NODE_DETAIL_TABLE";
+    protected static final String ADDRESS_DETAIL_TABLE = "ADDRESS_DETAIL_TABLE";
+
+
     // Message Store table columns
     protected static final String MESSAGE_ID = "MESSAGE_ID";
     protected static final String QUEUE_ID = "QUEUE_ID";
@@ -142,6 +148,15 @@ public class RDBMSConstants {
     protected static final String THRIFT_PORT = "THRIFT_PORT";
     protected static final String CLUSTER_AGENT_HOST = "CLUSTER_AGENT_HOST";
     protected static final String CLUSTER_AGENT_PORT = "CLUSTER_AGENT_PORT";
+
+
+    //Node detail table columns
+    protected static final String NODE_PORT = "NODE_PORT";
+    protected static final String FLAG= "FLAG";
+    protected static final String NODE_SSL_PORT= "NODE_SSL_PORT";
+    protected static final String NODE_IDENTIFIER = "NODE_IDENTIFIER";
+    protected static final String NODE_INTERFACE = "NODE_INTERFACE";
+    protected static final String NODE_ADDRESS = "NODE_ADDRESS";
 
     //Slot table columns
     protected static final String SLOT_ID = "SLOT_ID";
@@ -1033,13 +1048,61 @@ public class RDBMSConstants {
             "DELETE FROM " + MEMBERSHIP_TABLE;
 
     /**
-     * Prepared statement to slear membership change events destined to a particular member.
+     * Prepared statement to clear membership change events destined to a particular member.
      */
     protected static final String PS_CLEAN_MEMBERSHIP_EVENTS_FOR_NODE =
             "DELETE FROM " + MEMBERSHIP_TABLE
             + " WHERE " + NODE_ID + "=?";
 
+
+    /**
+     * Prepared statement to insert live node details.
+     */
+    protected static final String PS_NODE_DETAIL_INSERT =
+            "INSERT INTO " + NODE_DETAIL_TABLE + " ("
+                    + NODE_IDENTIFIER + ","
+                    + NODE_PORT +","
+                    + NODE_SSL_PORT + ")"
+                    + " VALUES (?,?,?)";
+
+
+    /**
+     * Prepared statement to remove live nodes.
+     */
+    protected static final String PS_REMOVE_NODE_DETAIL =
+            "DELETE FROM " + NODE_DETAIL_TABLE
+                    + " WHERE " + NODE_IDENTIFIER + "=?";
+
+
+    /**
+     * Prepared statement to select live node details.
+     */
+    protected static final String PS_SELECT_ORDERD_NODE_DETAILS =
+            "SELECT " +NODE_IDENTIFIER+","+ NODE_PORT + ","+NODE_SSL_PORT
+                    + " FROM " + NODE_DETAIL_TABLE;
+
+
+    protected static final String PS_ADDRESS_DETAIL_INSERT =
+            "INSERT INTO " + ADDRESS_DETAIL_TABLE + " ("
+                    + NODE_IDENTIFIER + ","
+                    + NODE_INTERFACE + ","
+                    + NODE_ADDRESS + ")"
+                    + " VALUES (?,?,?)";
+
+    protected static final String PS_SELECT_ADDRESS_DETAILS=
+            "SELECT " +NODE_IDENTIFIER+"," +NODE_INTERFACE+","+ NODE_ADDRESS
+                    + " FROM " + ADDRESS_DETAIL_TABLE
+                    + " WHERE " + NODE_IDENTIFIER + "=?";
+
+
+
+
     // Message Store related jdbc tasks executed
+    protected static final String TASK_CREATING_NODE_DETAILS = "creating node details";
+    protected static final String TASK_REMOVE_NODE_DETAILS = "  removing node details";
+    protected static final String TASK_UPDATE_NODE_DETAILS = "updating node flag";
+    protected static final String TASK_SELECT_ORDERD_NODE_DETAILS = " selecting orderd node details";
+
     protected static final String TASK_STORING_MESSAGE_PARTS = "storing message parts.";
     protected static final String TASK_DELETING_MESSAGE_PARTS = "deleting message parts.";
     protected static final String TASK_RETRIEVING_MESSAGE_PARTS = "retrieving message parts.";

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionFactory.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionFactory.java
@@ -68,6 +68,13 @@ public class AMQConnectionFactory implements ConnectionFactory, QueueConnectionF
     }
 
     /**
+     * Get the connections details.
+     * @return connection details
+     */
+    public ConnectionURL getAmqpConnection(){
+        return _connectionDetails;
+    }
+    /**
      * This constructor is never used!
      */
     public AMQConnectionFactory(ConnectionURL url)

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/jndi/discovery/DiscoveryValues.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/jndi/discovery/DiscoveryValues.java
@@ -1,0 +1,61 @@
+/*
+* Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.andes.jndi.discovery;
+
+/**
+ * Define all constants for dynamic discovery.
+ * This values use by client for initialize properties.
+ */
+public final class DiscoveryValues {
+
+    /**
+     * Key for getting trust store location.
+     */
+    public static final String TRUSTSTORE = "javax.net.ssl.trustStore";
+
+    /**
+     * Key for getting client username and password.
+     */
+    public static String AUTHENTICATION_CLIENT = "authentication_client";
+
+    /**
+     * Key for getting carbon Properties.
+     */
+    public static String CARBON_PROPERTIES = "carbon";
+
+    /**
+     * Key for getting failover properties.
+     */
+    public static String FAILOVER_PROPERTIES = "failover";
+
+    /**
+     * Key for getting connection Factory.
+     */
+    public static final String CF_NAME_PREFIX = "connectionfactory.";
+
+    /**
+     * Key for getting QPID connection factory.
+     */
+    public static final String CF_NAME = "qpidConnectionfactory";
+
+    /**
+     * Key for getting web service calling time interval.
+     */
+    public static final String PERIODIC_TIME_PREFIX = "web_service";
+
+}

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/jndi/discovery/DynamicDiscoveryContext.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/jndi/discovery/DynamicDiscoveryContext.java
@@ -1,0 +1,656 @@
+/*
+* Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.wso2.andes.jndi.discovery;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.andes.client.AMQBrokerDetails;
+import org.wso2.andes.client.AMQConnectionFactory;
+import org.wso2.andes.client.AMQDestination;
+import org.wso2.andes.client.AMQHeadersExchange;
+import org.wso2.andes.client.AMQQueue;
+import org.wso2.andes.client.AMQTopic;
+import org.wso2.andes.exchange.ExchangeDefaults;
+import org.wso2.andes.framing.AMQShortString;
+import org.wso2.andes.jms.ConnectionURL;
+import org.wso2.andes.jndi.ReadOnlyContext;
+import org.wso2.andes.url.BindingURL;
+import org.wso2.andes.url.URLSyntaxException;
+import org.wso2.andes.util.Strings;
+import org.wso2.andes.ws.DynamicDiscoveryWebServices;
+import org.wso2.securevault.SecretResolver;
+import org.wso2.securevault.SecretResolverFactory;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.Queue;
+import javax.jms.Topic;
+import javax.naming.ConfigurationException;
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactory;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringTokenizer;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * DynamicDiscoveryContext class implements InitialContextFactory.
+ * <p>
+ * This class use for the creating connection factories, creating queues, creating topics
+ */
+@SuppressWarnings("unused")
+public class DynamicDiscoveryContext implements InitialContextFactory {
+
+    protected final Logger logger = LoggerFactory.getLogger(DynamicDiscoveryContext.class);
+    private List<String> detailList = new ArrayList<>();
+    private String carbonClientId = null;
+    private String carbonHostName = null;
+    private String[] initialURLs = null;
+    private int retries = 0;
+    private int connectdelay = 0;
+    private int cyclecount = 0;
+    private String mode = "defalut";
+    private String certificateAliasInTrustsStore = null;
+    private String pathToTrustStore = null;
+    private String trustStorePassword = null;
+    private String pathToKeyStore = null;
+    private String keyStorePassword = null;
+    private String trustStoreLocation = null;
+    private String CONNECTION_FACTORY_PREFIX = "connectionfactory.";
+    private String DESTINATION_PREFIX = "destination.";
+    private String QUEUE_PREFIX = "queue.";
+    private String TOPIC_PREFIX = "topic.";
+    private DynamicDiscoveryWebServices dynamicDiscoveryWebServices;
+    private float time = 60;
+    private AMQConnectionFactory amqConnectionFactory;
+
+
+
+    /**
+     * Resolve carbon secure vault encrypted properties.
+     *
+     * @param environment property values which need to construct the InitialContext
+     */
+    private static void resolveEncryptedProperties(Hashtable environment) {
+        if (environment != null) {
+            Properties properties = convertToProperties(environment);
+            SecretResolver secretResolver = SecretResolverFactory.create(properties);
+            for (Object key : environment.keySet()) {
+                if (secretResolver != null && secretResolver.isInitialized()) {
+                    String value = environment.get(key.toString()).toString();
+                    String SECRET_ALIAS_PREFIX = "secretAlias:";
+                    if (value != null && value.startsWith(SECRET_ALIAS_PREFIX)) {
+                        value = value.split(SECRET_ALIAS_PREFIX)[1];
+                    }
+                    if (secretResolver.isTokenProtected(value)) {
+                        environment.put(key.toString(), secretResolver.resolve(value));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Convert Map to Properties object.
+     *
+     * @param map key value pair details
+     */
+    private static Properties convertToProperties(Map<String, String> map) {
+        Properties properties = new Properties();
+        for (Map.Entry entry : map.entrySet()) {
+            properties.setProperty(entry.getKey().toString(), entry.getValue().toString());
+        }
+        return properties;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public synchronized Context getInitialContext(Hashtable environment) throws NamingException {
+        Map data = new HashMap();
+
+        try {
+
+            String file;
+            if (environment.containsKey(Context.PROVIDER_URL)) {
+                file = (String) environment.get(Context.PROVIDER_URL);
+            } else {
+                file = System.getProperty(Context.PROVIDER_URL);
+            }
+
+            // Load the properties specified
+            if (file != null) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Loading Properties from:" + file);
+                }
+                BufferedInputStream inputStream;
+
+                if (file.contains("file:")) {
+                    inputStream = new BufferedInputStream(new FileInputStream(new File(new URI(file))));
+                } else {
+                    inputStream = new BufferedInputStream(new FileInputStream(file));
+                }
+
+                Properties properties = new Properties();
+
+                try {
+                    properties.load(inputStream);
+                } finally {
+
+                    try {
+                        inputStream.close();
+                    }catch (IOException e){
+                        logger.error("Error occurred while closing input stream",e);
+                    }
+                }
+
+                Strings.Resolver resolver = new Strings.ChainedResolver
+                        (Strings.SYSTEM_RESOLVER, new Strings.PropertiesResolver(properties));
+
+                for (Map.Entry me : properties.entrySet()) {
+                    String key = (String) me.getKey();
+                    String value = (String) me.getValue();
+                    String expanded = Strings.expand(value, resolver);
+                    environment.put(key, expanded);
+                    if (System.getProperty(key) == null) {
+                        System.setProperty(key, expanded);
+                    }
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Loaded Context Properties:" + environment.toString());
+                }
+            }
+        } catch (IOException | URISyntaxException ioe) {
+            logger.warn("Unable to load property file specified in Provider_URL:" + environment.get(Context.PROVIDER_URL)
+                    + "\n" +
+                    "Due to:" + ioe.getMessage());
+        }
+
+        try {
+            makeURL(environment);
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            throw new NamingException();
+        }
+
+        autoScale();
+
+        createConnectionFactories(data, environment);
+
+        createDestinations(data, environment);
+
+        createQueues(data, environment);
+
+        createTopics(data, environment);
+
+        return createContext(data, environment);
+    }
+
+    /**
+     * This method create the context
+     *
+     * @param data        Context information
+     * @param environment property values which need to construct the InitialContext
+     * @return ReadOnlyContext
+     */
+    private ReadOnlyContext createContext(Map data, Hashtable environment) {
+        return new ReadOnlyContext(environment, data);
+    }
+
+    /**
+     * Make the AMQP URL by getting details from web service.
+     *
+     * @param environment property values which need to construct the InitialContext
+     */
+    private synchronized void makeURL(Hashtable environment) throws IllegalAccessException, InstantiationException,
+            ClassNotFoundException, NamingException {
+
+        for (Object object : environment.entrySet()) {
+            Map.Entry entry = (Map.Entry) object;
+            String key = entry.getKey().toString();
+
+            //Get the initial URL to call web service
+            if (key.startsWith(CONNECTION_FACTORY_PREFIX)) {
+
+                String initialURL = entry.getValue().toString();
+                initialURLs = initialURL.split(",");
+
+                //Get the fail over properties
+            } else if (key.startsWith(DiscoveryValues.FAILOVER_PROPERTIES)) {
+
+                String names = entry.getValue().toString();
+
+                StringTokenizer stringTokenizer = new StringTokenizer(names, ",");
+
+                while (stringTokenizer.hasMoreElements()) {
+
+                    String failOverProperties = (String) stringTokenizer.nextElement();
+
+                    if (failOverProperties.startsWith("RETRIES")) {
+                        retries = Integer.parseInt(failOverProperties.substring(failOverProperties.lastIndexOf("=") + 1));
+                    } else if (failOverProperties.startsWith("CONNECTION_DELAY")) {
+                        connectdelay = Integer.parseInt(failOverProperties.substring(failOverProperties.lastIndexOf("=") + 1));
+                    } else if (failOverProperties.startsWith("CYCLE_COUNT")) {
+                        cyclecount = Integer.parseInt(failOverProperties.substring(failOverProperties.lastIndexOf("=") + 1));
+                    }
+                }
+
+                //Get the SSL certification URI.
+            } else if (key.startsWith(DiscoveryValues.TRUSTSTORE)) {
+
+                trustStoreLocation = entry.getValue().toString();
+
+
+            } else if (key.startsWith(DiscoveryValues.PERIODIC_TIME_PREFIX)) {
+
+                time = Float.parseFloat(entry.getValue().toString());
+
+                //Get the ssl properties.
+            } else if (key.startsWith("ssl")) {
+                mode = "ssl";
+                String names = entry.getValue().toString();
+                String[] namesList = names.split(",");
+
+                certificateAliasInTrustsStore = namesList[0];
+                pathToTrustStore = namesList[1];
+                trustStorePassword = namesList[2];
+                pathToKeyStore = namesList[3];
+                keyStorePassword = namesList[4];
+
+                //Get Carbon properties.
+            } else if (key.startsWith(DiscoveryValues.CARBON_PROPERTIES)) {
+
+                String names = entry.getValue().toString();
+                String[] namesList = names.split(",");
+                carbonClientId = namesList[0];
+                carbonHostName = namesList[1];
+
+                //Get username and password.
+            } else if (key.startsWith(DiscoveryValues.AUTHENTICATION_CLIENT)) {
+
+               // byte[] valueDecoded = Base64.decodeBase64((byte[]) entry.getValue());
+
+                StringTokenizer stringTokenizer = new StringTokenizer(entry.getValue().toString(), ",");
+
+                while (stringTokenizer.hasMoreElements()) {
+                    detailList.add((String) stringTokenizer.nextElement());
+                }
+
+            }
+
+        }
+        try {
+            Class aClass = Class.forName("org.wso2.andes.ws.DynamicDiscovery");
+            dynamicDiscoveryWebServices = (DynamicDiscoveryWebServices) aClass.newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new NamingException();
+        }
+
+        //Making AMQP URL
+        String amqpURL = getTCPConnectionURL(detailList.get(0), detailList.get(0), carbonClientId, carbonHostName, initialURLs,
+                retries, connectdelay, cyclecount);
+        environment.put("connectionfactory.qpidConnectionfactory", amqpURL);
+
+       /* environment.put("connectionfactory.qpidConnectionfactory",
+                "amqp://admin:admin@carbon/carbon?brokerlist='tcp://10.100.4.165:5673?retries='null'&connectdelay='null';tcp://10.100.4.165:5672?retries='0'&connectdelay='0''&failover='roundrobin?cyclecount='null''");
+*/
+
+    }
+
+    /**
+     * Periodically calling web service and update broker list.
+     */
+    private void autoScale() {
+
+        Runnable autoScaleRunnable = new Runnable() {
+            public void run() {
+
+                List<String> checkBrokersList;
+                List<String> exsistingBrokerList = new ArrayList<>();
+
+                checkBrokersList = dynamicDiscoveryWebServices.getLocalDynamicDiscoveryDetails(initialURLs,
+                        detailList.get(0), detailList.get(1), mode, trustStoreLocation);
+
+                try {
+                    ConnectionURL amqConnectionURL = amqConnectionFactory.getAmqpConnection();
+
+                    for (int i = 0; i < amqConnectionURL.getAllBrokerDetails().size(); i++) {
+
+                        exsistingBrokerList.add("" + amqConnectionURL.getAllBrokerDetails().get(i).getHost() + ":"
+                                + amqConnectionURL.getAllBrokerDetails().get(i).getPort() + "");
+                    }
+
+                    ((Collection) checkBrokersList).removeAll((Collection) exsistingBrokerList);
+
+                    for (Object object : ((Collection) checkBrokersList)) {
+                        String broker = object.toString();
+                        String addBroker = "tcp://" + broker + "?retries='" + retries + "'&connectdelay='"
+                                + connectdelay + "'";
+
+                        AMQBrokerDetails brokerDetails = new AMQBrokerDetails(addBroker);
+                        amqConnectionURL.addBrokerDetails(brokerDetails);
+                    }
+
+                } catch (URLSyntaxException e) {
+                    logger.error("URLSyntax error occurred while adding broker details to broker URL", e);
+                }
+            }
+        };
+
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(0);
+        executor.scheduleAtFixedRate(autoScaleRunnable, 1, (long) time, TimeUnit.MINUTES);
+    }
+
+    /**
+     * Making AMQP URL.
+     *
+     * @param username                 username
+     * @param password                 password
+     * @param CARBON_CLIENT_ID         carbon client ID
+     * @param CARBON_VIRTUAL_HOST_NAME carbon host name
+     * @param URL                      web service calling IP address and port
+     * @param retries                  The number of times to retry connection to each broker in the broker list
+     * @param connectDelay             Length of time (in milliseconds) to wait before attempting to reconnect
+     * @param cycleCount               How many cycles for retries.
+     * @return AMQP URL
+     */
+    private synchronized String getTCPConnectionURL(String username, String password, String CARBON_CLIENT_ID,
+                                       String CARBON_VIRTUAL_HOST_NAME, String[] URL, int retries,
+                                       int connectDelay, int cycleCount) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+        String ip = null;
+        StringBuilder output = new StringBuilder();
+        String failOver_Config = "retries='" + retries + "'&connectDelay='" + connectDelay + "'";
+
+        String ssl_Config = "?ssl='true'&ssl_cert_alias='" + certificateAliasInTrustsStore + "'&trust_store='"
+                + pathToTrustStore + "'&trust_store_password='" + trustStorePassword + "'&key_store='"
+                + pathToKeyStore + "'&key_store_password='" + keyStorePassword + "'";
+
+        List<String> wsResult = dynamicDiscoveryWebServices.getLocalDynamicDiscoveryDetails(URL, username, password, mode,
+                trustStoreLocation);
+
+        if (!wsResult.isEmpty()) {
+            ip = wsResult.get(0);
+            for (int i = 0; i < wsResult.size(); ) {
+                if (wsResult.get(i).equals(ip)) {
+                    i++;
+                } else {
+                    if (mode.equals("ssl")) {
+                        output.append(";tcp://").append(wsResult.get(i)).append(ssl_Config).append("&").append(failOver_Config);
+                        i++;
+                    } else {
+                        output.append(";tcp://").append(wsResult.get(i)).append("?").append(failOver_Config);
+                        i++;
+                    }
+                }
+            }
+        }
+
+        if (mode.equals("ssl")) {
+            // amqp://{username}:{password}@carbon/carbon?brokerlist='tcp://{hostname}:{port}'
+            return "amqp://" + username + ":" + password
+                    + "@" + CARBON_CLIENT_ID
+                    + "/" + CARBON_VIRTUAL_HOST_NAME + "?failover='roundrobin'&cycleCount='"
+                    + cycleCount + "'"
+                    + "&brokerlist='tcp://" + ip + ssl_Config
+                    + "&" + failOver_Config + output + "'";
+
+        } else {
+            // amqp://{username}:{password}@carbon/carbon?brokerlist='tcp://{hostname}:{port}'
+            return "amqp://" + username + ":" + password
+                    + "@" + CARBON_CLIENT_ID
+                    + "/" + CARBON_VIRTUAL_HOST_NAME + "?failover='roundrobin'&cycleCount='"
+                    + cycleCount + "'"
+                    + "&brokerlist='tcp://" + ip + "?" + failOver_Config
+                    + output + "'";
+        }
+    }
+
+    /**
+     * Create connection factory using given environment variables
+     *
+     * @param data        connection factory information to the relevant jndiname
+     * @param environment property values which need to construct the InitialContext
+     */
+    private synchronized void createConnectionFactories(Map data, Hashtable environment) throws ConfigurationException {
+        resolveEncryptedProperties(environment);
+
+        for (Object object : environment.entrySet()) {
+            Map.Entry entry = (Map.Entry) object;
+            String key = entry.getKey().toString();
+            if (key.startsWith(CONNECTION_FACTORY_PREFIX)) {
+                String jndiName = key.substring(CONNECTION_FACTORY_PREFIX.length());
+                ConnectionFactory connectionFactory = createFactory(entry.getValue().toString().trim());
+                if (connectionFactory != null) {
+                    data.put(jndiName, connectionFactory);
+                }
+            }
+        }
+    }
+
+    /**
+     * Create destinations using given environment variables
+     *
+     * @param data        designation information to the relevant jndiname
+     * @param environment property values which need to construct the InitialContext
+     * @throws ConfigurationException
+     */
+    private void createDestinations(Map data, Hashtable environment) throws ConfigurationException {
+        for (Object object : environment.entrySet()) {
+            Map.Entry entry = (Map.Entry) object;
+            String key = entry.getKey().toString();
+            if (key.startsWith(DESTINATION_PREFIX)) {
+                String jndiName = key.substring(DESTINATION_PREFIX.length());
+                Destination destination = createDestination(entry.getValue().toString().trim());
+                if (destination != null) {
+                    data.put(jndiName, destination);
+                }
+            }
+        }
+    }
+
+    /**
+     * Queue is created using this method.
+     *
+     * @param data        Queue information to the relevant jndiname
+     * @param environment property values which need to construct the InitialContext
+     */
+    private void createQueues(Map data, Hashtable environment) {
+        for (Object object : environment.entrySet()) {
+            Map.Entry entry = (Map.Entry) object;
+            String key = entry.getKey().toString();
+            if (key.startsWith(QUEUE_PREFIX)) {
+                String jndiName = key.substring(QUEUE_PREFIX.length());
+                Queue q = createQueue(entry.getValue().toString().trim());
+                if (q != null) {
+                    data.put(jndiName, q);
+                }
+            }
+        }
+    }
+
+    /**
+     * Topic is created in this method.
+     *
+     * @param data        Topic information to the relevant jndiname
+     * @param environment property values which need to construct the InitialContext
+     */
+    private void createTopics(Map data, Hashtable environment) {
+        for (Object object : environment.entrySet()) {
+            Map.Entry entry = (Map.Entry) object;
+            String key = entry.getKey().toString();
+            if (key.startsWith(TOPIC_PREFIX)) {
+                String jndiName = key.substring(TOPIC_PREFIX.length());
+                Topic topic = createTopic(entry.getValue().toString().trim());
+                if (topic != null) {
+                    if (logger.isDebugEnabled()) {
+                        StringBuilder stringBuilder = new StringBuilder();
+                        stringBuilder.append("Creating the topic: ").append(jndiName).append(" with the following binding keys ");
+                        for (AMQShortString binding : ((AMQTopic) topic).getBindingKeys()) {
+                            stringBuilder.append(binding.toString()).append(",");
+                        }
+
+                        logger.debug(stringBuilder.toString());
+                    }
+                    data.put(jndiName, topic);
+                }
+            }
+        }
+    }
+
+    /**
+     * Factory method to create new Connection Factory instances
+     *
+     * @param url AMQP URL
+     * @return AMQ connection factory
+     * @throws ConfigurationException
+     */
+    private synchronized ConnectionFactory createFactory(String url) throws ConfigurationException {
+        try {
+
+            amqConnectionFactory = new AMQConnectionFactory(url);
+            return amqConnectionFactory;
+        } catch (URLSyntaxException urlse) {
+            logger.warn("Unable to create factory:" + urlse);
+
+            ConfigurationException configurationException = new ConfigurationException("Failed to parse entry: " + urlse + " due to : " + urlse.getMessage());
+            configurationException.initCause(urlse);
+            throw configurationException;
+        }
+    }
+
+    /**
+     * Factory method to create new Destination instances from an AMQP BindingURL
+     */
+    private Destination createDestination(String str) throws ConfigurationException {
+        try {
+            return AMQDestination.createDestination(str);
+        } catch (Exception e) {
+            logger.warn("Unable to create destination:", e);
+
+            ConfigurationException configurationException = new ConfigurationException("Failed to parse entry: " + str + " due to : " + e.getMessage());
+            configurationException.initCause(e);
+            throw configurationException;
+        }
+    }
+
+    /**
+     * Factory method to create new Queue instances
+     */
+    protected Queue createQueue(Object value) {
+        if (value instanceof AMQShortString) {
+            return new AMQQueue(ExchangeDefaults.DIRECT_EXCHANGE_NAME, (AMQShortString) value);
+        } else if (value instanceof String) {
+            return new AMQQueue(ExchangeDefaults.DIRECT_EXCHANGE_NAME, new AMQShortString((String) value));
+        } else if (value instanceof BindingURL) {
+            return new AMQQueue((BindingURL) value);
+        }
+
+        return null;
+    }
+
+    /**
+     * Factory method to create new Topic instances
+     */
+    protected Topic createTopic(Object value) {
+        if (value instanceof AMQShortString) {
+            return new AMQTopic(ExchangeDefaults.TOPIC_EXCHANGE_NAME, (AMQShortString) value);
+        } else if (value instanceof String) {
+            String[] keys = ((String) value).split(",");
+            AMQShortString[] bindings = new AMQShortString[keys.length];
+            int i = 0;
+            for (String key : keys) {
+                bindings[i] = new AMQShortString(key.trim());
+                i++;
+            }
+            // The Destination has a dual nature. If this was used for a producer the key is used
+            // for the routing key. If it was used for the consumer it becomes the bindingKey
+            return new AMQTopic(ExchangeDefaults.TOPIC_EXCHANGE_NAME, bindings[0], null, bindings);
+        } else if (value instanceof BindingURL) {
+            return new AMQTopic((BindingURL) value);
+        }
+
+        return null;
+    }
+
+    /**
+     * Factory method to create new HeaderExchange instances
+     */
+    protected Destination createHeaderExchange(Object value) {
+        if (value instanceof String) {
+            return new AMQHeadersExchange((String) value);
+        } else if (value instanceof BindingURL) {
+            return new AMQHeadersExchange((BindingURL) value);
+        }
+
+        return null;
+    }
+
+
+    // Properties
+    @SuppressWarnings("unused")
+    public String getConnectionPrefix() {
+        return CONNECTION_FACTORY_PREFIX;
+    }
+
+    @SuppressWarnings("unused")
+    public void setConnectionPrefix(String connectionPrefix) {
+        this.CONNECTION_FACTORY_PREFIX = connectionPrefix;
+    }
+
+    @SuppressWarnings("unused")
+    public String getDestinationPrefix() {
+        return DESTINATION_PREFIX;
+    }
+
+    @SuppressWarnings("unused")
+    public void setDestinationPrefix(String destinationPrefix) {
+        this.DESTINATION_PREFIX = destinationPrefix;
+    }
+
+    @SuppressWarnings("unused")
+    public String getQueuePrefix() {
+        return QUEUE_PREFIX;
+    }
+
+    @SuppressWarnings("unused")
+    public void setQueuePrefix(String queuePrefix) {
+        this.QUEUE_PREFIX = queuePrefix;
+    }
+
+    @SuppressWarnings("unused")
+    public String getTopicPrefix() {
+        return TOPIC_PREFIX;
+    }
+
+    @SuppressWarnings("unused")
+    public void setTopicPrefix(String topicPrefix) {
+        this.TOPIC_PREFIX = topicPrefix;
+    }
+}

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/ws/DynamicDiscovery.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/ws/DynamicDiscovery.java
@@ -1,0 +1,139 @@
+/*
+* Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.andes.ws;
+
+import com.sun.org.apache.xerces.internal.parsers.DOMParser;
+import org.apache.axis.client.Call;
+import org.apache.axis.client.Service;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+import javax.xml.namespace.QName;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Dynamic discovery class implements DynamicDiscoveryWebServices. Web service is calling inside this class.
+ */
+
+public class DynamicDiscovery implements DynamicDiscoveryWebServices {
+
+    private static HashMap<String, List<String>> hashMap = new HashMap<>();
+    private final Logger log = LoggerFactory.getLogger(DynamicDiscovery.class);
+
+    @Override
+    public List<String> getLocalDynamicDiscoveryDetails(String[] initialAddress, String userName, String passWord,
+                                                        String mode, String trustStore) {
+         List<String> brokerDetailsList = new ArrayList<>();
+         List<String> checkerList = new ArrayList<>();
+
+        int count = 0;
+        int maxTries = initialAddress.length;
+        String decision = "port";
+
+        //Selecting mode ssl or default
+        if (mode.equals("ssl")) {
+            decision = "ssl-port";
+        }
+
+
+        for (int i = count; i < maxTries; ) {
+            try {
+                String endpoint = "https://" + initialAddress[count] + "/services/AndesManagerService";
+                System.setProperty(
+                        "javax.net.ssl.trustStore", trustStore);
+                Service service = new Service();
+                Call call = (Call) service.createCall();
+                call.setTargetEndpointAddress(new java.net.URL(endpoint));
+                call.setOperationName(new QName("http://mgt.cluster.andes.carbon.wso2.org", "getBrokerInformation"));
+                call.setUsername(userName);
+                call.setPassword(passWord);
+
+                String xmlResponse = (String) call.invoke(new Object[]{});
+                DOMParser parser = new DOMParser();
+                parser.parse(new InputSource(new java.io.StringReader(xmlResponse)));
+                Document doc = parser.getDocument();
+
+
+                for (int j = 0; j < doc.getDocumentElement().getElementsByTagName("Address").getLength(); ) {
+
+                    try {
+                        String nodeId = doc.getDocumentElement().getElementsByTagName("Address").item(j).getParentNode
+                                ().getParentNode().getAttributes().getNamedItem("id").getNodeValue();
+
+                        String Ip = doc.getDocumentElement().getElementsByTagName("Address").item(j).getAttributes()
+                                .getNamedItem("ip").getNodeValue();
+
+                        int port = Integer.parseInt(doc.getDocumentElement().getElementsByTagName("Address").item(j)
+                                .getAttributes()
+                                .getNamedItem(decision).getNodeValue());
+
+                        String interface_name = doc.getDocumentElement().getElementsByTagName("Address").item(j).getAttributes()
+                                .getNamedItem("interface-name").getNodeValue();
+
+                        if (hashMap.containsKey(nodeId)) {
+                            for (Object object : hashMap.entrySet()) {
+                                Map.Entry entry = (Map.Entry) object;
+                                String key = entry.getKey().toString();
+
+                                if (key.equals(nodeId)) {
+                                    List entryValue = (List) entry.getValue();
+
+                                    if (entryValue.contains(interface_name)) {
+                                        brokerDetailsList.add(Ip + ":" + port);
+                                        j++;
+                                    } else {
+                                        Socket socket = new Socket();
+                                        socket.connect(new InetSocketAddress(Ip, port), 1000);
+                                        brokerDetailsList.add(Ip + ":" + port);
+                                        checkerList.add(interface_name);
+                                        hashMap.put(nodeId, checkerList);
+                                        j++;
+                                    }
+                                }
+                            }
+                        } else {
+                            Socket socket = new Socket();
+                            socket.connect(new InetSocketAddress(Ip, port), 1000);
+                            brokerDetailsList.add(Ip + ":" + port);
+                            checkerList.add(interface_name);
+                            hashMap.put(nodeId, checkerList);
+                            j++;
+                        }
+                    } catch (Exception e) {
+                        j++;
+                    }
+                }
+                break;
+            } catch (Exception e) {
+
+                count++;
+                if (count == maxTries) {
+                    log.error("Error while calling dynamic discovery web service", e);
+                }
+            }
+        }
+        return brokerDetailsList;
+    }
+}

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/ws/DynamicDiscoveryWebServices.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/ws/DynamicDiscoveryWebServices.java
@@ -1,0 +1,39 @@
+/*
+* Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.andes.ws;
+
+import java.util.List;
+
+/**
+ * Interface that contains dynamic discovery web services
+ */
+public interface DynamicDiscoveryWebServices {
+
+    /**
+     * Get the all live node IP address
+     * @param initialAddress web service calling ip address
+     * @param userName username for log to server
+     * @param passWord password for log to server
+     * @param mode SSL or default
+     * @param trustStore security key for calling web service
+     * @return list of IP address
+     */
+    List<String> getLocalDynamicDiscoveryDetails(String[] initialAddress, String userName, String passWord , String mode, String trustStore);
+
+
+}

--- a/modules/andes-core/management/common/src/main/java/org/wso2/andes/management/common/mbeans/ClusterManagementInformation.java
+++ b/modules/andes-core/management/common/src/main/java/org/wso2/andes/management/common/mbeans/ClusterManagementInformation.java
@@ -2,8 +2,8 @@ package org.wso2.andes.management.common.mbeans;
 
 import org.wso2.andes.management.common.mbeans.annotations.MBeanAttribute;
 
-import java.util.List;
 import javax.management.JMException;
+import java.util.List;
 
 /**
  * <code>ClusterManagementInformation</code>
@@ -47,4 +47,13 @@ public interface ClusterManagementInformation {
      */
     @MBeanAttribute(name = "getStoreHealth", description = "Gets the message stores health status")
     boolean getStoreHealth();
+
+    /**
+     * Get the all live node's IP address and port which is bound to AMQP
+     * @return Transport data objects which contains IPs and the Ports
+     * @throws AndesException
+     */
+    @MBeanAttribute(name = "getBrokerDetail", description = "Gets the all live nodes")
+   String getBrokerDetail() throws JMException;
+
 }

--- a/modules/andes-core/pom.xml
+++ b/modules/andes-core/pom.xml
@@ -358,6 +358,16 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.axis/axis -->
+        <dependency>
+            <groupId>org.apache.axis</groupId>
+            <artifactId>axis</artifactId>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/javax.xml/jaxrpc-api -->
+        <dependency>
+            <groupId>javax.xml</groupId>
+            <artifactId>jaxrpc-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/orbit/andes-client/pom.xml
+++ b/modules/orbit/andes-client/pom.xml
@@ -101,9 +101,14 @@
                         <Import-Package>
                             org.slf4j.*;version="1.6.1",
                             org.apache.commons.logging.*,
+                            org.apache.commons.codec.*,
                             org.wso2.securevault.*,
                             org.ietf.jgss*,
                             javax.*,
+                            org.w3c.dom.*,
+                            com.sun.org.apache.xerces.internal.parsers.*,
+                            org.xml.sax.*,
+                            org.apache.axis.client.*,
                             com.google.common.base;version="19.0.0",
                             com.google.common.util.concurrent;version="19.0.0",  
                             com.google.common.cache;version="19.0.0"

--- a/modules/orbit/andes/pom.xml
+++ b/modules/orbit/andes/pom.xml
@@ -115,6 +115,16 @@
             <groupId>com.goldmansachs</groupId>
             <artifactId>gs-collections</artifactId>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.axis/axis -->
+        <dependency>
+            <groupId>org.apache.axis</groupId>
+            <artifactId>axis</artifactId>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/javax.xml/jaxrpc-api -->
+        <dependency>
+            <groupId>javax.xml</groupId>
+            <artifactId>jaxrpc-api</artifactId>
+        </dependency>
 
         <!--MQTT Dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -474,6 +474,16 @@
                 <artifactId>commons-pool2</artifactId>
                 <version>${org.apache.commons.pool.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.axis</groupId>
+                <artifactId>axis</artifactId>
+                <version>${axis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.xml</groupId>
+                <artifactId>jaxrpc-api</artifactId>
+                <version>${jaxrpc-api.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -639,6 +649,8 @@
         <gs-collections-api.version>7.0.3</gs-collections-api.version>
         <gs-collections.version>7.0.3</gs-collections.version>
         <org.apache.commons.pool.version>2.4.2</org.apache.commons.pool.version>
+        <axis.version>1.4</axis.version>
+        <jaxrpc-api.version>1.1</jaxrpc-api.version>
 
     </properties>
 


### PR DESCRIPTION
**Dynamic discovery of broker nodes in cluster project client side implementation.**  

In MB, the user/developers having to manually list out the IPs in the connection URL could be difficult. The change of IPs of the broker nodes would require reconfiguring and restart the client applications connected to it. I am implementing a way to dynamically detection the MB nodes in the cluster and load balance through them.

I got the IP address(all network interfaces) and AMQP ports(with SSL) and store database at cluster startup. When node shutdown that details are removed from the database.
I wrote an admin service [1] to get those database details at the carbon business module.

In Andes client, I implemented a new initialContextFactory and inside that, I made an AMQP URL

[1] https://github.com/wso2/carbon-business-messaging/pull/367