### PR TITLE
[MB-1842] Added null for task id when taskholder becomes null.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/task/TaskProcessor.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/task/TaskProcessor.java
@@ -95,7 +95,7 @@ final class TaskProcessor implements Callable<Boolean> {
                     if(null != taskHolder) {
                         id = taskHolder.getId();
                     } else {
-                        id = "";
+                        id = "null";
                     }
                     taskExceptionHandler.handleException(throwable, id);
                 } finally {


### PR DESCRIPTION
There are instances that taskholder becomes null. At such a situation we set "null" to task id. 