### PR TITLE
Made queue names case insensitive

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
@@ -470,7 +470,7 @@ public class QpidAndesBridge {
         try {
             List<StorageQueue> queues = AndesContext.getInstance().getStorageQueueRegistry().getAllStorageQueues();
             for (StorageQueue storageQueue : queues) {
-                if (storageQueue.getName().equalsIgnoreCase(queue.getName())) {
+                if (storageQueue.getName().equals(queue.getName())) {
                     throw new AMQException("Cannot create already existing queue: " + queue.getName());
                 }
             }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesConstants.java
@@ -28,7 +28,7 @@ public class AndesConstants {
     /**
      * The default Dead Letter Channel queue name suffix
      */
-    public static final String DEAD_LETTER_QUEUE_SUFFIX = "DeadLetterChannel";
+    public static final String DEAD_LETTER_QUEUE_SUFFIX = "deadletterchannel";
 
     /**
      * The separator to separate a domain name and the queue name in a tenant mode.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicConsumeMethodHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicConsumeMethodHandler.java
@@ -69,7 +69,12 @@ public class BasicConsumeMethodHandler implements StateAwareMethodListener<Basic
                               " args:" + body.getArguments());
             }
 
-            AMQQueue queue = body.getQueue() == null ? channel.getDefaultQueue() : vHost.getQueueRegistry().getQueue(body.getQueue().intern());
+            AMQQueue queue;
+            if (null == body.getQueue()) {
+                queue = channel.getDefaultQueue();
+            } else {
+                queue = vHost.getQueueRegistry().getQueue(AMQShortString.toLowerCase(body.getQueue().intern()));
+            }
 
             if (queue == null)
             {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/ExchangeBoundHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/ExchangeBoundHandler.java
@@ -74,8 +74,8 @@ public class ExchangeBoundHandler implements StateAwareMethodListener<ExchangeBo
 
 
         AMQShortString exchangeName = body.getExchange();
-        AMQShortString queueName = body.getQueue();
-        AMQShortString routingKey = body.getRoutingKey();
+        AMQShortString queueName = AMQShortString.toLowerCase(body.getQueue());
+        AMQShortString routingKey = AMQShortString.toLowerCase(body.getRoutingKey());
         if (exchangeName == null)
         {
             throw new AMQException("Exchange exchange must not be null");
@@ -141,7 +141,7 @@ public class ExchangeBoundHandler implements StateAwareMethodListener<ExchangeBo
             }
             else
             {
-                if (exchange.isBound(body.getRoutingKey(), queue))
+                if (exchange.isBound(routingKey, queue))
                 {
 
                     response = methodRegistry.createExchangeBoundOkBody(OK,	// replyCode
@@ -158,7 +158,7 @@ public class ExchangeBoundHandler implements StateAwareMethodListener<ExchangeBo
         }
         else
         {
-            if (exchange.isBound(body.getRoutingKey()))
+            if (exchange.isBound(routingKey))
             {
 
                 response = methodRegistry.createExchangeBoundOkBody(OK,	// replyCode

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueBindHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueBindHandler.java
@@ -83,17 +83,18 @@ public class QueueBindHandler implements StateAwareMethodListener<QueueBindBody>
 
             if (body.getRoutingKey() == null)
             {
-                routingKey = queue.getNameShortString();
+                routingKey = AMQShortString.toLowerCase(queue.getNameShortString());
             }
             else
             {
-                routingKey = body.getRoutingKey().intern();
+                routingKey = AMQShortString.toLowerCase(body.getRoutingKey().intern());
             }
         }
         else
         {
-            queue = queueRegistry.getQueue(body.getQueue());
-            routingKey = body.getRoutingKey() == null ? AMQShortString.EMPTY_STRING : body.getRoutingKey().intern();
+            queue = queueRegistry.getQueue(AMQShortString.toLowerCase(body.getQueue()));
+            routingKey = AMQShortString.toLowerCase(body.getRoutingKey() == null ? AMQShortString.EMPTY_STRING : body
+                    .getRoutingKey().intern());
         }
 
         if (queue == null)

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeclareHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeclareHandler.java
@@ -71,9 +71,9 @@ public class QueueDeclareHandler implements StateAwareMethodListener<QueueDeclar
 
         // if we aren't given a queue name, we create one which we return to the client
         if ((null == body.getQueue()) || (0 == body.getQueue().length())) {
-            queueName = createName();
+            queueName = AMQShortString.toLowerCase(createName());
         } else {
-            queueName = body.getQueue().intern();
+            queueName = AMQShortString.toLowerCase(body.getQueue().intern());
         }
         AMQQueue queue;
         try {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeleteHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueDeleteHandler.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.andes.AMQException;
 import org.wso2.andes.amqp.AMQPUtils;
 import org.wso2.andes.amqp.QpidAndesBridge;
+import org.wso2.andes.framing.AMQShortString;
 import org.wso2.andes.framing.MethodRegistry;
 import org.wso2.andes.framing.QueueDeleteBody;
 import org.wso2.andes.framing.QueueDeleteOkBody;
@@ -87,7 +88,7 @@ public class QueueDeleteHandler implements StateAwareMethodListener<QueueDeleteB
         }
         else
         {
-            queue = queueRegistry.getQueue(body.getQueue());
+            queue = queueRegistry.getQueue(AMQShortString.toLowerCase(body.getQueue()));
         }
         if (!(DLCQueueUtils.isDeadLetterQueue(queue.getName()))) {
             if (null == queue) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueuePurgeHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueuePurgeHandler.java
@@ -19,6 +19,7 @@
 package org.wso2.andes.server.handler;
 
 import org.wso2.andes.AMQException;
+import org.wso2.andes.framing.AMQShortString;
 import org.wso2.andes.framing.QueuePurgeBody;
 import org.wso2.andes.framing.MethodRegistry;
 import org.wso2.andes.framing.AMQMethodBody;
@@ -84,7 +85,7 @@ public class QueuePurgeHandler implements StateAwareMethodListener<QueuePurgeBod
         }
         else
         {
-            queue = queueRegistry.getQueue(body.getQueue());
+            queue = queueRegistry.getQueue(AMQShortString.toLowerCase(body.getQueue()));
         }
 
         if(queue == null)

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueUnbindHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueUnbindHandler.java
@@ -78,13 +78,14 @@ public class QueueUnbindHandler implements StateAwareMethodListener<QueueUnbindB
                 throw body.getChannelException(AMQConstant.NOT_FOUND, "No default queue defined on channel and queue was null");
             }
 
-            routingKey = body.getRoutingKey() == null ? null : body.getRoutingKey().intern();
-
+        } else {
+            queue = queueRegistry.getQueue(AMQShortString.toLowerCase(body.getQueue()));
         }
-        else
-        {
-            queue = queueRegistry.getQueue(body.getQueue());
-            routingKey = body.getRoutingKey() == null ? null : body.getRoutingKey().intern();
+
+        if (null == body.getRoutingKey()) {
+            routingKey = null;
+        } else {
+            routingKey = AMQShortString.toLowerCase(body.getRoutingKey().intern());
         }
 
         if (queue == null)

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/AMQQueueFactory.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/AMQQueueFactory.java
@@ -238,7 +238,7 @@ public class AMQQueueFactory
 
     public static AMQQueue createAMQQueueImpl(QueueConfiguration config, VirtualHost host) throws AMQException
     {
-        String queueName = config.getName();
+        String queueName = config.getName().toLowerCase();
 
         boolean durable = config.getDurable();
         boolean autodelete = config.getAutoDelete();

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/framing/AMQShortString.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/framing/AMQShortString.java
@@ -787,4 +787,18 @@ public final class AMQShortString implements CharSequence, Comparable<AMQShortSt
         }
     }
 
+    /**
+     * Given any string, this method returns the lower case representation of that.
+     *
+     * @param stringToConvert the original string
+     * @return the lower case representation of the the given string
+     */
+    public static AMQShortString toLowerCase(AMQShortString stringToConvert) {
+        if (null != stringToConvert) {
+            return new AMQShortString(stringToConvert.asString().toLowerCase());
+        } else {
+            return null;
+        }
+    }
+
 }

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/framing/abstraction/MessagePublishInfoImpl.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/framing/abstraction/MessagePublishInfoImpl.java
@@ -39,7 +39,7 @@ public class MessagePublishInfoImpl implements MessagePublishInfo
         _exchange = exchange;
         _immediate = immediate;
         _mandatory = mandatory;
-        _routingKey = routingKey;
+        _routingKey = AMQShortString.toLowerCase(routingKey);
     }
 
     public AMQShortString getExchange()

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/framing/amqp_0_9/MethodConverter_0_9.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/framing/amqp_0_9/MethodConverter_0_9.java
@@ -80,7 +80,7 @@ public class MethodConverter_0_9 extends AbstractMethodConverter implements Prot
         final BasicPublishBody publishBody = ((BasicPublishBody) methodBody);
 
         final AMQShortString exchange = publishBody.getExchange();
-        final AMQShortString routingKey = publishBody.getRoutingKey();
+        final AMQShortString routingKey = AMQShortString.toLowerCase(publishBody.getRoutingKey());
 
         return new MessagePublishInfoImpl(exchange,
                                           publishBody.getImmediate(),

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/framing/amqp_0_91/MethodConverter_0_91.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/framing/amqp_0_91/MethodConverter_0_91.java
@@ -80,7 +80,7 @@ public class MethodConverter_0_91 extends AbstractMethodConverter implements Pro
         final BasicPublishBody publishBody = ((BasicPublishBody) methodBody);
 
         final AMQShortString exchange = publishBody.getExchange();
-        final AMQShortString routingKey = publishBody.getRoutingKey();
+        final AMQShortString routingKey = AMQShortString.toLowerCase(publishBody.getRoutingKey());
 
         return new MessagePublishInfoImpl(exchange,
                                           publishBody.getImmediate(),

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/framing/amqp_8_0/MethodConverter_8_0.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/framing/amqp_8_0/MethodConverter_8_0.java
@@ -90,7 +90,7 @@ public class MethodConverter_8_0 extends AbstractMethodConverter implements Prot
         final BasicPublishBody publishBody = ((BasicPublishBody) methodBody);
 
         final AMQShortString exchange = publishBody.getExchange();
-        final AMQShortString routingKey = publishBody.getRoutingKey();
+        final AMQShortString routingKey = AMQShortString.toLowerCase(publishBody.getRoutingKey());
 
         return new MessagePublishInfoImpl(exchange == null ? null : exchange.intern(),
                                           publishBody.getImmediate(),


### PR DESCRIPTION
Addresses the issue reported at https://wso2.org/jira/browse/MB-1902

Queue names are converted to the lower case before processing any further, so that no 2 queues from different cases are accepted into the core.

Queue names are turned to lower case when the admin services are called in https://github.com/wso2/carbon-business-messaging/pull/419

Test cases are modified in https://github.com/wso2/product-mb/pull/468