### PR TITLE
Introduce InboundEventHandler abstract class

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/InboundEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/InboundEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,15 +18,14 @@
 
 package org.wso2.andes.kernel.disruptor;
 
-import org.wso2.andes.kernel.AndesMessage;
-
-import java.util.List;
-import java.util.Map;
+import com.lmax.disruptor.EventHandler;
+import org.wso2.andes.kernel.disruptor.inbound.InboundEventContainer;
 
 /**
- * Batch event handler for ConcurrentBatchEventHandler
+ * Abstract class handling inbound events. This is to make each inbound event handler stem from the same event
+ * handler class without using generics. Avoid generic array type error when creating an array consisting of different
+ * types of inbound event handlers in {@link org.wso2.andes.kernel.disruptor.inbound.InboundEventManager}
  */
-public interface BatchEventHandler {
+public abstract class InboundEventHandler implements EventHandler<InboundEventContainer> {
 
-    void onEvent(final List<AndesMessage> eventList, Map<String, AndesMessage> retainMap) throws Exception;
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/AckEventBatchHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/AckEventBatchHandler.java
@@ -18,15 +18,15 @@
 
 package org.wso2.andes.kernel.disruptor.inbound;
 
-import com.lmax.disruptor.EventHandler;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.kernel.AndesAckData;
+import org.wso2.andes.kernel.disruptor.InboundEventHandler;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class AckEventBatchHandler implements EventHandler<InboundEventContainer> {
+public class AckEventBatchHandler extends InboundEventHandler {
 
     private static Log log = LogFactory.getLog(AckHandler.class);
     private final List<AndesAckData> ackDataList;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundEventManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundEventManager.java
@@ -32,6 +32,7 @@ import org.wso2.andes.kernel.AndesMessage;
 import org.wso2.andes.kernel.DisablePubAckImpl;
 import org.wso2.andes.kernel.MessagingEngine;
 import org.wso2.andes.kernel.disruptor.ConcurrentBatchEventHandler;
+import org.wso2.andes.kernel.disruptor.InboundEventHandler;
 import org.wso2.andes.kernel.disruptor.LogExceptionHandler;
 import org.wso2.andes.kernel.disruptor.compression.LZ4CompressionHelper;
 import org.wso2.andes.kernel.dtx.DtxBranch;
@@ -99,6 +100,8 @@ public class InboundEventManager {
         Integer transactionBatchSize = AndesConfigurationManager.readValue(
                 MAX_TRANSACTION_BATCH_SIZE);
 
+        Integer dtxDbWriterCount = 1; // need to merge local and distributed transaction writing logic to the same
+
         disablePubAck = new DisablePubAckImpl();
         int maxContentChunkSize = AndesConfigurationManager.readValue(
                 PERFORMANCE_TUNING_MAX_CONTENT_CHUNK_SIZE);
@@ -109,7 +112,6 @@ public class InboundEventManager {
                 .setNameFormat("DisruptorInboundEventThread-%d").build();
         ExecutorService executorPool = Executors.newCachedThreadPool(namedThreadFactory);
 
-
         disruptor = new Disruptor<>(InboundEventContainer.getFactory(),
                 bufferSize,
                 executorPool,
@@ -118,8 +120,8 @@ public class InboundEventManager {
 
         disruptor.handleExceptionsWith(new LogExceptionHandler());
 
-        ConcurrentBatchEventHandler[] concurrentBatchEventHandlers =
-                new ConcurrentBatchEventHandler[writeHandlerCount + transactionHandlerCount];
+        InboundEventHandler[] batchEventHandlers = new InboundEventHandler[
+                writeHandlerCount + transactionHandlerCount + ackHandlerCount + dtxDbWriterCount];
 
         lz4CompressionHelper = new LZ4CompressionHelper();
 
@@ -134,24 +136,28 @@ public class InboundEventManager {
         }
 
         for (int turn = 0; turn < writeHandlerCount; turn++) {
-            concurrentBatchEventHandlers[turn] =
+            batchEventHandlers[turn] =
                     new ConcurrentBatchEventHandler(turn, writeHandlerCount, writerBatchSize, MESSAGE_EVENT,
                                                     new MessageWriter(messagingEngine, writerBatchSize));
         }
 
         for (int turn = 0; turn < transactionHandlerCount; turn++) {
-            concurrentBatchEventHandlers[writeHandlerCount + turn] =
+            batchEventHandlers[writeHandlerCount + turn] =
                     new ConcurrentBatchEventHandler(turn, transactionHandlerCount,
                             transactionBatchSize,
                             TRANSACTION_COMMIT_EVENT,
                             new MessageWriter(messagingEngine, transactionBatchSize));
         }
 
-        AckEventBatchHandler[] ackEventBatchHandlers = new AckEventBatchHandler[ackHandlerCount];
         for (int turn = 0; turn < ackHandlerCount; turn++) {
-            ackEventBatchHandlers[turn] = new AckEventBatchHandler(turn, ackHandlerCount,
-                                                          ackHandlerBatchSize,
-                                                          new AckHandler(messagingEngine));
+            batchEventHandlers[writeHandlerCount+ transactionHandlerCount + turn] =
+                    new AckEventBatchHandler(turn, ackHandlerCount, ackHandlerBatchSize,
+                                             new AckHandler(messagingEngine));
+        }
+
+        for (int turn = 0; turn < dtxDbWriterCount; turn++) {
+            batchEventHandlers[writeHandlerCount+ transactionHandlerCount + ackHandlerCount + turn] =
+                    new DtxDbWriter(messagingEngine, turn, dtxDbWriterCount);
         }
 
         MessagePreProcessor preProcessor = new MessagePreProcessor();
@@ -160,15 +166,11 @@ public class InboundEventManager {
         // Order in which handlers run in Disruptor
         // - ContentChunkHandlers
         // - MessagePreProcessor
-        // - AckHandlers
-        // - MessageWriters
-        // - DtxDbWriter
+        // - AckHandlers, MessageWriters, DtxDbWriter
         // - StateEventHandler
         disruptor.handleEventsWith(chunkHandlers).then(preProcessor);
         disruptor.after(preProcessor)
-                .handleEventsWith(ackEventBatchHandlers)
-                .then(concurrentBatchEventHandlers)
-                .then(new DtxDbWriter(messagingEngine))
+                .handleEventsWith(batchEventHandlers)
                 .then(stateEventHandler);   // State event handler update the state of Andes after other handlers work
                                             // is done. State event handler will execute last. This handler will clear
                                             // the event container.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/MessageWriter.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/MessageWriter.java
@@ -24,7 +24,6 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesMessage;
 import org.wso2.andes.kernel.MessagingEngine;
-import org.wso2.andes.kernel.disruptor.BatchEventHandler;
 import org.wso2.andes.store.AndesBatchUpdateException;
 import org.wso2.andes.store.AndesTransactionRollbackException;
 import org.wso2.andes.store.FailureObservingStoreManager;
@@ -39,7 +38,7 @@ import java.util.Map;
 /**
  * Writes messages in Disruptor ring buffer to message store in batches.
  */
-public class MessageWriter implements BatchEventHandler, StoreHealthListener {
+public class MessageWriter implements StoreHealthListener {
 
     private static Log log = LogFactory.getLog(MessageWriter.class);
 
@@ -73,7 +72,6 @@ public class MessageWriter implements BatchEventHandler, StoreHealthListener {
         FailureObservingStoreManager.registerStoreHealthListener(this);
     }
 
-    @Override
     public void onEvent(final List<AndesMessage> messageList, final Map<String, AndesMessage> retainMap) throws Exception {
 
         if (messageStoresUnavailable) {


### PR DESCRIPTION
- To make acknowledge handlers, transactional and non transactional message writers run in parallel (in disruptor) created the InboundEventHandler abstract class. All those handlers stem from this base class.