### PR TITLE
Add a hash set to keep track of stored Xids in DtxRegistry

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
@@ -298,7 +298,6 @@ public class QpidAndesBridge {
         part.setData(chunkData);
         part.setMessageID(messageID);
         part.setOffSet(offsetInMessage);
-        part.setDataLength(chunkData.length);
 
         return part;
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessagePart.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessagePart.java
@@ -22,10 +22,9 @@ package org.wso2.andes.kernel;
  * This class defines the content of an Andes message.
  */
 public class AndesMessagePart {
-    long messageID;
-    int offSet = 0;
+    private long messageID;
+    private int offSet = 0;
     private byte[] data;
-    private int dataLength;
 
     public int getOffset() {
         return offSet;
@@ -52,11 +51,7 @@ public class AndesMessagePart {
     }
 
     public int getDataLength() {
-        return dataLength;
-    }
-
-    public void setDataLength(int dataLength) {
-        this.dataLength = dataLength;
+        return data.length;
     }
 
     /**
@@ -69,7 +64,6 @@ public class AndesMessagePart {
         clone.messageID = messageId;
         clone.offSet = offSet;
         clone.data = data;
-        clone.dataLength = dataLength;
         return clone;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DtxStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DtxStore.java
@@ -18,11 +18,13 @@
 
 package org.wso2.andes.kernel;
 
+import org.wso2.andes.dtx.XidImpl;
 import org.wso2.andes.kernel.dtx.AndesPreparedMessageMetadata;
 import org.wso2.andes.kernel.dtx.DtxBranch;
 import org.wso2.andes.store.HealthAwareStore;
 
 import java.util.List;
+import java.util.Set;
 import javax.transaction.xa.Xid;
 
 /**
@@ -68,4 +70,13 @@ public interface DtxStore extends HealthAwareStore {
      * @throws AndesException throws {@link AndesException} on store exceptions
      */
     long recoverBranchData(DtxBranch branch, String nodeId) throws AndesException;
+
+    /**
+     * Retrieve already prepared xid set for the given broker node.
+     *
+     * @param nodeId Node id of the broker
+     * @return Set of {@link XidImpl}
+     * @throws AndesException throws {@link AndesException} on store related error
+     */
+    Set<XidImpl> getStoredXidSet(String nodeId) throws AndesException;
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/compression/LZ4CompressionHelper.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/compression/LZ4CompressionHelper.java
@@ -194,7 +194,6 @@ public class LZ4CompressionHelper {
         AndesMessagePart messagePart = new AndesMessagePart();
         messagePart.setMessageID(messageID);
         // Ultimately we write the full content as a chunk here
-        messagePart.setDataLength(data.length);
         messagePart.setOffSet(0);
         messagePart.setData(data);
 
@@ -230,7 +229,6 @@ public class LZ4CompressionHelper {
 
             AndesMessagePart messagePart = new AndesMessagePart();
             messagePart.setMessageID(messageID);
-            messagePart.setDataLength(copy.length);
             messagePart.setOffSet(srcOffset);
             messagePart.setData(copy);
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/ContentChunkHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/ContentChunkHandler.java
@@ -181,7 +181,6 @@ public class ContentChunkHandler implements EventHandler<InboundEventContainer> 
 
                 AndesMessagePart newChunk = new AndesMessagePart();
                 newChunk.setMessageID(chunk.getMessageID());
-                newChunk.setDataLength(data.length); // ultimately we write a max chunk here
                 newChunk.setOffSet(written);
                 newChunk.setData(data);
                 chunkList.add(newChunk);
@@ -223,7 +222,6 @@ public class ContentChunkHandler implements EventHandler<InboundEventContainer> 
                     AndesMessagePart newChunk = new AndesMessagePart();
                     newChunk.setMessageID(chunk.getMessageID());
                     newChunk.setOffSet(written);
-                    newChunk.setDataLength(data.length);
                     newChunk.setData(data);
                     chunkList.add(newChunk);
                     written = written + data.length;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/utils/MQTTUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/utils/MQTTUtils.java
@@ -79,7 +79,6 @@ public class MQTTUtils {
         messageBody.setOffSet(0); //Here we set the offset to 0, but it will be a problem when large messages are sent
         messageBody.setData(message);
         messageBody.setMessageID(messagID);
-        messageBody.setDataLength(message.length);
         return messageBody;
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingDtxStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingDtxStore.java
@@ -18,6 +18,7 @@
 
 package org.wso2.andes.store;
 
+import org.wso2.andes.dtx.XidImpl;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesMessage;
 import org.wso2.andes.kernel.AndesMessageMetadata;
@@ -26,6 +27,7 @@ import org.wso2.andes.kernel.dtx.AndesPreparedMessageMetadata;
 import org.wso2.andes.kernel.dtx.DtxBranch;
 
 import java.util.List;
+import java.util.Set;
 import javax.transaction.xa.Xid;
 
 /**
@@ -86,6 +88,16 @@ public class FailureObservingDtxStore extends FailureObservingStore<DtxStore> im
     public long recoverBranchData(DtxBranch branch, String nodeId) throws AndesException {
         try {
             return wrappedInstance.recoverBranchData(branch, nodeId);
+        } catch (AndesStoreUnavailableException e) {
+            notifyFailures(e);
+            throw new AndesException(e);
+        }
+    }
+
+    @Override
+    public Set<XidImpl> getStoredXidSet(String nodeId) throws AndesException {
+        try {
+            return wrappedInstance.getStoredXidSet(nodeId);
         } catch (AndesStoreUnavailableException e) {
             notifyFailures(e);
             throw new AndesException(e);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -1089,6 +1089,11 @@ public class RDBMSConstants {
                     + " AND " + DTX_GLOBAL_ID + "=?"
                     + " AND " + NODE_ID + "=?";
 
+
+    static final String PS_SELECT_PREPARED_XID =
+            "SELECT " + DTX_FORMAT + "," + DTX_BRANCH_ID + "," + DTX_GLOBAL_ID
+                    + " FROM " + DTX_ENTRY_TABLE;
+
     public static final String PS_SELECT_DTX_DEQUEUE_METADATA =
             "SELECT " + MESSAGE_ID + "," + QUEUE_NAME + "," + METADATA
                     + " FROM " + DTX_DEQUEUE_RECORD_TABLE
@@ -1261,4 +1266,5 @@ public class RDBMSConstants {
      */
     private RDBMSConstants() {
     }
+
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSMessageStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSMessageStoreImpl.java
@@ -353,7 +353,6 @@ public class RDBMSMessageStoreImpl implements MessageStore {
         AndesMessagePart messagePart = new AndesMessagePart();
         messagePart.setMessageID(messageId);
         messagePart.setData(b);
-        messagePart.setDataLength(b.length);
         messagePart.setOffSet(offsetValue);
 
         return messagePart;
@@ -2290,7 +2289,6 @@ public class RDBMSMessageStoreImpl implements MessageStore {
 
                 messagePart.setMessageID(messageID);
                 messagePart.setData(b);
-                messagePart.setDataLength(b.length);
                 messagePart.setOffSet(offset);
                 contentParts.put(offset, messagePart);
             }

--- a/modules/andes-core/broker/src/test/java/org/wso2/andes/kernel/disruptor/inbound/ContentChunkHandlerTest.java
+++ b/modules/andes-core/broker/src/test/java/org/wso2/andes/kernel/disruptor/inbound/ContentChunkHandlerTest.java
@@ -88,7 +88,6 @@ public class ContentChunkHandlerTest {
 
             part.setData(contentPart.getBytes());
             part.setOffSet(offset);
-            part.setDataLength(originalChunkSize);
             originalChunks.add(part);
             offset = offset + originalChunkSize;
         }

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/dtx/XidImpl.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/dtx/XidImpl.java
@@ -173,61 +173,6 @@ public class XidImpl implements Xid, Serializable {
     }
 
     //--- Object operations
-
-    /**
-     * Indicates whether some other Xid is "equal to" this one.
-     * <p> Two Xids are equal if and only if their three elementary parts are equal
-     *
-     * @param o the object to compare this <code>XidImpl</code> against.
-     * @return true if the <code>XidImpl</code> are equal, false otherwise.
-     */
-    public boolean equals(Object o)
-    {
-        if (this == o)
-        {
-            return true;
-        }
-        if (o instanceof XidImpl)
-        {
-            XidImpl other = (XidImpl) o;
-            if (_formatID == other.getFormatId())
-            {
-                if (_branchQualifier.length == other.getBranchQualifier().length)
-                {
-                    for (int i = 0; i < _branchQualifier.length; i++)
-                    {
-                        if (_branchQualifier[i] != other.getBranchQualifier()[i])
-                        {
-                            return false;
-                        }
-                    }
-                    if (_globalTransactionID.length == other.getGlobalTransactionId().length)
-                    {
-                        for (int i = 0; i < _globalTransactionID.length; i++)
-                        {
-                            if (_globalTransactionID[i] != other.getGlobalTransactionId()[i])
-                            {
-                                return false;
-                            }
-                        }
-                        // everithing is equal
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode()
-    {
-        int result = _branchQualifier != null ? Arrays.hashCode(_branchQualifier) : 0;
-        result = 31 * result + _formatID;
-        result = 31 * result + (_globalTransactionID != null ? Arrays.hashCode(_globalTransactionID) : 0);
-        return result;
-    }
-
     //-- Static helper method
     /**
      * Convert an Xid into the AMQP String format.
@@ -263,5 +208,40 @@ public class XidImpl implements Xid, Serializable {
 
         return getClass().getSimpleName() + "(" + getFormatId() + "|" + Arrays.toString(getGlobalTransactionId())
                 + "|" + Arrays.toString(getBranchQualifier()) + ")";
+    }
+
+    /**
+     * Indicates whether some other Xid is "equal to" this one.
+     * <p> Two Xids are equal if and only if their three elementary parts are equal
+     *
+     * @param o the object to compare this <code>XidImpl</code> against.
+     * @return true if the <code>XidImpl</code> are equal, false otherwise.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Xid that = (Xid) o;
+
+        return Arrays.equals(this.getBranchQualifier(), that.getBranchQualifier())
+                && Arrays.equals(this.getGlobalTransactionId(), that.getGlobalTransactionId());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 0;
+        for (int i = 0; i < this.getGlobalTransactionId().length; i++) {
+            result = 31 * result + (int) this.getGlobalTransactionId()[i];
+        }
+        for (int i = 0; i < this.getBranchQualifier().length; i++) {
+            result = 31 * result + (int) this.getBranchQualifier()[i];
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
- DtxRegistry will populate an internal hash set with stored xids in the database that are not in memory. Call to #getBranch will check the hash set before querying the database for the branch. To improve the performance of Dtx.start by avoiding an extra DB call for a nonexisting branch.

- Remove dataLength property from AndesMessagePart since the value can be derived using the data.