### PR TITLE
[MB-1865] Added modifications to execute slot deleting tasks in parallel.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -434,7 +434,22 @@ public enum AndesConfiguration implements ConfigurationProperty {
     PERFORMANCE_TUNING_SUBMIT_SLOT_TIMER_PERIOD (
             "performanceTuning/slots/timerPeriod", "3000", Integer.class, PERFORMANCE_TUNING_SUBMIT_SLOT_TIMEOUT),
 
-    
+    /**
+     * Number of parallel threads to execute slot deletion task. Increasing this value will remove slots
+     * whose messages are read, delivered to consumers, acknowledged faster reducing heap memory used by server.
+     */
+    PERFORMANCE_TUNING_SLOT_DELETE_TASK_COUNT (
+            "performanceTuning/slots/deleteTaskCount", "5",  Integer.class),
+
+    /**
+     * Max number of pending message count to delete per Slot Deleting Task. This config is used to raise a WARN
+     * when pending scheduled number of slots exceeds this limit (indicate of an  issue that can lead to
+     * message accumulation on server.
+     */
+    PERFORMANCE_TUNING_MAX_PENDING_SLOTS_TO_DELETE (
+             "performanceTuning/slots/SlotDeleteQueueDepthWarningThreshold", "1000", Integer.class),
+
+
     /**
      * Maximum number of undelivered messages that can be in memory. Increasing this value could cause out of memory
      * scenarios, but performance will be improved

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
@@ -132,7 +132,11 @@ public class AndesKernelBoot {
         //Start slot deleting thread only if clustering is enabled.
         //Otherwise slots assignment will not happen
         if (AndesContext.getInstance().isClusteringEnabled()) {
-            SlotDeletionExecutor.getInstance().init();
+            int slotDeletingTaskCount = AndesConfigurationManager.readValue
+                    (AndesConfiguration.PERFORMANCE_TUNING_SLOT_DELETE_TASK_COUNT);
+            int maxNumberOfPendingSlotsToDelete = AndesConfigurationManager.readValue
+                    (AndesConfiguration.PERFORMANCE_TUNING_MAX_PENDING_SLOTS_TO_DELETE);
+            SlotDeletionExecutor.getInstance().init(slotDeletingTaskCount, maxNumberOfPendingSlotsToDelete);
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageHandler.java
@@ -33,7 +33,6 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -157,7 +156,7 @@ public class MessageHandler {
 
         //if no messages are in the slot range, delete the slot from coordinator. No use of it
         if (messagesReadFromStore.isEmpty()) {
-            SlotDeletionExecutor.getInstance().executeSlotDeletion(currentSlot);
+            SlotDeletionExecutor.getInstance().scheduleToDelete(currentSlot);
         }
 
         Slot trackedSlot = slotsRead.get(currentSlot.getId());

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/MessageDeliveryTask.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/MessageDeliveryTask.java
@@ -88,9 +88,10 @@ final class MessageDeliveryTask extends Task {
                 }
             } else {
                 if (log.isDebugEnabled()) {
-                    log.debug("Received slot for storage queue " + storageQueueName + " is: " +
-                                      currentSlot.getStartMessageId() + " - " + currentSlot.getEndMessageId() +
-                                      "Thread Id:" + Thread.currentThread().getId());
+                    log.debug("Received slot for storage queue " + storageQueueName
+                            + " is: " + currentSlot.getStartMessageId() + " - "
+                            + currentSlot.getEndMessageId() + "Thread Id:"
+                            + Thread.currentThread().getId());
                 }
 
                 storageQueue.loadMessagesForDelivery(currentSlot);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/Slot.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/Slot.java
@@ -397,10 +397,10 @@ public class Slot implements Serializable, Comparable<Slot> {
         if (messageCount == 0) {
 
             if (log.isDebugEnabled()) {
-                log.debug("Slot has no pending messages. Now re-checking slot for messages. " + this.toString());
+                log.debug("Slot has no pending messages. Scheduling to delete slot " + this.toString());
             }
             setSlotInactive();
-            SlotDeletionExecutor.getInstance().executeSlotDeletion(this);
+            SlotDeletionExecutor.getInstance().scheduleToDelete(this);
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotCoordinator.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotCoordinator.java
@@ -29,7 +29,7 @@ public interface SlotCoordinator {
      * @return New Slot
      * @throws ConnectionException
      */
-    public Slot getSlot(String queueName) throws ConnectionException;
+     Slot getSlot(String queueName) throws ConnectionException;
 
     /**
      * Record Slot's last message ID related to a particular queue
@@ -39,14 +39,14 @@ public interface SlotCoordinator {
      * @param localSafeZone
      * @throws ConnectionException
      */
-    public void updateMessageId(String queueName,long startMessageId, long endMessageId, long localSafeZone) throws ConnectionException;
+     void updateMessageId(String queueName,long startMessageId, long endMessageId, long localSafeZone) throws ConnectionException;
 
     /**
      *  Record safe zone to delete slots by node. This ping comes from nodes as messages are not
      *  published by them so that safe zone value keeps moving ahead.
      * @param currentSlotDeleteSafeZone Safe zone value of the node
      */
-    public void updateSlotDeletionSafeZone(long currentSlotDeleteSafeZone) throws ConnectionException;
+     void updateSlotDeletionSafeZone(long currentSlotDeleteSafeZone) throws ConnectionException;
 
     /**
      * Delete slot records from SlotManagerClusterMode
@@ -55,20 +55,20 @@ public interface SlotCoordinator {
      * @return Whether the slot deletion is successful or not
      * @throws ConnectionException
      */
-    public boolean deleteSlot(String queueName, Slot slot) throws ConnectionException;
+     boolean deleteSlot(String queueName, Slot slot) throws ConnectionException;
 
     /**
      * Re-assign slot to SlotManagerClusterMode when there are no subscribers
      * @param queueName Name of the queue
      * @throws ConnectionException
      */
-    public void reAssignSlotWhenNoSubscribers(String queueName) throws ConnectionException;
+     void reAssignSlotWhenNoSubscribers(String queueName) throws ConnectionException;
 
     /**
      * Delete all slot associations with a given queue. This is required to handle a queue purge event.
      * @param queueName Name of the queue
      */
-    public void clearAllActiveSlotRelationsToQueue(String queueName) throws ConnectionException;
+     void clearAllActiveSlotRelationsToQueue(String queueName) throws ConnectionException;
 
     /**
      * Add listener to coordinator connection listeners so that they can be notified when the conneciton is broken with

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeletingTask.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotDeletingTask.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.andes.kernel.slot;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.MessagingEngine;
+import org.wso2.andes.kernel.subscription.StorageQueue;
+
+import java.util.UUID;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Task executing the slot delete. It will poll on slots scheduled to delete and
+ * coordinate with slot coordinator in cluster to delete slots.
+ */
+public class SlotDeletingTask implements Runnable {
+
+    private static Log log = LogFactory.getLog(SlotDeletingTask.class);
+
+    /**
+     * Unique ID of the task
+     */
+    private UUID id;
+
+    /**
+     * Condition running the task.
+     */
+    private volatile boolean isLive = true;
+
+    /**
+     * Queue to keep slots to be removed. Reason to use a queue is
+     * if a slot could not be removed, it is definite later slots cannot be removed
+     * as well (because of safe-zone)
+     */
+    private LinkedBlockingDeque<Slot> slotsToDelete;
+
+    /**
+     * Maximum number of slots to keep scheduled for deletion before
+     * raising a WARN
+     */
+    private int maxNumberOfPendingSlots;
+
+    /**
+     * Specifically disable slot deleting task. At start up task
+     * is enabled by default. Once disabled cannot enable again.
+     */
+    void stop() {
+        isLive = false;
+    }
+
+    /**
+     * Create an instance of SlotDeletingTask
+     *
+     * @param maxNumberOfPendingSlots max number of pending slots to be deleted (used to raise a WARN)
+     */
+    public SlotDeletingTask(int maxNumberOfPendingSlots) {
+        this.id = UUID.randomUUID();
+        this.maxNumberOfPendingSlots = maxNumberOfPendingSlots;
+        this.slotsToDelete = new LinkedBlockingDeque<>();
+    }
+
+    @Override
+    public void run() {
+        while (isLive) {
+            try {
+                // Slot to attempt current deletion. This call will block if there is no slot
+                Slot slot = slotsToDelete.take();
+
+                if (log.isDebugEnabled()) {
+                    log.debug("SlotDeletingTask id= " + id + " trying to delete slot " + slot.toString());
+                }
+                // Check DB for any remaining messages. (JIRA FIX: MB-1612)
+                // If there are any remaining messages wait till overlapped slot delivers the messages
+                if (MessagingEngine.getInstance().getMessageCountForQueueInRange(
+                        slot.getStorageQueueName(), slot.getStartMessageId(), slot.getEndMessageId()) == 0) {
+                    // Invoke coordinator to delete slot
+                    boolean deleteSuccess = deleteSlotAtCoordinator(slot);
+                    if (!deleteSuccess) {
+                        // Delete attempt not success, therefore adding slot to the head of queue
+                        slotsToDelete.addFirst(slot);
+                        if (log.isDebugEnabled()) {
+                            log.debug("SlotDeletingTask id= " + id + " could not agree with "
+                                    + "coordinator to delete slot " + slot.toString());
+                        }
+                        //here try again after a second time delay (let coordinator update safe zone)
+                        //TODO: is there other good way to fix this? We need to delete in the rate we read slots
+                        TimeUnit.SECONDS.sleep(1);
+                    } else {
+                        StorageQueue storageQueue = slot.getStorageQueue();
+                        storageQueue.deleteSlot(slot);
+                        if (log.isDebugEnabled()) {
+                            log.debug("SlotDeletingTask id= " + id + " deleted slot " + slot.toString());
+                        }
+                    }
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("SlotDeletingTask id= " + id + " could not deleted slot "
+                                + slot.toString() + " as there are messages in range of slot");
+                    }
+                    slotsToDelete.put(slot); // Not deleted. Hence putting back to tail of queue
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("SlotDeletionTask was interrupted while trying to delete the slot.", e);
+            } catch (Throwable throwable) {
+                log.error("Unexpected error occurred while trying to delete the slot.", throwable);
+            }
+        }
+
+        log.info("SlotDeletingTask " + id + " has shutdown with " + slotsToDelete.size() + " slots to delete.");
+    }
+
+    /**
+     * Delete slot at coordinator and return delete status
+     *
+     * @param slot slot to be removed from cluster
+     * @return slot deletion status
+     */
+    private boolean deleteSlotAtCoordinator(Slot slot) {
+        boolean deleteSuccess = false;
+        try {
+            deleteSuccess = MessagingEngine.getInstance().getSlotCoordinator().deleteSlot
+                    (slot.getStorageQueueName(), slot);
+        } catch (ConnectionException e) {
+            log.error("Error while trying to delete the slot " + slot + " Thrift connection failed. " +
+                    "Rescheduling delete.", e);
+
+        }
+        return deleteSuccess;
+    }
+
+    /**
+     * Schedule a slot for deletion. This will continuously try to delete the slot
+     * until slot manager informs that the slot is successfully removed
+     *
+     * @param slot slot to be removed from cluster
+     */
+    public void scheduleToDelete(Slot slot) {
+        int currentNumberOfSlotsToDelete = slotsToDelete.size();
+        if (currentNumberOfSlotsToDelete > maxNumberOfPendingSlots) {
+            log.warn("Too many slots submitted to delete. Consider increasing <deleteTaskCount> "
+                    + "and <thriftClientPoolSize> parameters. Current submit value = "
+                    + currentNumberOfSlotsToDelete + " safe zone value = "
+                    + SlotMessageCounter.getInstance().getCurrentNodeSafeZoneId());
+        }
+        slotsToDelete.add(slot);
+
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotManagerClusterMode.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/slot/SlotManagerClusterMode.java
@@ -388,7 +388,7 @@ public class SlotManagerClusterMode extends AbstractSlotManager {
                                 nodeId + " as member left");
                     }
                 } else { // Delete empty slots
-                    SlotDeletionExecutor.getInstance().executeSlotDeletion(slotToBeReAssigned);
+                    SlotDeletionExecutor.getInstance().scheduleToDelete(slotToBeReAssigned);
                 }
             }
             slotAgent.deleteOverlappedSlots(nodeId);


### PR DESCRIPTION
WSO2 MB reads slots, deliver messages and remove them from memory if all messages are ACKED of that slot. This deletion happens with a cluster-wide agreement (safe zone value calculation).
We have seen issues slots are getting accumulated in long running due to various reasons.
1. A few messages are not always ACKED. So slot remains
2. Slot deletion task gets inactive? 
3. Safe zone value calculation is jumbled
nodes are not time synced
heat beat stops
So it is better to know if slots are getting accumulated ahead before situation get worse. Thus need a WARN level log that prints every now and again.
Also need to make several slot deleting tasks to execute slot delete tasks in parallel (using thrift connection pool) because slot read happens in parallel (slot delivery worker threads > 1) and delivery happens in parallel. Acknowledge and slot removal should also happen in parallel to stop message accumulation in long run.