### PR TITLE
NPE in the mix subscriptions test case is fixed.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
@@ -287,9 +287,6 @@ public class AndesContextInformationManager {
     public void deleteQueue(StorageQueue storageQueue) throws AndesException {
         String storageQueueName = storageQueue.getName();
 
-        //remove all subscriptions to the queue
-        subscriptionManager.closeAllSubscriptionsBoundToQueue(storageQueueName);
-
         //remove all bindings from memory if not removed
         List<AndesBinding> removedBindings = amqpConstructStore.removeAllBindingsForQueue(storageQueueName);
         for (AndesBinding removedBinding : removedBindings) {
@@ -328,9 +325,6 @@ public class AndesContextInformationManager {
     public void syncQueueDelete(InboundQueueSyncEvent queueDeleteSyncEvent) throws AndesException {
         StorageQueue queueWithEvent = queueDeleteSyncEvent.toStorageQueue();
         String storageQueueName = queueWithEvent.getName();
-
-        //remove all subscriptions to the queue
-        subscriptionManager.closeAllSubscriptionsBoundToQueue(storageQueueName);
 
         //clear in-memory messages buffered for queue
         handleQueuePurgeNotification(queueDeleteSyncEvent);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscription.java
@@ -15,6 +15,10 @@
 
 package org.wso2.andes.kernel.subscription;
 
+import com.googlecode.cqengine.attribute.Attribute;
+import com.googlecode.cqengine.attribute.SimpleAttribute;
+import com.googlecode.cqengine.attribute.SimpleNullableAttribute;
+import com.googlecode.cqengine.query.option.QueryOptions;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.logging.Log;
@@ -26,9 +30,6 @@ import org.wso2.andes.kernel.MessageFlusher;
 import org.wso2.andes.kernel.MessageStatus;
 import org.wso2.andes.kernel.MessagingEngine;
 import org.wso2.andes.kernel.ProtocolType;
-import com.googlecode.cqengine.attribute.Attribute;
-import com.googlecode.cqengine.attribute.SimpleAttribute;
-import com.googlecode.cqengine.query.option.QueryOptions;
 import org.wso2.andes.metrics.MetricsConstants;
 import org.wso2.andes.server.ClusterResourceHolder;
 import org.wso2.andes.tools.utils.MessageTracer;
@@ -425,20 +426,27 @@ public class AndesSubscription {
         }
     };
 
-    public static final Attribute<AndesSubscription, String> ROUTER_NAME = new SimpleAttribute<AndesSubscription,
-            String>("routerName") {
+    public static final Attribute<AndesSubscription, String> ROUTER_NAME =
+            new SimpleNullableAttribute<AndesSubscription, String>("routerName") {
         @Override
         public String getValue(AndesSubscription sub, QueryOptions queryOptions) {
-            return sub.storageQueue.getMessageRouter().getName();
+            String routerName = null;
+            if (sub.storageQueue.getMessageRouter() != null) {
+                routerName = sub.storageQueue.getMessageRouter().getName();
+            }
+            return routerName;
         }
     };
 
-    public static final Attribute<AndesSubscription, String> ROUTING_KEY = new SimpleAttribute<AndesSubscription,
-            String>
-            ("routingKey") {
+    public static final Attribute<AndesSubscription, String> ROUTING_KEY =
+            new SimpleNullableAttribute<AndesSubscription, String>("routingKey") {
         @Override
         public String getValue(AndesSubscription sub, QueryOptions queryOptions) {
-            return sub.getStorageQueue().getMessageRouterBindingKey().toLowerCase();
+            String routingKey = null;
+            if (sub.getStorageQueue().getMessageRouter() != null) {
+                routingKey = sub.getStorageQueue().getMessageRouterBindingKey().toLowerCase();
+            }
+            return routingKey;
         }
     };
 


### PR DESCRIPTION
Last nondurable subscriber disconnect causes purge messages and deletes queue. In queue
delete, we again invoke close subscription and send a notification. It was repeated queue
delete again and end up with NPE. Therefore, invoking subscription close inside queue delete
was removed in the code. Also, when syncing subscription, cqengine query trying to
access a null object. Null check added to ROUTER_NAME and ROUTING_KEY.