### PR TITLE
MB-1815 issue fixed.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPLocalSubscription.java
@@ -137,6 +137,11 @@ public class AMQPLocalSubscription implements OutboundSubscription {
         return subscribeTime;
     }
 
+    @Override
+    public String getProtocolQueueName() {
+        return amqpSubscription.getQueue().getName();
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscription.java
@@ -180,6 +180,15 @@ public class AndesSubscription {
     }
 
     /**
+     * Get protocol queue name
+     *
+     * @return queue name
+     */
+    public String getProtocolQueue() {
+        return subscriberConnection.getProtocolQueueName();
+    }
+
+    /**
      * Get protocol of the subscriber
      *
      * @return protocol of the connection

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/NullSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/NullSubscription.java
@@ -69,4 +69,10 @@ public class NullSubscription implements OutboundSubscription {
         return 0;
     }
 
+    @Override
+    public String getProtocolQueueName() {
+        log.warn("NullSubscription  getProtocolQueueName() method invoked");
+        return null;
+    }
+
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/OutboundSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/OutboundSubscription.java
@@ -78,4 +78,10 @@ public interface OutboundSubscription {
      */
     long getSubscribeTime();
 
+    /**
+     * Get name of the protocol queue
+     *
+     * @return name of the queue set by protocol
+     */
+    String getProtocolQueueName();
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/SubscriberConnection.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/SubscriberConnection.java
@@ -144,6 +144,15 @@ public class SubscriberConnection {
     }
 
     /**
+     * Get name of the protocol queue
+     *
+     * @return name of the queue set by protocol
+     */
+    public String getProtocolQueueName() {
+        return outboundSubscription.getProtocolQueueName();
+    }
+
+    /**
      * Forcefully disconnects protocol subscriber connection from server. This is initiated by a server admin using the
      * management console.
      *

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
@@ -235,6 +235,11 @@ public class MQTTLocalSubscription implements OutboundSubscription {
         return 0;
     }
 
+    @Override
+    public String getProtocolQueueName() {
+        return wildcardDestination;
+    }
+
     //TODO: decide how to call this
     public void ackReceived(long messageID) {
         // Remove if received acknowledgment message id contains in retained message list.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/SubscriptionManagementInformationMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/SubscriptionManagementInformationMBean.java
@@ -336,7 +336,8 @@ public class SubscriptionManagementInformationMBean extends AMQManagedObject imp
         subscriptionForUI.append(SEPARATOR);
         subscriptionForUI.append(subscription.getStorageQueue().getMessageRouter().getName());
         subscriptionForUI.append(SEPARATOR);
-        subscriptionForUI.append(subscription.getStorageQueue().getName());
+        subscriptionForUI.append(subscription.isDurable() ? subscription.getStorageQueue().getName()
+                : subscription.getProtocolQueue());
         subscriptionForUI.append(SEPARATOR);
         subscriptionForUI.append(subscription.isDurable());
         subscriptionForUI.append(SEPARATOR);


### PR DESCRIPTION
Non durable topic subscriber connection closed through subscription list page. The subscriber connection closed without issue. But topic couldn't delete in the topic list page due to registry resource not getting cleared. The issue was user subject not passed to the authorization when closing the connection. This was fixed by changing the close connection and delete registry entry as two different calls. 

Public JIRA - https://wso2.org/jira/browse/MB-1815