### PR TITLE
Use multiple table-sets to store messages (& metadata)

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -408,6 +408,12 @@ public enum AndesConfiguration implements ConfigurationProperty {
             Integer.class),
 
     /**
+     * Number of maximum thrift clients connections that should be created when utilizing the thrift client
+     * connection pool.
+     */
+    PERFORMANCE_TUNING_THRIFT_CLIENT_POOL_SIZE("performanceTuning/slots/thriftClientPoolSize", "10", Integer.class),
+
+    /**
      * Published message information is sent to slot coordinator by the node when it either reaches the slot window
      * size or the window creation timeout in milliseconds. This configures the timeout for slot window creation task.
      * <p>

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -456,6 +456,11 @@ public enum AndesConfiguration implements ConfigurationProperty {
                                                          Integer.class),
 
     /**
+     * Number of MB_METADATA and MB_CONTENT tables that create in the database.
+     */
+    PERFORMANCE_TUNING_NUMBER_OF_TABLES ("performanceTuning/numberOfMessagingTables", "5", Integer.class),
+
+    /**
      * Number of parallel decompression handlers used to decompress messages before send to subscribers. Increasing
      * this value will speedup the message decompressing mechanism. But the system load will increase.
      */
@@ -471,6 +476,7 @@ public enum AndesConfiguration implements ConfigurationProperty {
 
     /**
      * Content batch size for each content batch read. This is a loose guarantee.
+     * The Batch size is 65000 bytes.
      */
     PERFORMANCE_TUNING_DELIVERY_CONTENT_READ_BATCH_SIZE("performanceTuning/delivery/contentReadBatchSize", "65000",
             Integer.class),

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014-2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,7 +19,6 @@
 package org.wso2.andes.kernel;
 
 import com.gs.collections.impl.list.mutable.primitive.LongArrayList;
-import com.gs.collections.impl.map.mutable.primitive.LongObjectHashMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.configuration.AndesConfigurationManager;
@@ -46,6 +45,7 @@ import org.wso2.carbon.metrics.manager.Meter;
 import org.wso2.carbon.metrics.manager.MetricManager;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -463,9 +463,6 @@ public class Andes {
      * @return AndesMessagePart
      * @throws AndesException
      */
-    public AndesMessagePart getMessageContentChunk(long messageID, int offsetInMessage) throws AndesException {
-        return MessagingEngine.getInstance().getMessageContentChunk(messageID, offsetInMessage);
-    }
 
     /**
      * Get a single metadata object.
@@ -526,26 +523,15 @@ public class Andes {
     }
 
     /**
-     * Get content chunk from store.
-     *
-     * @param messageId   id of the message
-     * @param offsetValue chunk id
-     * @return message content
-     * @throws AndesException
-     */
-    public AndesMessagePart getContent(long messageId, int offsetValue) throws AndesException {
-        return MessagingEngine.getInstance().getContent(messageId, offsetValue);
-    }
-
-    /**
      * Get content chunks for a list of message ids from store.
      *
      * @param messageIdList list of messageIds
+     * @param destinationQueueName queue Name for each messageID lists
      * @return map of message id:content chunk list
      * @throws AndesException
      */
-    public LongObjectHashMap<List<AndesMessagePart>> getContent(LongArrayList messageIdList) throws AndesException {
-        return MessagingEngine.getInstance().getContent(messageIdList);
+    public HashMap<Long ,List<AndesMessagePart>> getContent(LongArrayList messageIdList, String destinationQueueName) throws AndesException {
+        return MessagingEngine.getInstance().getContent(destinationQueueName , messageIdList);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessageMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessageMetadata.java
@@ -476,7 +476,7 @@ public class AndesMessageMetadata implements Comparable<AndesMessageMetadata> {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof AndesMessageMetadata)){
+        if (!(o instanceof AndesMessageMetadata)) {
             return false;
         }
         AndesMessageMetadata andesMessageMetadata = (AndesMessageMetadata) o;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesUtils.java
@@ -26,14 +26,12 @@ import org.wso2.andes.kernel.subscription.AndesSubscription;
 import org.wso2.andes.kernel.subscription.StorageQueue;
 import org.wso2.andes.mqtt.utils.MQTTUtils;
 import org.wso2.andes.server.ClusterResourceHolder;
-import org.wso2.andes.server.queue.QueueEntry;
 import org.wso2.andes.server.store.MessageMetaDataType;
 
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -58,12 +56,6 @@ public class AndesUtils {
     private static ConcurrentHashMap<String, Long> browserMessageIdCorrelater = new ConcurrentHashMap<>();
 
     private static PrintWriter printWriterGlobal;
-
-    public static String printAMQMessage(QueueEntry message) {
-        ByteBuffer buf = ByteBuffer.allocate(100);
-        int readCount = message.getMessage().getContent(buf, 0);
-        return "(" + message.getMessage().getMessageNumber() + ")" + new String(buf.array(), 0, readCount);
-    }
 
     /**
      * Register a mapping between browser message Id and Andes message Id. This is expected to be invoked

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliveryResponsibility.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliveryResponsibility.java
@@ -36,7 +36,7 @@ public abstract class DeliveryResponsibility {
      *
      * @param deliveryResponsibility responsibility that need to be performed in the delivery path
      */
-    public void setNextDeliveryFilter(DeliveryResponsibility deliveryResponsibility){
+    public void setNextDeliveryFilter(DeliveryResponsibility deliveryResponsibility) {
         this.nextDeliveryResponsibility = deliveryResponsibility;
     }
 
@@ -45,12 +45,13 @@ public abstract class DeliveryResponsibility {
      *
      * @param subscription subscription to which message should be delivered
      * @param message message to deliver
+     * @throws AndesException
      */
     public void handleDeliveryMessage(AndesSubscription subscription, DeliverableAndesMetadata message)
-            throws AndesException{
+            throws AndesException {
 
-        if(performResponsibility(subscription,message) && (null != nextDeliveryResponsibility)){
-            nextDeliveryResponsibility.handleDeliveryMessage(subscription,message);
+        if (performResponsibility(subscription, message) && (null != nextDeliveryResponsibility)) {
+            nextDeliveryResponsibility.handleDeliveryMessage(subscription, message);
         }
 
     }
@@ -61,6 +62,7 @@ public abstract class DeliveryResponsibility {
      * @param subscription subscription to which message should be delivered
      * @param message message to deliver
      * @return true if it is okay to hand over to the next responsibility in the chain
+     * @throws AndesException
      */
     protected abstract boolean performResponsibility (AndesSubscription subscription,
                                                       DeliverableAndesMetadata message) throws AndesException;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ExpiredMessageHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ExpiredMessageHandler.java
@@ -38,7 +38,7 @@ public class ExpiredMessageHandler extends DeliveryResponsibility {
      *
      * @param task deletion task
      */
-    public void setExpiryMessageDeletionTask(PreDeliveryExpiryMessageDeletionTask task){
+    public void setExpiryMessageDeletionTask(PreDeliveryExpiryMessageDeletionTask task) {
         this.preDeliveryExpiryMessageDeletionTask = task;
     }
 
@@ -51,14 +51,14 @@ public class ExpiredMessageHandler extends DeliveryResponsibility {
     protected boolean performResponsibility(AndesSubscription subscription,
                                             DeliverableAndesMetadata message) throws AndesException {
         boolean isOkayToProceed = true;
-         // Check if destination entry has expired. Any expired message will not be delivered
+        // Check if destination entry has expired. Any expired message will not be delivered
         if (message.isExpired()) {
             log.warn("Message is expired. Therefore, it will not be sent. : id= " + message.getMessageID());
-             // Since this message is not going to be delivered, no point in wait for ack.
+            // Since this message is not going to be delivered, no point in wait for ack.
             message.getSlot().decrementPendingMessageCount();
-             // Add the expired messages to a list for a batch delete
+            // Add the expired messages to a list for a batch delete
             preDeliveryExpiryMessageDeletionTask.addMessageIdToExpiredQueue(message.getMessageID());
-            MessageTracer.trace(message,MessageTracer.EXPIRED_MESSAGE_DETECTED_AND_QUEUED);
+            MessageTracer.trace(message, MessageTracer.EXPIRED_MESSAGE_DETECTED_AND_QUEUED);
             isOkayToProceed = false;
         }
         return isOkayToProceed;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageExpiryManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageExpiryManager.java
@@ -39,7 +39,7 @@ public class MessageExpiryManager {
      * @param dlcQueueName DLC queue name
      */
     public void moveMetadataToDLC(List<AndesMessageMetadata> messages, String dlcQueueName)
-            throws AndesException{
+            throws AndesException {
         messageStore.moveMetadataToDLC(messages, dlcQueueName);
     }
 
@@ -50,7 +50,7 @@ public class MessageExpiryManager {
      * @param dlcQueueName DLC Queue name for which the message is routed to
      * @throws AndesException
      */
-    public void moveMetadataToDLC(long messageId, String dlcQueueName) throws AndesException{
+    public void moveMetadataToDLC(long messageId, String dlcQueueName) throws AndesException {
         messageStore.moveMetadataToDLC(messageId, dlcQueueName);
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005-2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2005-2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,12 +19,12 @@
 package org.wso2.andes.kernel;
 
 import com.gs.collections.impl.list.mutable.primitive.LongArrayList;
-import com.gs.collections.impl.map.mutable.primitive.LongObjectHashMap;
 import org.wso2.andes.configuration.util.ConfigurationProperties;
 import org.wso2.andes.kernel.slot.Slot;
 import org.wso2.andes.kernel.slot.RecoverySlotCreator;
 import org.wso2.andes.store.HealthAwareStore;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -45,14 +45,6 @@ public interface MessageStore extends HealthAwareStore {
             ConfigurationProperties connectionProperties) throws AndesException;
 
     /**
-     * store a message content chunk set
-     *
-     * @param partList message content chunk list
-     * @throws AndesException
-     */
-    void storeMessagePart(List<AndesMessagePart> partList) throws AndesException;
-
-    /**
      * read content chunk from store
      *
      * @param messageId   id of the message chunk belongs
@@ -65,11 +57,12 @@ public interface MessageStore extends HealthAwareStore {
     /**
      * Read content for given message metadata list
      *
-     * @param messageIDList message id list for the content to be retrieved
+     * @param queueName queueName for each messageID list.
      * @return <code>Map<Long, List<AndesMessagePart>></code> Message id and its corresponding message part list
      * @throws AndesException
      */
-    LongObjectHashMap<List<AndesMessagePart>> getContent(LongArrayList messageIDList) throws AndesException;
+    HashMap<Long, List<AndesMessagePart>> getContent(String queueName, LongArrayList messageIdList)
+            throws AndesException;
 
     /**
      * Store messages into database.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014-2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,7 +19,6 @@
 package org.wso2.andes.kernel;
 
 import com.gs.collections.impl.list.mutable.primitive.LongArrayList;
-import com.gs.collections.impl.map.mutable.primitive.LongObjectHashMap;
 import org.apache.log4j.Logger;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
@@ -115,8 +114,6 @@ public class MessagingEngine {
 
         this.messageStore = messageStore;
         this.messageExpiryManager = messageExpiryManager;
-
-
         /*
         Initialize the SlotCoordinator
          */
@@ -140,15 +137,15 @@ public class MessagingEngine {
     }
 
     /**
-     * Read content for given message metadata list
+     * Read content for given message metadata list per queue
      *
      * @param messageIdList message id list for the content to be retrieved
      * @return <code>Map<Long, List<AndesMessagePart>></code> Message id and its corresponding message part list
      * @throws AndesException
      */
-    public LongObjectHashMap<List<AndesMessagePart>> getContent(LongArrayList messageIdList) throws AndesException {
-        return messageStore.getContent(messageIdList);
-
+    public HashMap<Long, List<AndesMessagePart>> getContent(String queueName, LongArrayList messageIdList)
+            throws AndesException {
+        return messageStore.getContent(queueName, messageIdList);
     }
 
     /**
@@ -275,7 +272,7 @@ public class MessagingEngine {
      * @throws AndesException
      */
     public void deleteMessagesById(List<Long> messagesToRemove) throws AndesException {
-            messageStore.deleteMessages(messagesToRemove);
+        messageStore.deleteMessages(messagesToRemove);
     }
 
 
@@ -405,7 +402,7 @@ public class MessagingEngine {
      * @throws AndesException
      */
     public List<DeliverableAndesMetadata> getMetaDataList(final Slot slot, final String queueName, long firstMsgId,
-            long lastMsgID) throws AndesException {
+                                                          long lastMsgID) throws AndesException {
         return messageStore.getMetadataList(slot, queueName, firstMsgId, lastMsgID);
     }
 
@@ -420,7 +417,7 @@ public class MessagingEngine {
      * @throws AndesException
      */
     public List<AndesMessageMetadata> getNextNMessageMetadataFromQueue(final String queueName, long firstMsgId,
-            int count) throws AndesException {
+                                                                       int count) throws AndesException {
         return messageStore.getNextNMessageMetadataFromQueue(queueName, firstMsgId, count);
     }
 
@@ -435,7 +432,9 @@ public class MessagingEngine {
      * @throws AndesException
      */
     public List<AndesMessageMetadata> getNextNMessageMetadataInDLCForQueue(final String queueName,
-            final String dlcQueueName, long firstMsgId, int count) throws AndesException {
+                                                                           final String dlcQueueName,
+                                                                           long firstMsgId, int count)
+            throws AndesException {
         return messageStore.getNextNMessageMetadataForQueueFromDLC(queueName, dlcQueueName, firstMsgId, count);
     }
 
@@ -449,7 +448,7 @@ public class MessagingEngine {
      * @throws AndesException
      */
     public List<AndesMessageMetadata> getNextNMessageMetadataFromDLC(final String dlcQueueName, long firstMsgId,
-            int count) throws AndesException {
+                                                                     int count) throws AndesException {
         return messageStore.getNextNMessageMetadataFromDLC(dlcQueueName, firstMsgId, count);
     }
 
@@ -457,7 +456,7 @@ public class MessagingEngine {
      * Get expired but not yet deleted messages from message store
      *
      * @param lowerBoundMessageID lower bound message Id of the safe zone for delete
-     * @param  queueName Queue name
+     * @param queueName           Queue name
      * @return AndesRemovableMetadata
      * @throws AndesException
      */

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -35,7 +35,6 @@ import org.wso2.andes.server.ClusterResourceHolder;
 import org.wso2.andes.server.cluster.coordination.MessageIdGenerator;
 import org.wso2.andes.server.cluster.coordination.TimeStampBasedMessageIdGenerator;
 import org.wso2.andes.server.queue.DLCQueueUtils;
-import org.wso2.andes.thrift.MBThriftClient;
 import org.wso2.andes.tools.utils.MessageTracer;
 
 import java.util.ArrayList;
@@ -530,10 +529,6 @@ public class MessagingEngine {
         log.info("Starting SlotDelivery Workers.");
         //Start all slotDeliveryWorkers
         SlotDeliveryWorkerManager.getInstance().startMessageDelivery();
-        //Start thrift reconnecting thread if started
-        if (MBThriftClient.isReconnectingStarted()) {
-            MBThriftClient.setReconnectingFlag(true);
-        }
         log.info("Start Disruptor writing messages to store.");
     }
 
@@ -545,10 +540,6 @@ public class MessagingEngine {
         log.info("Stopping SlotDelivery Worker.");
         //Stop all slotDeliveryWorkers
         SlotDeliveryWorkerManager.getInstance().stopMessageDelivery();
-        //Stop thrift reconnecting thread if started
-        if (MBThriftClient.isReconnectingStarted()) {
-            MBThriftClient.setReconnectingFlag(false);
-        }
         SlotMessageCounter.getInstance().stop();
         //Stop delivery disruptor
         MessageFlusher.getInstance().stopMessageFlusher();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/PreDeliveryExpiryMessageDeletionTask.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/PreDeliveryExpiryMessageDeletionTask.java
@@ -24,12 +24,8 @@ import org.wso2.andes.store.HealthAwareStore;
 import org.wso2.andes.store.StoreHealthListener;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.BlockingDeque;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingDeque;
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/PreDeliveryExpiryMessageDeletionTask.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/PreDeliveryExpiryMessageDeletionTask.java
@@ -53,7 +53,7 @@ public class PreDeliveryExpiryMessageDeletionTask implements Runnable, StoreHeal
      */
     private volatile SettableFuture<Boolean> messageStoresUnavailable;
 
-    public PreDeliveryExpiryMessageDeletionTask(){
+    public PreDeliveryExpiryMessageDeletionTask() {
 
         this.messageStoresUnavailable = null;
         this.expiredMessageIds = new LinkedBlockingDeque<>();
@@ -62,7 +62,7 @@ public class PreDeliveryExpiryMessageDeletionTask implements Runnable, StoreHeal
 
     }
 
-    public void addMessageIdToExpiredQueue(long messageId){
+    public void addMessageIdToExpiredQueue(long messageId) {
         expiredMessageIds.add(messageId);
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/PurgedMessageHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/PurgedMessageHandler.java
@@ -46,7 +46,7 @@ public class PurgedMessageHandler extends DeliveryResponsibility {
                     + ". Therefore, it will not be sent. id= "
                     + message.getMessageID());
 
-            if(!message.isPurgedOrDeletedOrExpired()) {
+            if (!message.isPurgedOrDeletedOrExpired()) {
                 message.markAsPurgedMessage();
             }
         } else {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/QueueBrowserDeliveryWorker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/QueueBrowserDeliveryWorker.java
@@ -39,7 +39,7 @@ import java.util.List;
  * A client uses a QueueBrowser to look at messages on a destination without removing
  * them.
  * The browse methods return a java.util.Enumeration that is used to scan the
- * destination’s messages. It may be an enumeration of the entire content of a destination or
+ * destination's messages. It may be an enumeration of the entire content of a destination or
  * it may only contain the messages matching a message selector.
  * Messages may be arriving and expiring while the scan is done. JMS does not
  * require the content of an enumeration to be a static snapshot of destination content.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/ContentDecompressionHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/ContentDecompressionHandler.java
@@ -70,7 +70,6 @@ public class ContentDecompressionHandler implements EventHandler<DeliveryEventDa
      */
     @Override
     public void onEvent(DeliveryEventData deliveryEventData, long sequence, boolean endOfBatch) throws Exception {
-
         // If the content is already decompressed, there is no point in further decompressing
         // Therefore ignore
         if (!(deliveryEventData.availableForDecompression())) {
@@ -82,7 +81,6 @@ public class ContentDecompressionHandler implements EventHandler<DeliveryEventDa
         ProtocolMessage metadata = deliveryEventData.getMetadata();
         int originalMessageSize = metadata.getMessage().getMessageContentLength();
         long messageID = metadata.getMessageID();
-
         boolean isCompressed = metadata.getMessage().isCompressed();
 
         if (log.isDebugEnabled()) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
@@ -91,7 +91,6 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
             try {
                 if (deliveryEventData.isErrorOccurred()) {
                     onSendError(message, subscription);
-                    
                     routeMessageToDLC(message, subscription, deliveryEventData.isErrorOccurred());
                     return;
                 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/MessageWriter.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/MessageWriter.java
@@ -19,7 +19,6 @@
 package org.wso2.andes.kernel.disruptor.inbound;
 
 import com.google.common.util.concurrent.SettableFuture;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.kernel.AndesException;
@@ -27,7 +26,6 @@ import org.wso2.andes.kernel.AndesMessage;
 import org.wso2.andes.kernel.MessagingEngine;
 import org.wso2.andes.kernel.disruptor.BatchEventHandler;
 import org.wso2.andes.store.AndesBatchUpdateException;
-import org.wso2.andes.store.AndesStoreUnavailableException;
 import org.wso2.andes.store.AndesTransactionRollbackException;
 import org.wso2.andes.store.FailureObservingStoreManager;
 import org.wso2.andes.store.HealthAwareStore;
@@ -96,6 +94,7 @@ public class MessageWriter implements BatchEventHandler, StoreHealthListener {
             currentMessageList.addAll(event.getMessageList());
 
             if (null != event.retainMessage) {
+                // TODO : we can get queueName here, one by one using a Hash map.
                 retainMap.put(event.retainMessage.getMetadata().getDestination(), event.retainMessage);
             }
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/router/MQTTMessageRouter.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/router/MQTTMessageRouter.java
@@ -106,7 +106,7 @@ public class MQTTMessageRouter extends AndesMessageRouter {
             Iterator<StorageQueue> queueIterator = matchingQueues.iterator();
             while (queueIterator.hasNext()) {
                 StorageQueue matchingQueue = queueIterator.next();
-                if(matchingQueue.isDurable() && matchingQueue.getBoundSubscriptions().isEmpty()) {
+                if (matchingQueue.isDurable() && matchingQueue.getBoundSubscriptions().isEmpty()) {
                     queueIterator.remove();
                 }
             }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/CoordinatorConnectionListener.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/CoordinatorConnectionListener.java
@@ -16,20 +16,20 @@
  * under the License.
  */
 
-package org.wso2.andes.thrift;
+package org.wso2.andes.kernel.slot;
 
 /**
- * Listener interface to listen to {@link MBThriftClient} network connection disruptions.
+ * Listener interface to listen to network connection disruptions with the coordinator.
  */
-public interface ThriftConnectionListener {
+public interface CoordinatorConnectionListener {
 
     /**
-     * Triggered when the connection to thrift server is lost
+     * Triggered when the connection to the coordinator is lost
      */
-    void onThriftClientDisconnect();
+    void onCoordinatorDisconnect();
 
     /**
-     * Triggered when the connection to thrift server is established
+     * Triggered when the connection to the coordinator is re-established
      */
-    void onThriftClientConnect();
+    void onCoordinatorReconnect();
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotCoordinator.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotCoordinator.java
@@ -69,4 +69,12 @@ public interface SlotCoordinator {
      * @param queueName Name of the queue
      */
     public void clearAllActiveSlotRelationsToQueue(String queueName) throws ConnectionException;
+
+    /**
+     * Add listener to coordinator connection listeners so that they can be notified when the conneciton is broken with
+     * the coordinator.
+     *
+     * @param listener The listener implementation which acts upon coordinator disconnects and reconnects
+     */
+    void addCoordinatorConnectionListener(CoordinatorConnectionListener listener);
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotCoordinatorStandalone.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotCoordinatorStandalone.java
@@ -80,4 +80,12 @@ public class SlotCoordinatorStandalone implements SlotCoordinator {
     public void clearAllActiveSlotRelationsToQueue(String queueName) {
         slotManagerStandalone.clearAllActiveSlotRelationsToQueue(queueName);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addCoordinatorConnectionListener(CoordinatorConnectionListener listener) {
+        // Do nothing as this is the standalone mode and coordinator is also the same node
+    }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionManager.java
@@ -380,13 +380,13 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
                  equal(AndesSubscription.ROUTER_NAME, messageRouter),
                  equal(AndesSubscription.ROUTING_KEY, bindingKeyPattern.toLowerCase()));
 
-        if(!SELECT_ALL_NODES.equals(connectedNode)){
-            subscriptionQuery = and (subscriptionQuery, equal(AndesSubscription.NODE_ID, connectedNode));
+        if (!SELECT_ALL_NODES.equals(connectedNode)) {
+            subscriptionQuery = and(subscriptionQuery, equal(AndesSubscription.NODE_ID, connectedNode));
         }
 
         Iterable<AndesSubscription> subscriptions = subscriptionRegistry.exucuteQuery(subscriptionQuery);
 
-        for(AndesSubscription subscription : subscriptions){
+        for (AndesSubscription subscription : subscriptions) {
             filteredSubscriptions.add(subscription);
         }
         return filteredSubscriptions;
@@ -406,8 +406,8 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
         List<AndesSubscription> allInactiveSubscriptions = getInactiveSubscriberRepresentations();
 
         for (AndesSubscription inactiveSubscription : allInactiveSubscriptions) {
-            if(inactiveSubscription.getStorageQueue().getMessageRouterBindingKey().equalsIgnoreCase
-                    (bindingKeyPattern)){
+            if (inactiveSubscription.getStorageQueue().getMessageRouterBindingKey().equalsIgnoreCase
+                    (bindingKeyPattern)) {
                 filteredSubscriptions.add(inactiveSubscription);
             }
         }
@@ -438,8 +438,8 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
                  equal(AndesSubscription.ROUTER_NAME, messageRouter),
                  contains(AndesSubscription.ROUTING_KEY, bindingKeyPattern.toLowerCase()));
 
-        if(!SELECT_ALL_NODES.equals(connectedNode)){
-            subscriptionQuery = and (subscriptionQuery, equal(AndesSubscription.NODE_ID, connectedNode));
+        if (!SELECT_ALL_NODES.equals(connectedNode)) {
+            subscriptionQuery = and(subscriptionQuery, equal(AndesSubscription.NODE_ID, connectedNode));
         }
 
         Iterable<AndesSubscription> subscriptions = subscriptionRegistry.exucuteQuery(subscriptionQuery);
@@ -467,8 +467,8 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
         List<AndesSubscription> allInactiveSubscriptions = getInactiveSubscriberRepresentations();
 
         for (AndesSubscription inactiveSubscription : allInactiveSubscriptions) {
-            if(StringUtils.containsIgnoreCase(inactiveSubscription.getStorageQueue().getMessageRouterBindingKey(),
-                    bindingKeyPattern)){
+            if (StringUtils.containsIgnoreCase(inactiveSubscription.getStorageQueue().getMessageRouterBindingKey(),
+                    bindingKeyPattern)) {
                 filteredSubscriptions.add(inactiveSubscription);
             }
         }
@@ -487,25 +487,25 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
      */
     private Set<AndesSubscription> filterInactiveSubscriptionsBySubscriptionId(Set<AndesSubscription> subscriptions,
             ProtocolType protocolType, DestinationType destinationType,String subscriptionIdPattern,
-            boolean isExactMatchSubscriptionId){
+            boolean isExactMatchSubscriptionId) {
 
         Set<AndesSubscription> filteredSubscriptions = new HashSet<>();
         String messageRouter = destinationType.getAndesMessageRouter();
 
-        if(isExactMatchSubscriptionId){
+        if (isExactMatchSubscriptionId) {
             for (AndesSubscription inactiveSubscription : subscriptions) {
-                if(inactiveSubscription.getStorageQueue().getMessageRouter().getName().equals(messageRouter)
+                if (inactiveSubscription.getStorageQueue().getMessageRouter().getName().equals(messageRouter)
                         && inactiveSubscription.getProtocolType().equals(protocolType)
-                        && inactiveSubscription.getSubscriptionId().equalsIgnoreCase(subscriptionIdPattern)){
+                        && inactiveSubscription.getSubscriptionId().equalsIgnoreCase(subscriptionIdPattern)) {
                     filteredSubscriptions.add(inactiveSubscription);
                 }
             }
-        }else{
+        } else {
             for (AndesSubscription inactiveSubscription : subscriptions) {
-                if(inactiveSubscription.getStorageQueue().getMessageRouter().getName().equals(messageRouter)
+                if (inactiveSubscription.getStorageQueue().getMessageRouter().getName().equals(messageRouter)
                         && inactiveSubscription.getProtocolType().equals(protocolType)
                         && StringUtils.containsIgnoreCase(inactiveSubscription.getSubscriptionId(),
-                        subscriptionIdPattern)){
+                        subscriptionIdPattern)) {
                     filteredSubscriptions.add(inactiveSubscription);
                 }
             }
@@ -522,11 +522,11 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
      * @return Set of subscriptions filtered according to search criteria
      */
     private Set<AndesSubscription> filterActiveSubscriptionsBySubscriptionId(Set<AndesSubscription> subscriptions,String
-            subscriptionIdPattern, boolean isExactMatchSubscriptionId){
+            subscriptionIdPattern, boolean isExactMatchSubscriptionId) {
 
         Set<AndesSubscription> filteredSubscriptions = new HashSet<>();
 
-        if(isExactMatchSubscriptionId) {
+        if (isExactMatchSubscriptionId) {
             for (AndesSubscription subscription : subscriptions) {
                 if (subscriptionIdPattern.equalsIgnoreCase(subscription.getSubscriptionId())) {
                     filteredSubscriptions.add(subscription);
@@ -537,7 +537,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
                     }
                 }
             }
-        } else{
+        } else {
             for (AndesSubscription subscription : subscriptions) {
                 if (StringUtils.containsIgnoreCase(subscription.getSubscriptionId(), subscriptionIdPattern)) {
                     filteredSubscriptions.add(subscription);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/PersistenceStoreConnector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/PersistenceStoreConnector.java
@@ -327,7 +327,7 @@ public class PersistenceStoreConnector implements MQTTConnector {
             Andes.getInstance().closeLocalSubscription(subscriptionCloseEvent);
 
             //remove binding from MQTT message router so that no longer messages are persisted to that queue
-            if(localSubscription.getStorageQueue().getBoundSubscriptions().isEmpty()
+            if (localSubscription.getStorageQueue().getBoundSubscriptions().isEmpty()
                     && !mqttTopicSubscriber.isDurable()) {
 
                 QueueInfo queueInfo = new QueueInfo(localSubscription.getStorageQueue().getName(),

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/message/ServerMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/message/ServerMessage.java
@@ -17,9 +17,9 @@
  */
 package org.wso2.andes.server.message;
 
-import java.nio.ByteBuffer;
-
 import org.wso2.andes.configuration.qpid.SessionConfig;
+
+import java.nio.ByteBuffer;
 
 public interface ServerMessage extends EnqueableMessage, MessageContentSource
 {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/QueueEntryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/QueueEntryImpl.java
@@ -18,12 +18,8 @@
 package org.wso2.andes.server.queue;
 
 import org.apache.log4j.Logger;
-
 import org.wso2.andes.AMQException;
-import org.wso2.andes.configuration.AndesConfigurationManager;
-import org.wso2.andes.configuration.enums.AndesConfiguration;
 import org.wso2.andes.kernel.AndesContext;
-import org.wso2.andes.kernel.AndesMessageMetadata;
 import org.wso2.andes.server.exchange.Exchange;
 import org.wso2.andes.server.message.AMQMessageHeader;
 import org.wso2.andes.server.message.MessageReference;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/Subscription_0_10.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/Subscription_0_10.java
@@ -22,7 +22,6 @@ import org.wso2.andes.configuration.qpid.*;
 import org.wso2.andes.framing.AMQShortString;
 import org.wso2.andes.framing.BasicContentHeaderProperties;
 import org.wso2.andes.framing.FieldTable;
-import org.wso2.andes.configuration.qpid.*;
 import org.wso2.andes.server.filter.FilterManager;
 import org.wso2.andes.server.flow.CreditCreditManager;
 import org.wso2.andes.server.flow.FlowCreditManager;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
@@ -19,7 +19,6 @@
 package org.wso2.andes.store;
 
 import com.gs.collections.impl.list.mutable.primitive.LongArrayList;
-import com.gs.collections.impl.map.mutable.primitive.LongObjectHashMap;
 import org.apache.log4j.Logger;
 import org.wso2.andes.configuration.util.ConfigurationProperties;
 import org.wso2.andes.kernel.AndesContextStore;
@@ -30,10 +29,11 @@ import org.wso2.andes.kernel.AndesMessagePart;
 import org.wso2.andes.kernel.DeliverableAndesMetadata;
 import org.wso2.andes.kernel.DurableStoreConnection;
 import org.wso2.andes.kernel.MessageStore;
-import org.wso2.andes.kernel.slot.Slot;
 import org.wso2.andes.kernel.slot.RecoverySlotCreator;
+import org.wso2.andes.kernel.slot.Slot;
 import org.wso2.andes.tools.utils.MessageTracer;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
@@ -98,19 +98,6 @@ public class FailureObservingMessageStore implements MessageStore {
      * {@inheritDoc}
      */
     @Override
-    public void storeMessagePart(List<AndesMessagePart> partList) throws AndesException {
-        try {
-            wrappedInstance.storeMessagePart(partList);
-        } catch (AndesStoreUnavailableException exception) {
-            notifyFailures(exception);
-            throw exception;
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public AndesMessagePart getContent(long messageId, int offsetValue) throws AndesException {
         try {
             return wrappedInstance.getContent(messageId, offsetValue);
@@ -122,11 +109,13 @@ public class FailureObservingMessageStore implements MessageStore {
 
     /**
      * {@inheritDoc}
+     * @param queueName
+     * @param messageIDList
      */
     @Override
-    public LongObjectHashMap<List<AndesMessagePart>> getContent(LongArrayList messageIDList) throws AndesException {
+    public HashMap<Long, List<AndesMessagePart>> getContent(String queueName, LongArrayList messageIDList) throws AndesException {
         try {
-            return wrappedInstance.getContent(messageIDList);
+            return wrappedInstance.getContent(queueName, messageIDList);
         } catch (AndesStoreUnavailableException exception) {
             notifyFailures(exception);
             throw exception;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cache/AndesMessageCache.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cache/AndesMessageCache.java
@@ -19,10 +19,10 @@
 package org.wso2.andes.store.cache;
 
 import com.gs.collections.impl.list.mutable.primitive.LongArrayList;
-import com.gs.collections.impl.map.mutable.primitive.LongObjectHashMap;
 import org.wso2.andes.kernel.AndesMessage;
 import org.wso2.andes.kernel.AndesMessagePart;
 
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -51,7 +51,7 @@ public interface AndesMessageCache {
     /**
      * Removes a message with a given id from the cache
      *
-     * @param messagesToRemove list of message Ids
+     * @param messageToRemove list of message Ids
      */
     abstract void removeFromCache(long messageToRemove);
 
@@ -66,12 +66,12 @@ public interface AndesMessageCache {
     /**
      * Get the list of messages found from the cache.
      * <b> This method modifies the provided messageIDList </b>
-     *
-     * @param messageIDList message id to be found in cache.
+     *  @param messageIDList message id to be found in cache.
      * @param contentList   the list the fill
+     * @param queueName
      */
     abstract void fillContentFromCache(LongArrayList messageIDList,
-            LongObjectHashMap<List<AndesMessagePart>> contentList);
+                                       HashMap<Long, List<AndesMessagePart>> contentList, String queueName);
 
     /**
      * Return a {@link AndesMessagePart} from the cache.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cache/DisabledMessageCacheImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cache/DisabledMessageCacheImpl.java
@@ -19,10 +19,10 @@
 package org.wso2.andes.store.cache;
 
 import com.gs.collections.impl.list.mutable.primitive.LongArrayList;
-import com.gs.collections.impl.map.mutable.primitive.LongObjectHashMap;
 import org.wso2.andes.kernel.AndesMessage;
 import org.wso2.andes.kernel.AndesMessagePart;
 
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -68,7 +68,7 @@ public class DisabledMessageCacheImpl implements AndesMessageCache {
      */
     @Override
     public void fillContentFromCache(LongArrayList messageIDList,
-            LongObjectHashMap<List<AndesMessagePart>> contentList) {
+                                     HashMap<Long, List<AndesMessagePart>> contentList, String queueName) {
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cache/GuavaBasedMessageCacheImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/cache/GuavaBasedMessageCacheImpl.java
@@ -23,7 +23,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.Weigher;
 import com.gs.collections.api.iterator.MutableLongIterator;
 import com.gs.collections.impl.list.mutable.primitive.LongArrayList;
-import com.gs.collections.impl.map.mutable.primitive.LongObjectHashMap;
 import org.apache.log4j.Logger;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
@@ -31,8 +30,8 @@ import org.wso2.andes.kernel.AndesMessage;
 import org.wso2.andes.kernel.AndesMessagePart;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -176,7 +175,7 @@ public class GuavaBasedMessageCacheImpl implements AndesMessageCache {
      */
     @Override
     public void fillContentFromCache(LongArrayList messageIDList,
-            LongObjectHashMap<List<AndesMessagePart>> contentList) {
+                                     HashMap<Long, List<AndesMessagePart>> contentList, String queueName) {
 
         MutableLongIterator iterator = messageIDList.longIterator();
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -211,12 +211,6 @@ public class RDBMSConstants {
 
     protected static final String PS_ALIAS_FOR_COUNT = "count";
 
-    protected static final String PS_SELECT_QUEUE_MESSAGE_COUNT =
-            "SELECT COUNT(" + QUEUE_ID + ") AS " + PS_ALIAS_FOR_COUNT
-            + " FROM " + METADATA_TABLE
-            + " WHERE " + QUEUE_ID + "=?"
-            + " AND " + DLC_QUEUE_ID + "=-1";
-
     /**
      * Prepared statement to retrieve message count within a message id range for a queue.
      */
@@ -335,6 +329,11 @@ public class RDBMSConstants {
             "DELETE  FROM " + METADATA_TABLE
             + " WHERE " + DLC_QUEUE_ID + "=?";
 
+    /**
+     * MB_EXPIRATION_DATA table is ON DELETE CASCADE to MB_METADATA table.
+     * So when MB_METADATA# deletes it automatically deletes MB_EXPIRATION_DATA#
+     * So need to create MB_EXPIRATION_DATA tables as to number of tables.
+     */
     protected static final String PS_SELECT_EXPIRED_MESSAGES =
             "SELECT " + MESSAGE_ID + "," + DESTINATION_QUEUE
             + " FROM " + EXPIRATION_TABLE
@@ -1000,7 +999,8 @@ public class RDBMSConstants {
             + " WHERE " + MESSAGE_ID + "=?";
 
     /**
-     * Prepared statement to update DLC status in expiry table
+     * Prepared statement to update DLC status in expiry table. Since EXPIRATION_TABLE is cascade delete with
+     * MB_METADATA table, This should move to RDBMSMultipleTableHandler.
      */
     protected static final String PS_UPDATE_DLC_STATUS_IN_EXPIRY_TABLE =
             "UPDATE " + EXPIRATION_TABLE

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSMultipleTableHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSMultipleTableHandler.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.store.rdbms;
+
+import org.wso2.andes.configuration.AndesConfigurationManager;
+import org.wso2.andes.configuration.enums.AndesConfiguration;
+
+
+/**
+ * JDBC storage related prepared statements, table names, column names and tasks
+ * that changes according to the number of tables that are grouped.
+ */
+
+public class RDBMSMultipleTableHandler {
+
+    private static final String CONTENT_TABLE = "MB_CONTENT";
+    private static final String MESSAGE_ID = "MESSAGE_ID";
+    private static final String MSG_OFFSET = "CONTENT_OFFSET";
+    private static final String MESSAGE_CONTENT = "MESSAGE_CONTENT";
+
+    private static final String METADATA_TABLE = "MB_METADATA";
+    private static final String QUEUE_ID = "QUEUE_ID";
+    private static final String DLC_QUEUE_ID = "DLC_QUEUE_ID";
+    private static final String METADATA = "MESSAGE_METADATA";
+    private static final String PS_ALIAS_FOR_COUNT = "count";
+    protected static final String QUEUE_NAME = RDBMSConstants.QUEUE_NAME;
+    private static final String QUEUES_TABLE = "MB_QUEUE_MAPPING";
+    private static final String DESTINATION_QUEUE = "MESSAGE_DESTINATION";
+    private static final String EXPIRATION_TABLE = "MB_EXPIRATION_DATA";
+    private static final String EXPIRATION_TIME = "EXPIRATION_TIME";
+
+
+    private static final String ALIAS_FOR_QUEUES = "QUEUE_COUNT";
+
+    // Get number of tables from the configurations. Default value is 5.
+    private Integer numberOfTables = AndesConfigurationManager.readValue(
+            AndesConfiguration.PERFORMANCE_TUNING_NUMBER_OF_TABLES);
+
+    // Insert queries
+    private String[] psInsertMessagePart = new String[numberOfTables];
+    private String[] psInsertMetadata = new String[numberOfTables];
+
+    // Retrieve queries
+    private String[] psRetrieveMessagePart = new String[numberOfTables];
+
+    // Select queries
+    private String[] psSelectQueueMessageCount = new String[numberOfTables];
+    private String[] psSelectRangedQueueMessageCount = new String[numberOfTables];
+    private String[] psSelectAllQueueMessageCount = new String[numberOfTables];
+    private String[] psSelectQueueMessageCountFromDlc = new String[numberOfTables];
+    private String[] psSelectMessageCountInDlc = new String[numberOfTables];
+    private String[] psSelectMetadata = new String[numberOfTables];
+    private String[] psSelectMetadataRangeFromQueue = new String[numberOfTables];
+    private String[] psSelectMetadataRangeFromQueueInDlc = new String[numberOfTables];
+    private String[] psSelectMetadataFromQueue = new String[numberOfTables];
+    private String[] psSelectMessageIdsFromQueue = new String[numberOfTables];
+    private String[] psSelectMetadataInDlcForQueue = new String[numberOfTables];
+    private String[] psSelectMetadataInDlc = new String[numberOfTables];
+    private String[] psSelectMessageIdsFromMetadataForQueue = new String[numberOfTables];
+    private String[] psSelectExpiredMessages = new String[numberOfTables];
+    private String[] psSelectExpiredMessagesFromDlc = new String[numberOfTables];
+    private String[] psSelectContentPart = new String[numberOfTables];
+
+    // Delete, Clear queries
+    private String[] psDeleteMetadataFromQueue = new String[numberOfTables];
+    private String[] psDeleteMetadataInDlc = new String[numberOfTables];
+    private String[] psDeleteMetadata = new String[numberOfTables];
+    private String[] psClearQueueFromMetadata = new String[numberOfTables];
+    private String[] psClearDlcQueue = new String[numberOfTables];
+
+    // Update queries
+    private String[] psUpdateMetadataQueue = new String[numberOfTables];
+    private String[] psUpdateMetadata = new String[numberOfTables];
+    private String[] psMoveMetadataToDlc = new String[numberOfTables];
+    private String[] psUpdateDlcStatusInExpiryTable = new String[numberOfTables];
+
+    /**
+     * Constructor that initialize all the prepared statements, that will change according to the number of tables.
+     */
+    public RDBMSMultipleTableHandler() {
+
+        for (int tableCount = 0; tableCount < numberOfTables; tableCount++) {
+
+            psInsertMessagePart[tableCount] = ("INSERT INTO "
+                    + CONTENT_TABLE + tableCount + " ( " + MESSAGE_ID + " , "
+                    + MSG_OFFSET + " , " + MESSAGE_CONTENT + ")" + " VALUES (?, ?, ?)");
+
+            psRetrieveMessagePart[tableCount] = ("SELECT " + MESSAGE_CONTENT
+                    + " FROM " + CONTENT_TABLE + tableCount
+                    + " WHERE " + MESSAGE_ID + "=?"
+                    + " AND " + MSG_OFFSET + "=?");
+
+            psInsertMetadata[tableCount] = ("INSERT INTO "
+                    + METADATA_TABLE + tableCount + " ( " + MESSAGE_ID + " , "
+                    + QUEUE_ID + " , " + DLC_QUEUE_ID + " , " + METADATA + " ) " + " VALUES ( ?,?,-1,? )");
+
+            psSelectQueueMessageCount[tableCount] = ("SELECT COUNT(" + QUEUE_ID + ") AS " + PS_ALIAS_FOR_COUNT
+                    + " FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + QUEUE_ID + "=?"
+                    + " AND " + DLC_QUEUE_ID + "=-1");
+
+            psSelectRangedQueueMessageCount[tableCount] = ("SELECT COUNT(" + MESSAGE_ID + ") AS " + PS_ALIAS_FOR_COUNT
+                    + " FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + QUEUE_ID + "=?"
+                    + " AND " + MESSAGE_ID + " BETWEEN ? AND ?"
+                    + " AND " + DLC_QUEUE_ID + "=-1");
+
+            psSelectAllQueueMessageCount[tableCount] = ("SELECT " + QUEUE_NAME + ", " + PS_ALIAS_FOR_COUNT
+                    + " FROM " + QUEUES_TABLE + " LEFT OUTER JOIN "
+                    + "(SELECT " + QUEUE_ID + ", COUNT(" + QUEUE_ID + ") AS " + PS_ALIAS_FOR_COUNT
+                    + " FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + DLC_QUEUE_ID + "=-1"
+                    + " GROUP BY " + QUEUE_ID + " ) " + ALIAS_FOR_QUEUES
+                    + " ON " + QUEUES_TABLE + "." + QUEUE_ID + "=" + ALIAS_FOR_QUEUES + "." + QUEUE_ID);
+
+            psSelectQueueMessageCountFromDlc[tableCount] = ("SELECT COUNT(" + MESSAGE_ID + ")"
+                    + " AS " + PS_ALIAS_FOR_COUNT
+                    + " FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + QUEUE_ID + "=?"
+                    + " AND " + DLC_QUEUE_ID + "=?");
+
+            psSelectMessageCountInDlc[tableCount] = ("SELECT COUNT(" + MESSAGE_ID + ")"
+                    + " AS " + PS_ALIAS_FOR_COUNT
+                    + " FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + DLC_QUEUE_ID + "=?");
+
+            psSelectMetadata[tableCount] = ("SELECT " + METADATA
+                    + " FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + MESSAGE_ID + "=?");
+
+            psSelectMetadataRangeFromQueue[tableCount] = ("SELECT " + MESSAGE_ID + "," + METADATA
+                    + " FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + QUEUE_ID + "=?"
+                    + " AND " + DLC_QUEUE_ID + "=-1"
+                    + " AND " + MESSAGE_ID + " BETWEEN ? AND ?"
+                    + " ORDER BY " + MESSAGE_ID);
+
+            psSelectMetadataRangeFromQueueInDlc[tableCount] = ("SELECT " + MESSAGE_ID + "," + METADATA
+                    + " FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + QUEUE_ID + "=?"
+                    + " AND " + DLC_QUEUE_ID + "=?"
+                    + " AND " + MESSAGE_ID + " BETWEEN ? AND ?"
+                    + " ORDER BY " + MESSAGE_ID);
+
+            psSelectMetadataFromQueue[tableCount] = ("SELECT " + MESSAGE_ID + "," + METADATA
+                    + " FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + MESSAGE_ID + ">?"
+                    + " AND " + QUEUE_ID + "=?"
+                    + " AND " + DLC_QUEUE_ID + "=-1"
+                    + " ORDER BY " + MESSAGE_ID);
+
+            psSelectMessageIdsFromQueue[tableCount] = ("SELECT " + MESSAGE_ID
+                    + " FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + MESSAGE_ID + ">?"
+                    + " AND " + QUEUE_ID + "=?"
+                    + " AND " + DLC_QUEUE_ID + "=-1"
+                    + " ORDER BY " + MESSAGE_ID);
+
+            psSelectMetadataInDlcForQueue[tableCount] = ("SELECT " + MESSAGE_ID + "," + METADATA
+                    + " FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + MESSAGE_ID + ">?"
+                    + " AND " + QUEUE_ID + "=?"
+                    + " AND " + DLC_QUEUE_ID + "=?"
+                    + " ORDER BY " + MESSAGE_ID);
+
+            psSelectMetadataInDlc[tableCount] = ("SELECT " + MESSAGE_ID + "," + METADATA
+                    + " FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + MESSAGE_ID + ">?"
+                    + " AND " + DLC_QUEUE_ID + "=?"
+                    + " ORDER BY " + MESSAGE_ID);
+
+            psSelectMessageIdsFromMetadataForQueue[tableCount] = ("SELECT " + MESSAGE_ID
+                    + " FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + QUEUE_ID + "=?"
+                    + " ORDER BY " + MESSAGE_ID);
+
+            psDeleteMetadataFromQueue[tableCount] = ("DELETE  FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + QUEUE_ID + "=?"
+                    + " AND " + MESSAGE_ID + "=?");
+
+            psDeleteMetadataInDlc[tableCount] = ("DELETE  FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + MESSAGE_ID + "=?"
+                    + " AND " + DLC_QUEUE_ID + "!= -1");
+
+            psDeleteMetadata[tableCount] = ("DELETE  FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + MESSAGE_ID + "=?");
+
+            psClearQueueFromMetadata[tableCount] = ("DELETE  FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + QUEUE_ID + "=?");
+
+            psClearDlcQueue[tableCount] = ("DELETE  FROM " + METADATA_TABLE + tableCount
+                    + " WHERE " + DLC_QUEUE_ID + "=?");
+
+            psUpdateMetadataQueue[tableCount] = ("UPDATE " + METADATA_TABLE + tableCount
+                    + " SET " + QUEUE_ID + " = ?"
+                    + " WHERE " + MESSAGE_ID + " = ?"
+                    + " AND " + QUEUE_ID + " = ?");
+
+            psUpdateMetadata[tableCount] = ("UPDATE " + METADATA_TABLE + tableCount
+                    + " SET " + QUEUE_ID + " = ?," + METADATA + " = ?"
+                    + " WHERE " + MESSAGE_ID + " = ?"
+                    + " AND " + QUEUE_ID + " = ?");
+
+            psMoveMetadataToDlc[tableCount] = ("UPDATE " + METADATA_TABLE + tableCount
+                    + " SET " + DLC_QUEUE_ID + "=?"
+                    + " WHERE " + MESSAGE_ID + "=?");
+
+
+            psSelectContentPart[tableCount] = ( "SELECT " + MESSAGE_CONTENT + ", " + MESSAGE_ID + ", " + MSG_OFFSET +
+                            " FROM " + CONTENT_TABLE + tableCount +
+                            " WHERE " + MESSAGE_ID + " IN (");
+
+            //MB_EXPIRATION_DATA table is ON DELETE CASCADE to MB_METADATA table.
+            //So when MB_METADATA# deletes it automatically deletes MB_EXPIRATION_DATA#
+            //So need to improvise MB_EXPIRATION_DATA table as to number of tables.
+            psSelectExpiredMessages[tableCount] = ( "SELECT " + MESSAGE_ID + "," + DESTINATION_QUEUE
+                    + " FROM " + EXPIRATION_TABLE + tableCount
+                    + " WHERE " + EXPIRATION_TIME + "<?"
+                    + " AND " + MESSAGE_ID + ">=?"
+                    + " AND " + DESTINATION_QUEUE + "=?");
+
+            psUpdateDlcStatusInExpiryTable[tableCount] = ("UPDATE " + EXPIRATION_TABLE + tableCount
+                    + " SET " + DLC_QUEUE_ID + "=?"
+                    + " WHERE " + MESSAGE_ID + "=?");
+
+            psSelectExpiredMessagesFromDlc[tableCount] = ("SELECT " + MESSAGE_ID
+                    + " FROM " + EXPIRATION_TABLE + tableCount
+                    + " WHERE " + EXPIRATION_TIME + "<?"
+                    + " AND " + DLC_QUEUE_ID + " != -1");
+
+        }
+    }
+
+    /**
+     * get tableID according to the queueID.
+     * eg: By default number of tables = 5. If queueID= 1, TableID (for that queue) = 1 % 5 = 1
+     * TableIDs are given according to the Round-robin manner.
+     *
+     * @param queueId that pass.
+     * @return tableID relevant to the queueID given.
+     */
+    private int queueIdToTableId(int queueId) {
+        int tableID;
+        tableID = queueId % numberOfTables;
+        return tableID;
+    }
+
+    //Get the String query arrays according to the table id given.
+    public String getPsInsertMessagePart(int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psInsertMessagePart[tableID];
+    }
+
+    public String getPsInsertMetadata(int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psInsertMetadata[tableID];
+    }
+
+    public String getPsSelectContentPart (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        String psSelect = psSelectContentPart[tableID];
+        return psSelect;
+    }
+
+    public String getPsRetrieveMessagePart(int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psRetrieveMessagePart[tableID];
+    }
+
+    public String getPsSelectQueueMessageCount(int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectQueueMessageCount[tableID];
+    }
+
+    public String getPsSelectRangedQueueMessageCount(int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectRangedQueueMessageCount[tableID];
+    }
+
+    public String getPsSelectAllQueueMessageCount (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectAllQueueMessageCount[tableID];
+    }
+
+    public String getPsSelectQueueMessageCountFromDlc (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectQueueMessageCountFromDlc[tableID];
+    }
+
+    public String getPsSelectMessageCountInDlc (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectMessageCountInDlc[tableID];
+    }
+
+    public String getPsSelectMetadata (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectMetadata[tableID];
+    }
+
+    public String getPsSelectMetadataRangeFromQueue (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectMetadataRangeFromQueue[tableID];
+    }
+
+    public String getPsSelectMetadataRangeFromQueueInDlc (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectMetadataRangeFromQueueInDlc[tableID];
+    }
+
+    public String getPsSelectMetadataFromQueue (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectMetadataFromQueue[tableID];
+    }
+
+    public String getPsSelectMessageIdsFromQueue (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectMessageIdsFromQueue[tableID];
+    }
+
+    public String getPsSelectMetadataInDlcForQueue (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectMetadataInDlcForQueue[tableID];
+    }
+
+    public String getPsSelectMetadataInDlc (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectMetadataInDlc[tableID];
+    }
+
+    public String getPsSelectMessageIdsFromMetadataForQueue (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectMessageIdsFromMetadataForQueue[tableID];
+    }
+
+    public String getPsDeleteMetadataFromQueue (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psDeleteMetadataFromQueue[tableID];
+    }
+
+    public String getPsDeleteMetadataInDlc (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psDeleteMetadataInDlc[tableID];
+    }
+
+    public String getPsDeleteMetadata (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psDeleteMetadata[tableID];
+    }
+
+    public String getPsClearQueueFromMetadata (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psClearQueueFromMetadata[tableID];
+    }
+
+    public String getPsClearDlcQueue (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psClearDlcQueue[tableID];
+    }
+
+    public String getPsUpdateMetadataQueue(int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psUpdateMetadataQueue[tableID];
+    }
+
+    public String getPsUpdateMetadata (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psUpdateMetadata[tableID];
+    }
+
+    public String getPsMoveMetadataToDlc (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psMoveMetadataToDlc[tableID];
+    }
+
+    public String getPsSelectExpiredMessages (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectExpiredMessages[tableID];
+    }
+
+    public String getPsUpdateDlcStatusInExpiryTable (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psUpdateDlcStatusInExpiryTable[tableID];
+    }
+
+    public String getPsSelectExpiredMessagesFromDlc (int queueID) {
+        int tableID = queueIdToTableId(queueID);
+        return psSelectExpiredMessagesFromDlc[tableID];
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/thrift/MBThriftClient.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/thrift/MBThriftClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005-2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -20,32 +20,26 @@ package org.wso2.andes.thrift;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.PooledObjectFactory;
+import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.thrift.TException;
-import org.apache.thrift.protocol.TBinaryProtocol;
-import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.transport.TSocket;
-import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
-import org.wso2.andes.kernel.AndesContext;
 import org.wso2.andes.kernel.slot.ConnectionException;
+import org.wso2.andes.kernel.slot.CoordinatorConnectionListener;
 import org.wso2.andes.kernel.slot.Slot;
-import org.wso2.andes.server.cluster.ClusterAgent;
-import org.wso2.andes.thrift.exception.ThriftClientException;
 import org.wso2.andes.thrift.slot.gen.SlotInfo;
 import org.wso2.andes.thrift.slot.gen.SlotManagementService;
 
-import java.net.InetSocketAddress;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * A wrapper client for the native thrift client. All the public methods in this class are
- * synchronized in order to avoid out of sequence response exception from thrift server. Only one
- * method should be triggered at a time in order to get the responses from the server in order.
+ * A wrapper client for the native thrift client with a client connection pool and retry logic.
  */
 
 public class MBThriftClient {
@@ -54,17 +48,38 @@ public class MBThriftClient {
      * A state variable to indicate whether the reconnecting  to the thrift server is started or
      * not
      */
-    private static boolean reconnectingStarted = false;
+    private boolean reconnecting = false;
 
-    private static TTransport transport;
+    private final Log log = LogFactory.getLog(MBThriftClient.class);
 
-    private static SlotManagementService.Client client = null;
+    private final Queue<CoordinatorConnectionListener> connectionListenerQueue = new ConcurrentLinkedQueue<>();
 
-    private static final Log log = LogFactory.getLog(MBThriftClient.class);
+    private AtomicBoolean isConnected = new AtomicBoolean(false);
 
-    private static final Queue<ThriftConnectionListener> connectionListenerQueue = new ConcurrentLinkedQueue<>();
+    /**
+     * Thrift client factory to build thrift client pool.
+     */
+    private PooledObjectFactory<SlotManagementService.Client> thriftClientFactory = new ThriftClientFactory();
 
-    private static AtomicBoolean isConnected = new AtomicBoolean(false);
+    /**
+     * The thrift client pool.
+     */
+    private ObjectPool<SlotManagementService.Client> thriftClientPool;
+
+    /**
+     * Number of times each thrift operation retries before checking for a coordinator change.
+     */
+    private static final int RETRY_COUNT = 1;
+
+    /**
+     * Keeps track of the timestamp of the last successful reconnect so that reconnect requests received before this
+     * can be ignored.
+     */
+    private long lastReconnectionSuccessTimestamp = 0;
+
+    public MBThriftClient() {
+        initializeThriftConnectionPool();
+    }
 
     /**
      * getSlot method. Returns Slot Object, when the
@@ -73,37 +88,39 @@ public class MBThriftClient {
      * @param queueName name of the queue
      * @param nodeId    of this node
      * @return slot object
-     * @throws ConnectionException
+     * @throws ConnectionException Throws when thrift connection fails
      */
-    public static synchronized Slot getSlot(String queueName, String nodeId) throws ConnectionException {
+    public Slot getSlot(String queueName, String nodeId) throws ConnectionException {
         SlotInfo slotInfo;
-        try {
-            client = getServiceClient();
-            slotInfo = client.getSlotInfo(queueName, nodeId);
-            return convertSlotInforToSlot(slotInfo);
-        } catch (TException e) {
+
+        for (int i = 0; i <= RETRY_COUNT; i++) {
+            SlotManagementService.Client client = null;
+
             try {
-                //retry once
-                reConnectToServer();
+                client = getServiceClient();
                 slotInfo = client.getSlotInfo(queueName, nodeId);
                 return convertSlotInforToSlot(slotInfo);
-            } catch (TException e1) {
-                handleCoordinatorChanges();
-                throw new ConnectionException("Coordinator has changed", e);
+            } catch (TException e) {
+                invalidateServiceClient(client);
+                log.error("Attempt " + i + " failed requesting a slot from coordinator", e);
+            } finally {
+                if (client != null) {
+                    returnServiceClient(client);
+                }
             }
-        } catch (ThriftClientException e) {
-            handleCoordinatorChanges();
-            throw new ConnectionException("Error occurred in thrift client " + e.getMessage(), e);
         }
+
+        handleCoordinatorChanges();
+        throw new ConnectionException("Coordinator has changed");
     }
 
     /**
      * Add Thrift connection listener
      *
-     * @param connectionListener {@link ThriftConnectionListener}
+     * @param connectionListener {@link CoordinatorConnectionListener}
      *
      */
-    public static void addConnectionListener(ThriftConnectionListener connectionListener) {
+    public void addConnectionListener(CoordinatorConnectionListener connectionListener) {
         connectionListenerQueue.add(connectionListener);
     }
 
@@ -113,7 +130,7 @@ public class MBThriftClient {
      * @param slotInfo object generated by thrift
      * @return slot object
      */
-    private static Slot convertSlotInforToSlot(SlotInfo slotInfo) {
+    private Slot convertSlotInforToSlot(SlotInfo slotInfo) {
         Slot slot = new Slot();
         slot.setStartMessageId(slotInfo.getStartMessageId());
         slot.setEndMessageId(slotInfo.getEndMessageId());
@@ -131,26 +148,33 @@ public class MBThriftClient {
      * @param startMessageId start message Id of the locally chosen slot.
      * @param endMessageId end message Id of the locally chosen slot.
      * @param localSafeZone Minimum message ID of the node that is deemed safe.
-     * @throws TException in case of an connection error
+     * @throws ConnectionException in case of an connection error
      */
-    public static synchronized void updateMessageId(String queueName, String nodeId,
-                                                    long startMessageId, long endMessageId, long localSafeZone) throws ConnectionException {
-        try {
-            client = getServiceClient();
-            client.updateMessageId(queueName, nodeId, startMessageId, endMessageId, localSafeZone);
-        } catch (TException e) {
-            try {
-                //retry once
-                reConnectToServer();
-                client.updateMessageId(queueName, nodeId, startMessageId, endMessageId, localSafeZone);
-            } catch (TException e1) {
-                handleCoordinatorChanges();
-                throw new ConnectionException("Coordinator has changed", e);
-            }
+    public synchronized void updateMessageId(String queueName, String nodeId, long startMessageId,
+                                             long endMessageId, long localSafeZone) throws ConnectionException {
 
-        } catch (ThriftClientException e) {
-            log.error("Error occurred while receiving coordinator details from map", e);
+        boolean updateSuccess = false;
+
+        for (int i = 0; i <= RETRY_COUNT; i++) {
+            SlotManagementService.Client client = null;
+
+            try {
+                client = getServiceClient();
+                client.updateMessageId(queueName, nodeId, startMessageId, endMessageId, localSafeZone);
+                updateSuccess = true;
+            } catch (TException e) {
+                invalidateServiceClient(client);
+                log.error("Attempt " + i + " failed updating message Id", e);
+            } finally {
+                if (client != null) {
+                    returnServiceClient(client);
+                }
+            }
+        }
+
+        if (!updateSuccess) {
             handleCoordinatorChanges();
+            throw new ConnectionException("Coordinator has changed");
         }
     }
 
@@ -160,31 +184,32 @@ public class MBThriftClient {
      *
      * @param queueName  name of the queue where slot belongs to
      * @param slot      to be deleted
-     * @throws TException
+     * @throws ConnectionException Throws when thrift connection fails
      */
-    public static synchronized boolean deleteSlot(String queueName, Slot slot,
+    public boolean deleteSlot(String queueName, Slot slot,
                                                String nodeId) throws ConnectionException {
+
         SlotInfo slotInfo = new SlotInfo(slot.getStartMessageId(), slot.getEndMessageId(),
                 slot.getStorageQueueName(),nodeId,slot.isAnOverlappingSlot());
-        boolean deleteSuccess = false;
-        try {
-            client = getServiceClient();
-            deleteSuccess = client.deleteSlot(queueName, slotInfo, nodeId);
-        } catch (TException e) {
+
+        for (int i = 0; i <= RETRY_COUNT; i++) {
+            SlotManagementService.Client client = null;
+
             try {
-                //retry to connect once
-                reConnectToServer();
-                deleteSuccess = client.deleteSlot(queueName, slotInfo, nodeId);
-            } catch (TException e1) {
-                handleCoordinatorChanges();
-                throw new ConnectionException("Coordinator has changed", e);
+                client = getServiceClient();
+                return client.deleteSlot(queueName, slotInfo, nodeId);
+            } catch (TException e) {
+                invalidateServiceClient(client);
+                log.error("Attempt " + i + " failed deleting slot");
+            } finally {
+                if (client != null) {
+                    returnServiceClient(client);
+                }
             }
-        } catch (ThriftClientException e) {
-            log.error("Error occurred while receiving coordinator details from map", e);
-            handleCoordinatorChanges();
         }
-        
-        return deleteSuccess;
+
+        handleCoordinatorChanges();
+        throw new ConnectionException("Coordinator has changed");
     }
 
     /**
@@ -192,25 +217,33 @@ public class MBThriftClient {
      *
      * @param nodeId    of this node
      * @param queueName name of the queue
-     * @throws TException
+     * @throws ConnectionException Throws when thrift connection fails
      */
-    public static synchronized void reAssignSlotWhenNoSubscribers(String nodeId,
+    public synchronized void reAssignSlotWhenNoSubscribers(String nodeId,
                                                                   String queueName) throws ConnectionException {
-        try {
-            client = getServiceClient();
-            client.reAssignSlotWhenNoSubscribers(nodeId, queueName);
-        } catch (TException e) {
+
+        boolean reassignSuccess = false;
+
+        for (int i = 0; i <= RETRY_COUNT; i++) {
+            SlotManagementService.Client client = null;
+
             try {
-                //retry to do the operation once
-                reConnectToServer();
+                client = getServiceClient();
                 client.reAssignSlotWhenNoSubscribers(nodeId, queueName);
-            } catch (TException e1) {
-                handleCoordinatorChanges();
-                throw new ConnectionException("Coordinator has changed", e);
+                reassignSuccess = true;
+            } catch (TException e) {
+                invalidateServiceClient(client);
+                log.error("Attempt " + i + " failed reassigning slot", e);
+            } finally {
+                if (client != null) {
+                    returnServiceClient(client);
+                }
             }
-        } catch (ThriftClientException e) {
-            log.error("Error occurred while receiving coordinator details from map", e);
+        }
+
+        if (!reassignSuccess) {
             handleCoordinatorChanges();
+            throw new ConnectionException("Coordinator has changed");
         }
     }
 
@@ -218,190 +251,33 @@ public class MBThriftClient {
      * Delete all in-memory slot associations with a given queue. This is required to handle a queue purge event.
      *
      * @param queueName name of destination queue
-     * @throws ConnectionException
+     * @throws ConnectionException Throws when thrift connection fails
      */
-    public static synchronized void clearAllActiveSlotRelationsToQueue(String queueName) throws ConnectionException {
+    public synchronized void clearAllActiveSlotRelationsToQueue(String queueName) throws ConnectionException {
 
-        try {
-            client = getServiceClient();
-            client.clearAllActiveSlotRelationsToQueue(queueName);
-        } catch (TException e) {
+        boolean success = false;
+
+        for (int i = 0; i <= RETRY_COUNT; i++) {
+            SlotManagementService.Client client = null;
+
             try {
-                //retry to do the operation once
-                reConnectToServer();
+                client = getServiceClient();
                 client.clearAllActiveSlotRelationsToQueue(queueName);
-            } catch (TException e1) {
-                handleCoordinatorChanges();
-                throw new ConnectionException("Coordinator has changed", e);
-            }
-        } catch (ThriftClientException e) {
-            log.error("Could not initialize the Thrift client." + e.getMessage(), e);
-            handleCoordinatorChanges();
-        }
-    }
-
-    /**
-     * Returns an instance of Slot Management service client which is used to communicate to the
-     * thrift server. If it does not succeed in connecting to the server, it throws a  TTransportException
-     *
-     * @return a SlotManagementService client
-     */
-    private static SlotManagementService.Client getServiceClient() throws TTransportException, ThriftClientException {
-
-        if (client == null) {
-            ClusterAgent clusterAgent =  AndesContext.getInstance().getClusterAgent();
-            InetSocketAddress thriftAddressOfCoordinator = clusterAgent.getThriftAddressOfCoordinator();
-
-            if (null == thriftAddressOfCoordinator) {
-                throw new ThriftClientException("Thrift coordinator details are not updated in the map yet");
-            }
-
-            int soTimeout = AndesConfigurationManager.readValue(AndesConfiguration.COORDINATION_THRIFT_SO_TIMEOUT);
-
-            transport = new TSocket(thriftAddressOfCoordinator.getHostName(), thriftAddressOfCoordinator.getPort(),
-                    soTimeout);
-            try {
-                transport.open();
-                TProtocol protocol = new TBinaryProtocol(transport);
-                return new SlotManagementService.Client(protocol);
-            } catch (TTransportException e) {
-                log.error("Could not initialize the Thrift client", e);
-                throw new TTransportException("Could not initialize the Thrift client", e);
-            }
-        }
-
-        return client;
-    }
-
-    /**
-     * Start the thrift server reconnecting thread when the coordinator of the cluster is changed.
-     */
-    private static void handleCoordinatorChanges() {
-
-        notifyDisconnection();
-        resetServiceClient();
-        if (!isReconnectingStarted()) {
-            setReconnectingFlag(true);
-            startServerReconnectingThread();
-        }
-    }
-
-    /**
-     * Notify Thrift connection disconnect to the {@link ThriftConnectionListener}s
-     */
-    private static void notifyDisconnection() {
-        if (isConnected.compareAndSet(true, false)) {
-            for (ThriftConnectionListener listener : connectionListenerQueue) {
-                listener.onThriftClientDisconnect();
-            }
-        }
-    }
-
-    /**
-     * Set mbThriftClient to null
-     */
-    private static void resetServiceClient() {
-        client = null;
-        transport.close();
-    }
-
-    /**
-     * Try to reconnect to server by taking latest values in the hazelcalst thrift server details
-     * map
-     *
-     * @throws TTransportException when connecting to thrift server is unsuccessful
-     */
-    private static void reConnectToServer() throws TTransportException {
-        Long reconnectTimeout = (Long) AndesConfigurationManager.readValue
-                (AndesConfiguration.COORDINATOR_THRIFT_RECONNECT_TIMEOUT) * 1000;
-        try {
-            //Reconnect timeout set because Hazelcast coordinator may still not elected in failover scenario
-            Thread.sleep(reconnectTimeout);
-
-            ClusterAgent clusterAgent =  AndesContext.getInstance().getClusterAgent();
-            InetSocketAddress thriftAddressOfCoordinator = clusterAgent.getThriftAddressOfCoordinator();
-
-            if (null == thriftAddressOfCoordinator) {
-                throw new TTransportException("Thrift coordinator details are not updated in the map yet");
-            }
-
-            int soTimeout = AndesConfigurationManager.readValue(AndesConfiguration.COORDINATION_THRIFT_SO_TIMEOUT);
-
-            transport = new TSocket(thriftAddressOfCoordinator.getHostName(), thriftAddressOfCoordinator.getPort(),
-                    soTimeout);
-            log.info("Reconnecting to Slot Coordinator " + thriftAddressOfCoordinator.toString());
-
-            transport.open();
-            TProtocol protocol = new TBinaryProtocol(transport);
-            client = new SlotManagementService.Client(protocol);
-            notifyConnection();
-        } catch (TTransportException e) {
-            log.error("Could not connect to the Thrift Server" , e);
-            throw new TTransportException("Could not connect to the Thrift Server", e);
-        } catch (InterruptedException ignore) {
-        }
-    }
-
-    /**
-     * Notify Thrift connection establish signal to the {@link ThriftConnectionListener}
-     */
-    private static void notifyConnection() {
-        if (isConnected.compareAndSet(false, true)) {
-            for (ThriftConnectionListener listener : connectionListenerQueue) {
-                listener.onThriftClientConnect();
-            }
-        }
-    }
-
-    /**
-     * This thread is responsible of reconnecting to the thrift server of the coordinator until it
-     * gets succeeded
-     */
-    private static void startServerReconnectingThread() {
-        new Thread() {
-            public void run() {
-
-                // This thread will try to connect to thrift server while reconnectingStarted flag is true
-                // After successfully connecting to the server this flag will be set to true.
-                // While loop is therefore intentional.
-                while (reconnectingStarted) {
-
-                    try {
-                        reConnectToServer();
-                        // If re connect to server is successful, following code segment will be executed
-                        reconnectingStarted = false;
-                    } catch (Throwable e) {
-                        log.error("Error occurred while reconnecting to slot coordinator", e);
-
-                        try {
-                            TimeUnit.SECONDS.sleep(2);
-                        } catch (InterruptedException interruptedException) {
-                            Thread.currentThread().interrupt();
-                        }
-                    }
+                success = true;
+            } catch (TException e) {
+                invalidateServiceClient(client);
+                log.error("Attempt " + i + " failed clearing active slot relations to queue", e);
+            } finally {
+                if (client != null) {
+                    returnServiceClient(client);
                 }
             }
-        }.start();
-    }
+        }
 
-
-    /**
-     * A flag to specify whether the reconnecting to thrift server is happening or not
-     *
-     * @return whether the reconnecting to thrift server is happening or not
-     */
-    public static boolean isReconnectingStarted() {
-        return reconnectingStarted;
-    }
-
-    /**
-     * Set reconnecting flag
-     *
-     * @param reconnectingFlag  flag to see whether the reconnecting to the thrift server is
-     *                          started
-     */
-    public static void setReconnectingFlag(boolean reconnectingFlag) {
-        reconnectingStarted = reconnectingFlag;
+        if (!success) {
+            handleCoordinatorChanges();
+            throw new ConnectionException("Coordinator has changed");
+        }
     }
 
     /**
@@ -411,26 +287,196 @@ public class MBThriftClient {
      * @return global safeZone
      * @throws ConnectionException when MB thrift server is down
      */
-    public static synchronized long updateSlotDeletionSafeZone(long safeZoneMessageID, String nodeID) throws ConnectionException {
-        long globalSafeZone = 0;
-        try {
-            client = getServiceClient();
-            globalSafeZone = client.updateCurrentMessageIdForSafeZone(safeZoneMessageID, nodeID);
-        } catch (TException e) {
+    public synchronized long updateSlotDeletionSafeZone(long safeZoneMessageID, String nodeID) throws ConnectionException {
+
+        for (int i = 0; i <= RETRY_COUNT; i++) {
+            SlotManagementService.Client client = null;
+
             try {
-                //retry once
-                reConnectToServer();
-                globalSafeZone = client.updateCurrentMessageIdForSafeZone(safeZoneMessageID, nodeID);
-                return globalSafeZone;
-            } catch (TException e1) {
-                handleCoordinatorChanges();
-                throw new ConnectionException("Coordinator has changed", e);
+                client = getServiceClient();
+                return client.updateCurrentMessageIdForSafeZone(safeZoneMessageID, nodeID);
+            } catch (TException e) {
+                invalidateServiceClient(client);
+                log.error("Attempt " + i + " failed updating slot delete safe zone", e);
+            } finally {
+                if (client != null) {
+                    returnServiceClient(client);
+                }
             }
-        } catch (ThriftClientException e) {
-            log.error("Error occurred while receiving coordinator details from map", e);
-            handleCoordinatorChanges();
         }
 
-        return globalSafeZone;
+        handleCoordinatorChanges();
+        throw new ConnectionException("Coordinator has changed");
+    }
+
+    /**
+     * Start the thrift server reconnecting thread when the coordinator of the cluster is changed.
+     */
+    private void handleCoordinatorChanges() {
+
+        long attemptStartTimeMillis = System.currentTimeMillis();
+
+        synchronized (this) {
+
+            if (!isReconnecting() && lastReconnectionSuccessTimestamp < attemptStartTimeMillis) {
+                notifyDisconnection();
+                setReconnectingFlag();
+                startReconnecting();
+            }
+        }
+    }
+
+    /**
+     * Notify Thrift connection disconnect to the {@link CoordinatorConnectionListener}s
+     */
+    private void notifyDisconnection() {
+        if (isConnected.compareAndSet(true, false)) {
+            for (CoordinatorConnectionListener listener : connectionListenerQueue) {
+                listener.onCoordinatorDisconnect();
+            }
+        }
+    }
+
+    /**
+     * This will try to connect to thrift server until successful.
+     * reconnecting flag will be set to false when reconnecting is successful.
+     *
+     * @throws TTransportException when connecting to thrift server is unsuccessful
+     */
+    private void reConnectToServer() throws TTransportException {
+        Long reconnectTimeout = (Long) AndesConfigurationManager.readValue
+                (AndesConfiguration.COORDINATOR_THRIFT_RECONNECT_TIMEOUT) * 1000;
+        try {
+            //Reconnect timeout set because Hazelcast coordinator may still not elected in failover scenario
+            Thread.sleep(reconnectTimeout);
+
+            // re-initialize thrift connection pool discarding the previous pool
+            thriftClientPool.close();
+            initializeThriftConnectionPool();
+
+            // If following call succeeds that means a new thrift connection can be made to the coordinator.
+            SlotManagementService.Client client = thriftClientPool.borrowObject();
+
+            reconnecting = false;
+            lastReconnectionSuccessTimestamp = System.currentTimeMillis();
+
+            // Return the borrowed client back to the pool
+            thriftClientPool.returnObject(client);
+            notifyConnection();
+        } catch (TTransportException e) {
+            log.error("Could not connect to the Thrift Server" , e);
+            throw new TTransportException("Could not connect to the Thrift Server", e);
+        } catch (InterruptedException ignore) {
+        } catch (Exception e) {
+            log.error("Could not connect to the Thrift Server", e);
+        }
+    }
+
+    /**
+     * Notify Thrift connection establish signal to the {@link CoordinatorConnectionListener}
+     */
+    private void notifyConnection() {
+        if (isConnected.compareAndSet(false, true)) {
+            for (CoordinatorConnectionListener listener : connectionListenerQueue) {
+                listener.onCoordinatorReconnect();
+            }
+        }
+    }
+
+    /**
+     * This thread is responsible of reconnecting to the thrift server of the coordinator until it
+     * gets succeeded
+     */
+    private void startReconnecting() {
+        while (reconnecting) {
+
+            try {
+                reConnectToServer();
+                // If re connect to server is successful, following code segment will be executed
+                reconnecting = false;
+            } catch (Throwable e) {
+                log.error("Error occurred while reconnecting to slot coordinator", e);
+
+                try {
+                    TimeUnit.SECONDS.sleep(2);
+                } catch (InterruptedException interruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+    }
+
+
+    /**
+     * A flag to specify whether the reconnecting to thrift server is happening or not
+     *
+     * @return whether the reconnecting to thrift server is happening or not
+     */
+    public boolean isReconnecting() {
+        return reconnecting;
+    }
+
+    /**
+     * Set reconnecting flag to true.
+     *
+     */
+    public void setReconnectingFlag() {
+        reconnecting = true;
+    }
+
+    /**
+     * Initialize a new thrift client connection pool.
+     */
+    private void initializeThriftConnectionPool() {
+
+        int thriftClientPoolSize = AndesConfigurationManager.readValue
+                (AndesConfiguration.PERFORMANCE_TUNING_THRIFT_CLIENT_POOL_SIZE);
+
+        GenericObjectPool<SlotManagementService.Client> thriftConnectionPool = new GenericObjectPool<>(thriftClientFactory);
+        thriftConnectionPool.setMaxTotal(thriftClientPoolSize);
+        thriftClientPool = thriftConnectionPool;
+    }
+
+    /**
+     * Returns an instance of Slot Management service client from the pool which is used to communicate to the
+     * thrift server. If it does not succeed in connecting to the server, it throws a  ConnectionException
+     *
+     * @return a SlotManagementService client
+     */
+    private SlotManagementService.Client getServiceClient() throws ConnectionException {
+        try {
+            return thriftClientPool.borrowObject();
+        } catch (Exception e) {
+            throw new ConnectionException("Error burrowing a connection from thrift connection pool", e);
+        }
+    }
+
+    /**
+     * Return thrift client connection back to the connection pool.
+     *
+     * @param client The client to return to the pool
+     */
+    private void returnServiceClient(SlotManagementService.Client client) {
+        try {
+            thriftClientPool.returnObject(client);
+        } catch (Exception e) {
+            log.warn("Error returning thrift client back to the pool. Coordinator might have changed.", e);
+        }
+    }
+
+    /**
+     * Invalidate a thrift connection and ask to remove it from the pool.
+     *
+     * @param client Invalid thrift client connection
+     * @throws ConnectionException Throws when thrift client pool fails to invalidate the given object
+     */
+    private void invalidateServiceClient(SlotManagementService.Client client) throws ConnectionException {
+        if (client != null) {
+            try {
+                thriftClientPool.invalidateObject(client);
+            } catch (Exception e) {
+                throw new ConnectionException("Error invalidating a connection from thrift connection pool", e);
+            }
+        }
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/thrift/ThriftClientFactory.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/thrift/ThriftClientFactory.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ */
+
+package org.wso2.andes.thrift;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+import org.wso2.andes.configuration.AndesConfigurationManager;
+import org.wso2.andes.configuration.enums.AndesConfiguration;
+import org.wso2.andes.kernel.AndesContext;
+import org.wso2.andes.server.cluster.ClusterAgent;
+import org.wso2.andes.thrift.exception.ThriftClientException;
+import org.wso2.andes.thrift.slot.gen.SlotManagementService;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Thrift client ConnectionFactory which initialises a connection pool for thrift communication.
+ */
+public class ThriftClientFactory extends BasePooledObjectFactory<SlotManagementService.Client> {
+
+    private static final Log log = LogFactory.getLog(ThriftClientFactory.class);
+
+    /**
+     * When a new connection needs to be created this method is called.
+     *
+     * @return A new thrift client which is connected to the server
+     * @throws Exception Throws when a thrift client fails to connect to the server
+     */
+    @Override
+    public SlotManagementService.Client create() throws Exception {
+
+        ClusterAgent clusterAgent =  AndesContext.getInstance().getClusterAgent();
+        InetSocketAddress thriftAddressOfCoordinator = clusterAgent.getThriftAddressOfCoordinator();
+
+        if (null == thriftAddressOfCoordinator) {
+            throw new ThriftClientException("Thrift coordinator details are not updated in the map yet");
+        }
+
+        int soTimeout = AndesConfigurationManager.readValue(AndesConfiguration.COORDINATION_THRIFT_SO_TIMEOUT);
+
+        TTransport transport = new TSocket(thriftAddressOfCoordinator.getHostName(), thriftAddressOfCoordinator.getPort(),
+                soTimeout);
+        try {
+            transport.open();
+            TProtocol protocol = new TBinaryProtocol(transport);
+            return new SlotManagementService.Client(protocol);
+        } catch (TTransportException e) {
+            throw new TTransportException("Could not initialize the Thrift client", e);
+        }
+    }
+
+    /**
+     * When a new object needs to be added to the pool, this method is called.
+     *
+     * @param client The thrift client
+     * @return The thrift client wrapped by the PooledObject
+     */
+    @Override
+    public PooledObject<SlotManagementService.Client> wrap(SlotManagementService.Client client) {
+        return new DefaultPooledObject<>(client);
+    }
+
+    /**
+     * When an object is invalidated this method is called. We have to properly close the sockets before removing the
+     * connection.
+     *
+     * @param client The thrift client which should be destroyed
+     * @throws Exception Throws when the thrift connection could not be closed
+     */
+    @Override
+    public void destroyObject(PooledObject<SlotManagementService.Client> client) throws Exception {
+        client.getObject().getInputProtocol().getTransport().close();
+        super.destroyObject(client);
+    }
+}

--- a/modules/andes-core/broker/src/main/resources/slot.thrift
+++ b/modules/andes-core/broker/src/main/resources/slot.thrift
@@ -6,13 +6,13 @@ namespace java org.wso2.andes.thrift.slot.gen
  * messageCount - number of messages in the slotImp
  * startMessageId - starting message ID of the slotImp
  * endMessageId - ending message ID of the slotImp
- * queueName - the queueName which the slotImp belongs to
+ * storageQueueName - the storageQueueName which the slotImp belongs to
  */
 struct SlotInfo {
     1: optional i64  messageCount;
     2: i64  startMessageId;
     3: i64  endMessageId;
-    4: string queueName;
+    4: string storageQueueName;
     5: string assignedNodeId;
     6: bool hasOverlappingSlots;
     
@@ -24,21 +24,21 @@ struct SlotInfo {
 service SlotManagementService {
     /* The getSlot operation. This method is used to get a slotImp from SlotManager
     */
-    SlotInfo getSlotInfo(1: string queueName, 2: string nodeId),
+    SlotInfo getSlotInfo(1: string storageQueueName, 2: string nodeId),
 
     /* The updateMessageId operation is to update the message ID in the coordinator after chunk of messages are published.
     *  In addition, the coordinator will check if the received slot overlaps with any existing,assigned slots, 
     *  and memorize such ranges to be given back to the same node.
     */
-    void updateMessageId(1: string queueName, 2: string nodeId, 3: i64 startMessageId, 4: i64 endMessageId, 5: i64 localSafeZone),
+    void updateMessageId(1: string storageQueueName, 2: string nodeId, 3: i64 startMessageId, 4: i64 endMessageId, 5: i64 localSafeZone),
 
     /* Delete empty slots
     */
-    bool deleteSlot(1: string queueName, 2: SlotInfo slotInfo, 3: string nodeId),
+    bool deleteSlot(1: string storageQueueName, 2: SlotInfo slotInfo, 3: string nodeId),
 
     /* Re-assign the slot when there are no local subscribers in the node
     */
-    void reAssignSlotWhenNoSubscribers(1: string nodeId, 2: string queueName),
+    void reAssignSlotWhenNoSubscribers(1: string nodeId, 2: string storageQueueName),
 
     /* This is used by nodes to communicate their current generated message ID, so that the coordinator can decide the minimal message ID 
     *  to derive the safe zone for deleting slots.
@@ -48,8 +48,8 @@ service SlotManagementService {
     /**
      * Delete all in-memory slot associations with a given queue. This is required to handle a queue purge event.
      *
-     * @param queueName name of destination queue
+     * @param storageQueueName name of destination queue
      */
-    void clearAllActiveSlotRelationsToQueue(1: string queueName)
+    void clearAllActiveSlotRelationsToQueue(1: string storageQueueName)
 
 }

--- a/modules/andes-core/pom.xml
+++ b/modules/andes-core/pom.xml
@@ -78,10 +78,6 @@
             <artifactId>commons-logging-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-pool</groupId>
-            <artifactId>commons-pool</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
         </dependency>
@@ -357,6 +353,10 @@
         <dependency>
             <groupId>com.goldmansachs</groupId>
             <artifactId>gs-collections</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
         </dependency>
     </dependencies>
 

--- a/modules/andes-core/systests/etc/test-default.txt
+++ b/modules/andes-core/systests/etc/test-default.txt
@@ -59,7 +59,7 @@ ACL ALLOW client BIND EXCHANGE name="amq.direct" temporary=true
 ACL ALLOW client UNBIND EXCHANGE name="amq.direct" temporary=true
 ACL ALLOW client BIND EXCHANGE name="amq.direct" durable=true
 ACL ALLOW client UNBIND EXCHANGE name="amq.direct" durable=true
-ACL ALLOW server BIND EXCHANGE name="amq.direct" queueName="example.RequestQueue"
+ACL ALLOW server BIND EXCHANGE name="amq.direct" storageQueueName="example.RequestQueue"
 
 ## Allow client and server exchange access for the relevant topics
 ACL ALLOW client BIND EXCHANGE name="amq.topic" durable=true routingKey=kipper

--- a/modules/andes-core/systests/src/main/java/org/wso2/andes/test/unit/message/UTF8En
+++ b/modules/andes-core/systests/src/main/java/org/wso2/andes/test/unit/message/UTF8En
@@ -1,4 +1,4 @@
 exhangeName
-queueName
+storageQueueName
 routingkey
 data

--- a/pom.xml
+++ b/pom.xml
@@ -109,11 +109,6 @@
                 <version>${commons-logging-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-pool</groupId>
-                <artifactId>commons-pool</artifactId>
-                <version>${commons-pool.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derby</artifactId>
                 <version>${derby.version}</version>
@@ -474,6 +469,11 @@
                 <artifactId>gs-collections</artifactId>
                 <version>${gs-collections.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-pool2</artifactId>
+                <version>${org.apache.commons.pool.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -578,7 +578,6 @@
         <commons-codec.version>1.3</commons-codec.version>
         <commons-logging.version>1.1.1</commons-logging.version>
         <commons-logging-api.version>1.1</commons-logging-api.version>
-        <commons-pool.version>1.5.3</commons-pool.version>
         <FastInfoset.version>1.2.12</FastInfoset.version>
         <high-scale-lib.version>1.1.2</high-scale-lib.version>
         <javacc.version>3.2</javacc.version>
@@ -639,6 +638,7 @@
         <lz4.version>1.3.0</lz4.version>
         <gs-collections-api.version>7.0.3</gs-collections-api.version>
         <gs-collections.version>7.0.3</gs-collections.version>
+        <org.apache.commons.pool.version>2.4.2</org.apache.commons.pool.version>
 
     </properties>
 


### PR DESCRIPTION
Changes Done:
1)Changed AndesConfiguration and add a configure method for configure number of tables.
2)RDBMSConstants class contains the constant variables, so MB_METADATA s and MB_CONTENT s are variables. So added a new class to those quires which vary according to the number of tables (RDBMSMultipleTableHandler).
3) Changed the methods that use metadata table and content table in RDBMSMessageStoreMpl according to the new changes.