### PR TITLE
removed souts in andes client code.

### DIFF
--- a/modules/andes-core/client/example/src/main/java/org/wso2/andes/example/publisher/MonitorPublisher.java
+++ b/modules/andes-core/client/example/src/main/java/org/wso2/andes/example/publisher/MonitorPublisher.java
@@ -66,7 +66,6 @@ public class MonitorPublisher extends Publisher
         {
             //Have to assume our commit failed but do not rollback here as channel closed
             _log.error("JMSException", e);
-            e.printStackTrace();
             throw new UndeliveredMessageException("Cannot deliver immediate message", e);
         }
 
@@ -95,7 +94,6 @@ public class MonitorPublisher extends Publisher
         {
             //Have to assume our commit failed but do not rollback here as channel closed
             _log.error("JMSException", e);
-            e.printStackTrace();
             throw new UndeliveredMessageException("Cannot deliver immediate message", e);
         }
 

--- a/modules/andes-core/client/example/src/main/java/org/wso2/andes/example/publisher/Publisher.java
+++ b/modules/andes-core/client/example/src/main/java/org/wso2/andes/example/publisher/Publisher.java
@@ -91,7 +91,6 @@ public class Publisher
         }
         catch (Exception e)
         {
-            e.printStackTrace();
             _log.error("Exception", e);
         }
     }
@@ -140,7 +139,6 @@ public class Publisher
             {
                 _session.rollback();
                 _log.error("JMSException", e);
-                e.printStackTrace();
                 return false;
             }
             catch (JMSException j)

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionFactory.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionFactory.java
@@ -20,6 +20,8 @@
  */
 package org.wso2.andes.client;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wso2.andes.configuration.ClientProperties;
 import org.wso2.andes.jms.Connection;
 import org.wso2.andes.jms.ConnectionURL;
@@ -69,6 +71,8 @@ public class AMQConnectionFactory implements ConnectionFactory, QueueConnectionF
     private SSLConfiguration _sslConfig;
 
     private ThreadLocal<Boolean> removeBURL = new ThreadLocal<>();
+
+    private static final Logger log = LoggerFactory.getLogger(AMQConnectionFactory.class);
 
     public AMQConnectionFactory()
     {
@@ -356,7 +360,7 @@ public class AMQConnectionFactory implements ConnectionFactory, QueueConnectionF
             JMSException jmse = new JMSException("Error creating connection: " + e.getMessage());
             jmse.setLinkedException(e);
             jmse.initCause(e);
-            e.printStackTrace();
+            log.error("Error while creating connection", e);
             throw jmse;
         }
 

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/XAResource_0_10.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/XAResource_0_10.java
@@ -478,7 +478,7 @@ public class XAResource_0_10 implements XAResource
                 }
                 catch (XAException e)
                 {
-                    e.printStackTrace();
+                    _logger.error("XA Error ",e);
                     throw e;
                 }
             case ILLEGAL_STATE:

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/url/URLParser_0_10.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/url/URLParser_0_10.java
@@ -21,6 +21,8 @@ import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wso2.andes.client.AMQBrokerDetails;
 import org.wso2.andes.jms.BrokerDetails;
 
@@ -93,6 +95,7 @@ public class URLParser_0_10
     private String _currentPropName;
     private boolean _endOfURL = false;
     private URLParserState _currentParserState;
+    private static final Logger log = LoggerFactory.getLogger(URLParser_0_10.class);
 
     public URLParser_0_10(String url) throws MalformedURLException
     {
@@ -417,7 +420,7 @@ public class URLParser_0_10
         }
         catch (Exception e)
         {
-            e.printStackTrace();
+            log.error("Error while parsing url", e);
         }
     }
 }


### PR DESCRIPTION
There were inherited from Qpid's forked codebase. 