### PR TITLE
Fix issues identified while write dtx.start join, resume test cases

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/txn/QpidDistributedTransaction.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/txn/QpidDistributedTransaction.java
@@ -145,7 +145,13 @@ public class QpidDistributedTransaction implements ServerTransaction {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Preparing distributed transaction " + Arrays.toString(xid.getGlobalTransactionId()));
         }
-        distributedTransaction.prepare(xid);
+        try {
+            distributedTransaction.prepare(xid);
+        } finally {
+            for (Action action : postTransactionActions) {
+                action.postCommit();
+            }
+        }
     }
 
     public void commit(Xid xid, boolean onePhase, Runnable callback) throws UnknownDtxBranchException,
@@ -154,13 +160,7 @@ public class QpidDistributedTransaction implements ServerTransaction {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Committing distributed transaction " + Arrays.toString(xid.getGlobalTransactionId()));
         }
-        try {
-            distributedTransaction.commit(xid, onePhase, callback);
-        } finally {
-            for (Action action : postTransactionActions) {
-                action.postCommit();
-            }
-        }
+        distributedTransaction.commit(xid, onePhase, callback);
     }
 
     public void rollback(Xid xid)


### PR DESCRIPTION
- postCommit command for postTransactionActions are executed at
  prepared state since after prepared we cannot rollback
- sibling map is update for both compared xaResources in
  XAResource_0_9_1#isSameRM method