### PR TITLE
MB-1892 issue fixed.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscription.java
@@ -384,6 +384,18 @@ public class AndesSubscription {
     }
 
     /**
+     * Check subscription is belong to local node
+     *
+     * @return true/false based on the connection
+     */
+    public boolean isLocal() {
+        String myNodeID = ClusterResourceHolder.getInstance().getClusterManager().getMyNodeID();
+        String connectedNode = ((null == getSubscriberConnection()) ? "" : getSubscriberConnection()
+                .getConnectedNode());
+        return connectedNode.equals(myNodeID);
+    }
+
+    /**
      * Encode the subscription to a string representation
      *
      * @return String of encoded subscription

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/NullSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/NullSubscription.java
@@ -35,44 +35,38 @@ public class NullSubscription implements OutboundSubscription {
 
     @Override
     public void forcefullyDisconnect() throws AndesException {
-        log.warn("NullSubscription forcefullyDisconnect() method invoked");
+        throw new UnsupportedOperationException("Invalid operation for forcefully disconnect.");
     }
 
     @Override
     public boolean isMessageAcceptedBySelector(AndesMessageMetadata messageMetadata) throws AndesException {
-        log.warn("NullSubscription  isMessageAcceptedBySelector() method invoked");
-        return false;
+        throw new UnsupportedOperationException("Invalid operation for check a message is accepted by the selector.");
     }
 
     @Override
     public boolean sendMessageToSubscriber(ProtocolMessage messageMetadata, AndesContent content) throws
             AndesException {
-        log.warn("NullSubscription  sendMessageToSubscriber() method invoked");
-        return false;
+        throw new UnsupportedOperationException("Invalid operation for send messages to the subscriber.");
     }
 
     @Override
     public boolean isOutboundConnectionLive() {
-        log.warn("NullSubscription  isOutboundConnectionLive() method invoked");
-        return false;
+        throw new UnsupportedOperationException("Invalid operation for check outbound connection is live.");
     }
 
     @Override
     public UUID getChannelID() {
-        log.warn("NullSubscription  getChannelID() method invoked");
-        return null;
+        throw new UnsupportedOperationException("Invalid operation for retrieve channel id.");
     }
 
     @Override
     public long getSubscribeTime() {
-        log.warn("NullSubscription  getSubscribeTime() method invoked");
-        return 0;
+        throw new UnsupportedOperationException("Invalid operation for retrieve subscribes time.");
     }
 
     @Override
     public String getProtocolQueueName() {
-        log.warn("NullSubscription  getProtocolQueueName() method invoked");
-        return null;
+        throw new UnsupportedOperationException("Invalid operation for retrieve protocol name.");
     }
 
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/SubscriptionManagementInformationMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/SubscriptionManagementInformationMBean.java
@@ -336,8 +336,13 @@ public class SubscriptionManagementInformationMBean extends AMQManagedObject imp
         subscriptionForUI.append(SEPARATOR);
         subscriptionForUI.append(subscription.getStorageQueue().getMessageRouter().getName());
         subscriptionForUI.append(SEPARATOR);
-        subscriptionForUI.append(subscription.isDurable() ? subscription.getStorageQueue().getName()
-                : subscription.getProtocolQueue());
+        if (subscription.isLocal()) {
+            subscriptionForUI.append(subscription.isDurable() ? subscription.getStorageQueue().getName()
+                    : subscription.getProtocolQueue());
+        } else {
+            subscriptionForUI.append(subscription.isDurable() ? subscription.getStorageQueue().getName()
+                    : NOT_AVAILABLE);
+        }
         subscriptionForUI.append(SEPARATOR);
         subscriptionForUI.append(subscription.isDurable());
         subscriptionForUI.append(SEPARATOR);


### PR DESCRIPTION
Null subscription assigned if the subscriber connection is not a local. But when rendering nondurable subscriptions, we are fetching all subscriptions. Therefore, the condition added to check whether the subscription is local or not and based on that protocol queue name will retrieve. Also, NullSubscription class modified to return UnsupportedOperationException.

NullPointerException didn't occur following the given steps.

Public JIRA - https://wso2.org/jira/browse/MB-1892