### PR TITLE
Implement dtx.recover frame

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -47,6 +47,7 @@ import org.wso2.carbon.metrics.manager.Level;
 import org.wso2.carbon.metrics.manager.Meter;
 import org.wso2.carbon.metrics.manager.MetricManager;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +56,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.transaction.xa.Xid;
 
 import static org.wso2.andes.configuration.enums.AndesConfiguration.PERFORMANCE_TUNING_PURGED_COUNT_TIMEOUT;
 
@@ -804,6 +806,15 @@ public class Andes {
 
     public DistributedTransaction createDistributedTransaction(AndesChannel channel) {
         return new DistributedTransaction(dtxRegistry, inboundEventManager, channel);
+    }
+
+    /**
+     * Get list of prepared transactions from Dtx registry
+     *
+     * @return list of XIDs belonging to branches in prepared state
+     */
+    public ArrayList<Xid> getPreparedDtxTransactions() {
+        return dtxRegistry.getPreparedTransactions();
     }
 }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/dtx/DtxRegistry.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/dtx/DtxRegistry.java
@@ -26,6 +26,7 @@ import org.wso2.andes.server.txn.IncorrectDtxStateException;
 import org.wso2.andes.server.txn.RollbackOnlyDtxException;
 import org.wso2.andes.server.txn.TimeoutDtxException;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -275,6 +276,23 @@ public class DtxRegistry {
      */
     public void stop() {
         timeoutTaskExecutor.shutdown();
+    }
+
+    /**
+     * Return list of XIDs belonging to dtx branches in prepared state
+     *
+     * @return list of XIDs in prepared state
+     */
+    public ArrayList<Xid> getPreparedTransactions() {
+        ArrayList<Xid> preparedBranches = new ArrayList<>();
+
+        for (DtxBranch dtxBranch : branches.values()) {
+            if (dtxBranch.getState() == DtxBranch.State.PREPARED) {
+                preparedBranches.add(dtxBranch.getXid());
+            }
+        }
+
+        return preparedBranches;
     }
 
     private static final class ComparableXid {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
@@ -1450,9 +1450,20 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
     }
 
     /**
-     * Assert if dtxselect is called
+     * Return list of XIDs belonging to dtx branches in prepared state
+     *
+     * @return list of XIDs in prepared state
+     * @throws DtxNotSelectedException if dtx.select is not called before
+     */
+    public ArrayList<Xid> recoverDtxTransactions() throws DtxNotSelectedException {
+        return Andes.getInstance().getPreparedDtxTransactions();
+    }
+
+    /**
+     * Assert if dtx.select is called
+     *
      * @return matching DistributedTransaction object
-     * @throws DtxNotSelectedException if dtxselect is not called before
+     * @throws DtxNotSelectedException if dtx.select is not called before
      */
     private QpidDistributedTransaction assertDtxTransaction() throws DtxNotSelectedException {
         if(isAttachedToADistributedTransaction())

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/DtxRecoverHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/DtxRecoverHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.andes.server.handler;
+
+import org.apache.commons.lang.SerializationUtils;
+import org.wso2.andes.AMQException;
+import org.wso2.andes.framing.DtxRecoverOkBody;
+import org.wso2.andes.framing.amqp_0_91.DtxRecoverBodyImpl;
+import org.wso2.andes.framing.amqp_0_91.MethodRegistry_0_91;
+import org.wso2.andes.protocol.AMQConstant;
+import org.wso2.andes.server.AMQChannel;
+import org.wso2.andes.server.protocol.AMQProtocolSession;
+import org.wso2.andes.server.state.AMQStateManager;
+import org.wso2.andes.server.state.StateAwareMethodListener;
+import org.wso2.andes.server.txn.DtxNotSelectedException;
+
+import java.util.ArrayList;
+import javax.transaction.xa.Xid;
+
+/**
+ * Handler class for dtx.recover
+ */
+public class DtxRecoverHandler implements StateAwareMethodListener<DtxRecoverBodyImpl> {
+    private static DtxRecoverHandler _instance = new DtxRecoverHandler();
+
+    public static DtxRecoverHandler getInstance() {
+        return _instance;
+    }
+
+    private DtxRecoverHandler() {
+    }
+
+    @Override
+    public void methodReceived(AMQStateManager stateManager, DtxRecoverBodyImpl body, int channelId)
+            throws AMQException {
+        AMQProtocolSession session = stateManager.getProtocolSession();
+
+        AMQChannel channel = session.getChannel(channelId);
+
+        if (channel == null) {
+            throw body.getChannelNotFoundException(channelId);
+        }
+
+        try {
+            ArrayList<Xid> inDoubtXids = channel.recoverDtxTransactions();
+            MethodRegistry_0_91 methodRegistry = (MethodRegistry_0_91) session.getMethodRegistry();
+
+            byte[] serializedData = SerializationUtils.serialize(inDoubtXids);
+            DtxRecoverOkBody dtxRecoverOkBody = methodRegistry.createDtxRecoverOkBody(serializedData);
+            session.writeFrame(dtxRecoverOkBody.generateFrame(channelId));
+        } catch (DtxNotSelectedException e) {
+            throw body.getChannelException(AMQConstant.NOT_ALLOWED, "Not a distributed transacted session", e);
+        }
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/ServerMethodDispatcherImpl_0_91.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/ServerMethodDispatcherImpl_0_91.java
@@ -33,6 +33,8 @@ import org.wso2.andes.framing.DtxForgetBody;
 import org.wso2.andes.framing.DtxForgetOkBody;
 import org.wso2.andes.framing.DtxPrepareBody;
 import org.wso2.andes.framing.DtxPrepareOkBody;
+import org.wso2.andes.framing.DtxRecoverBody;
+import org.wso2.andes.framing.DtxRecoverOkBody;
 import org.wso2.andes.framing.DtxRollbackBody;
 import org.wso2.andes.framing.DtxRollbackOkBody;
 import org.wso2.andes.framing.DtxSelectBody;
@@ -60,6 +62,7 @@ import org.wso2.andes.framing.amqp_0_91.DtxCommitBodyImpl;
 import org.wso2.andes.framing.amqp_0_91.DtxEndBodyImpl;
 import org.wso2.andes.framing.amqp_0_91.DtxForgetBodyImpl;
 import org.wso2.andes.framing.amqp_0_91.DtxPrepareBodyImpl;
+import org.wso2.andes.framing.amqp_0_91.DtxRecoverBodyImpl;
 import org.wso2.andes.framing.amqp_0_91.DtxRollbackBodyImpl;
 import org.wso2.andes.framing.amqp_0_91.DtxSetTimeoutBodyImpl;
 import org.wso2.andes.framing.amqp_0_91.DtxStartBodyImpl;
@@ -85,6 +88,7 @@ public class ServerMethodDispatcherImpl_0_91
     private static final DtxRollbackHandler dtxRollbackHandler = DtxRollbackHandler.getInstance();
     private static final DtxForgetHandler dtxForgetHandler = DtxForgetHandler.getInstance();
     private static final DtxSetTimeoutHandler dtxSetTimeoutHandler = DtxSetTimeoutHandler.getInstance();
+    private static final DtxRecoverHandler dtxRecoverHandler = DtxRecoverHandler.getInstance();
 
     private final AMQStateManager stateManager;
 
@@ -153,6 +157,12 @@ public class ServerMethodDispatcherImpl_0_91
     }
 
     @Override
+    public boolean dispatchDtxRecover(DtxRecoverBody body, int channelId) throws AMQException {
+        dtxRecoverHandler.methodReceived(stateManager, (DtxRecoverBodyImpl) body, channelId);
+        return true;
+    }
+
+    @Override
     public boolean dispatchDtxRollback(DtxRollbackBody body, int channelId) throws AMQException {
         dtxRollbackHandler.methodReceived(stateManager, (DtxRollbackBodyImpl) body, channelId);
         return true;
@@ -170,6 +180,11 @@ public class ServerMethodDispatcherImpl_0_91
 
     @Override
     public boolean dispatchDtxPrepareOk(DtxPrepareOkBody body, int channelId) throws AMQException {
+        throw new UnexpectedMethodException(body);
+    }
+
+    @Override
+    public boolean dispatchDtxRecoverOk(DtxRecoverOkBody body, int channelId) throws AMQException {
         throw new UnexpectedMethodException(body);
     }
 

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/XAResource_0_9_1.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/XAResource_0_9_1.java
@@ -218,7 +218,7 @@ class XAResource_0_9_1 implements XAResource {
     @Override
     public int prepare(Xid xid) throws XAException {
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("prepare dtx branch with xid: ", xid);
+            LOGGER.debug("prepare dtx branch with xid: " + xid);
         }
 
         XaStatus resultStatus;
@@ -241,7 +241,19 @@ class XAResource_0_9_1 implements XAResource {
 
     @Override
     public Xid[] recover(int i) throws XAException {
-        throw new RuntimeException("Feature NotImplemented");
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("recover dtx branches with prepared state");
+        }
+
+        try {
+            List<Xid> xidList = session.recoverDtxTransactions();
+            return xidList.toArray(new Xid[xidList.size()]);
+
+        } catch (FailoverException | AMQException e) {
+            XAException xaException = new XAException("Error while recovering dtx sessions.");
+            xaException.initCause(e);
+            throw xaException;
+        }
     }
 
     @Override

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/handler/ClientMethodDispatcherImpl_0_91.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/handler/ClientMethodDispatcherImpl_0_91.java
@@ -41,6 +41,8 @@ import org.wso2.andes.framing.DtxForgetBody;
 import org.wso2.andes.framing.DtxForgetOkBody;
 import org.wso2.andes.framing.DtxPrepareBody;
 import org.wso2.andes.framing.DtxPrepareOkBody;
+import org.wso2.andes.framing.DtxRecoverBody;
+import org.wso2.andes.framing.DtxRecoverOkBody;
 import org.wso2.andes.framing.DtxRollbackBody;
 import org.wso2.andes.framing.DtxRollbackOkBody;
 import org.wso2.andes.framing.DtxSetTimeoutBody;
@@ -249,6 +251,15 @@ public class ClientMethodDispatcherImpl_0_91 extends ClientMethodDispatcherImpl 
     }
 
     @Override
+    public boolean dispatchDtxRecoverOk(DtxRecoverOkBody body, int channelId) throws AMQException {
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("Received dtx.recover-ok message, " + channelId);
+        }
+        return true;
+    }
+
+    @Override
     public boolean dispatchDtxRollbackOk(DtxRollbackOkBody body, int channelId) throws AMQException {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Received dtx.rollback-ok message, " + channelId + " with status: " + body.getXaResult());
@@ -276,6 +287,11 @@ public class ClientMethodDispatcherImpl_0_91 extends ClientMethodDispatcherImpl 
 
     @Override
     public boolean dispatchDtxPrepare(DtxPrepareBody body, int channelId) throws AMQException {
+        throw new AMQMethodNotImplementedException(body);
+    }
+
+    @Override
+    public boolean dispatchDtxRecover(DtxRecoverBody body, int channelId) throws AMQException {
         throw new AMQMethodNotImplementedException(body);
     }
 

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/dtx/XidImpl.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/dtx/XidImpl.java
@@ -24,13 +24,14 @@ import org.wso2.andes.AMQInvalidArgumentException;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Arrays;
 import javax.transaction.xa.Xid;
 
 /**
  * Implements javax.transaction.dtx.Xid
  */
-public class XidImpl implements Xid
+public class XidImpl implements Xid, Serializable
 {
     /**
      * this session's logger

--- a/modules/orbit/andes-client/pom.xml
+++ b/modules/orbit/andes-client/pom.xml
@@ -81,6 +81,10 @@
             <groupId>org.wso2.securevault</groupId>
             <artifactId>org.wso2.securevault</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -96,7 +100,8 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>
                             org.wso2.andes.*;-split-package:=merge-last,
-                            org.apache.mina.*;-split-package:=merge-last
+                            org.apache.mina.*;-split-package:=merge-last,
+                            org.apache.commons.lang.*;-split-package:=merge-last
                         </Export-Package>
                         <Import-Package>
                             org.slf4j.*;version="1.6.1",

--- a/modules/specs/amqp0-9-1.stripped.xml
+++ b/modules/specs/amqp0-9-1.stripped.xml
@@ -577,5 +577,15 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <chassis name="client" implement="MUST"/>
       <field name="xa-result" type="short"/>
     </method>
+
+    <method name="recover" synchronous="1" index="80">
+      <chassis name="server" implement="MUST"/>
+      <response name="recover-ok"/>
+    </method>
+
+    <method name="recover-ok" synchronous="1" index="81">
+      <chassis name="client" implement="MUST"/>
+      <field name="in-doubt" type="longstr"/>
+    </method>
   </class>
 </amqp>


### PR DESCRIPTION
The dtx.recover frame is used to query the broker node on distributed transaction in prepared state.