### PR TITLE
Fix rollback issue of not returning acked messages within transaction

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/MessagePreProcessor.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/MessagePreProcessor.java
@@ -66,7 +66,6 @@ public class MessagePreProcessor implements EventHandler<InboundEventContainer> 
             case TRANSACTION_COMMIT_EVENT:
                 preProcessTransaction(inboundEvent, sequence);
                 break;
-
             case DTX_COMMIT_EVENT:
                 preProcessDtxTransaction(inboundEvent, sequence);
                 break;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/txn/QpidDistributedTransaction.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/txn/QpidDistributedTransaction.java
@@ -49,6 +49,7 @@ import javax.transaction.xa.Xid;
  * Server Transaction type used to handle requests related to distributed transactions.
  */
 public class QpidDistributedTransaction implements ServerTransaction {
+
     /**
      * Class logger
      */
@@ -118,6 +119,9 @@ public class QpidDistributedTransaction implements ServerTransaction {
         throw new IllegalStateException("Cannot call tx.commit() on a distributed transaction");
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void rollback() {
         throw new IllegalStateException("Cannot call tx.rollback() on a distributed transaction");
@@ -163,14 +167,14 @@ public class QpidDistributedTransaction implements ServerTransaction {
         distributedTransaction.commit(xid, onePhase, callback);
     }
 
-    public void rollback(Xid xid)
+    public void rollback(Xid xid, UUID channelId)
             throws UnknownDtxBranchException, AndesException, TimeoutDtxException, IncorrectDtxStateException {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Rolling back distributed transaction " + Arrays.toString(xid.getGlobalTransactionId()));
         }
 
         try {
-            distributedTransaction.rollback(xid);
+            distributedTransaction.rollback(xid, channelId);
         } finally {
             for (Action action : postTransactionActions) {
                 action.onRollback();
@@ -188,6 +192,10 @@ public class QpidDistributedTransaction implements ServerTransaction {
         }
 
         distributedTransaction.enqueueMessage(andesMessage, andesChannel);
+    }
+
+    public void close(long sessionId) {
+        distributedTransaction.close(sessionId);
     }
 
     /**

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/transport/network/mina/MinaNetworkTransport.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/transport/network/mina/MinaNetworkTransport.java
@@ -25,24 +25,32 @@ import org.apache.mina.common.ExecutorThreadModel;
 import org.apache.mina.common.IoConnector;
 import org.apache.mina.common.IoSession;
 import org.apache.mina.filter.SSLFilter;
-import org.apache.mina.transport.socket.nio.*;
+import org.apache.mina.transport.socket.nio.SocketAcceptor;
+import org.apache.mina.transport.socket.nio.SocketAcceptorConfig;
+import org.apache.mina.transport.socket.nio.SocketConnector;
+import org.apache.mina.transport.socket.nio.SocketConnectorConfig;
+import org.apache.mina.transport.socket.nio.SocketSessionConfig;
 import org.apache.mina.util.NewThreadExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.andes.protocol.ProtocolEngineFactory;
 import org.wso2.andes.ssl.SSLContextFactory;
 import org.wso2.andes.thread.QpidThreadExecutor;
-import org.wso2.andes.transport.*;
+import org.wso2.andes.transport.ConnectionSettings;
+import org.wso2.andes.transport.NetworkTransportConfiguration;
+import org.wso2.andes.transport.Receiver;
+import org.wso2.andes.transport.SocketConnectorFactory;
+import org.wso2.andes.transport.TransportException;
 import org.wso2.andes.transport.network.IncomingNetworkTransport;
 import org.wso2.andes.transport.network.NetworkConnection;
 import org.wso2.andes.transport.network.OutgoingNetworkTransport;
 import org.wso2.andes.transport.network.Transport;
 import org.wso2.andes.transport.network.security.ssl.SSLUtil;
 
-import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import javax.net.ssl.SSLContext;
 
 import static org.wso2.andes.transport.ConnectionSettings.WILDCARD_ADDRESS;
 
@@ -215,7 +223,6 @@ public class MinaNetworkTransport implements OutgoingNetworkTransport, IncomingN
             {
                 throw new TransportException("Could not open connection");
             }
-
             IoSession session = future.getSession();
             session.setAttachment(receiver);
 


### PR DESCRIPTION
- When rollback is called return the messages that were acknowledged within the transaction

- Remove entries for none prepared distributed transactions from dtx registry when a session is closed.