### PR TITLE
[MB-1703] added new message status NO_MATCHING_CONSUMER

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
@@ -124,6 +124,7 @@ public class FlowControlledQueueMessageDeliveryImpl implements MessageDeliverySt
 
                     //if no subscriber has a matching selector, route message to DLC queue
                     if (!subscriberWithMatchingSelectorFound) {
+                        message.addMessageStatus(MessageStatus.NO_MATCHING_CONSUMER);
                         Andes.getInstance().moveMessageToDeadLetterChannel(message, message.getDestination());
                         iterator.remove();
                     } else {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
@@ -58,24 +58,29 @@ public enum MessageStatus {
     EXPIRED(6),
 
     /**
+     * Message is discarded as no valid subscriber to send
+     */
+    NO_MATCHING_CONSUMER(7),
+
+    /**
      * Message is moved to the DLC queue
      */
-    DLC_MESSAGE(7),
+    DLC_MESSAGE(8),
 
     /**
      * Message has been cleared from delivery due to a queue purge event.
      */
-    PURGED(8),
+    PURGED(9),
 
     /**
      * Message is deleted from the store
      */
-    DELETED(9),
+    DELETED(10),
 
     /**
      * Slot of the message is returned back to the coordinator, causing message to remove from memory
      */
-    SLOT_RETURNED(10);
+    SLOT_RETURNED(11);
 
 
     private int code;
@@ -144,8 +149,11 @@ public enum MessageStatus {
         READ.next = EnumSet.of(BUFFERED, SLOT_RETURNED);
         READ.previous = EnumSet.complementOf(EnumSet.allOf(MessageStatus.class));
 
-        BUFFERED.next = EnumSet.of(SCHEDULED_TO_SEND, SLOT_RETURNED);
+        BUFFERED.next = EnumSet.of(SCHEDULED_TO_SEND, NO_MATCHING_CONSUMER, SLOT_RETURNED);
         BUFFERED.previous = EnumSet.of(READ);
+
+        NO_MATCHING_CONSUMER.next = EnumSet.of(DLC_MESSAGE);
+        NO_MATCHING_CONSUMER.previous = EnumSet.of(BUFFERED);
 
         SCHEDULED_TO_SEND.next = EnumSet.of(EXPIRED, ACKED_BY_ALL, BUFFERED, DLC_MESSAGE, SLOT_RETURNED);
         SCHEDULED_TO_SEND.previous = EnumSet.of(BUFFERED);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRejectMethodHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRejectMethodHandler.java
@@ -127,7 +127,6 @@ public class BasicRejectMethodHandler implements StateAwareMethodListener<BasicR
             }
             else
             {
-                _logger.warn("Dropping message as requeue not required and there is no dead letter queue");
                 try {
                     DeliverableAndesMetadata andesMetadata = AndesUtils.lookupDeliveredMessage(message.getMessage()
                             .getMessageNumber(), channel.getId());
@@ -135,7 +134,8 @@ public class BasicRejectMethodHandler implements StateAwareMethodListener<BasicR
                             .getQueue()
                             .getName());
                 } catch (AndesException e) {
-                    _logger.error("Error while moving message to DLC" , e);
+                    _logger.error("Error while moving message to DLC message Id = "
+                            + message.getMessage().getMessageNumber() , e);
                     throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error while moving message to DLC", e);
                 }
             }


### PR DESCRIPTION
Scenario: When there is no subscriber with a matching selector if it is a queue message we place in on DLC. 

BUFFERED >> SCHEDULED_TO_SEND >> DLC (invalid transition)

With the fix

BUFFERED >> NO_MATCHING_CONSUMER >> DLC
