### PR TITLE
[MB-1893] Fixed state transition issue while deleting expired  messages

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
@@ -340,8 +340,9 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
      */
     public boolean isPurgedOrDeletedOrExpired() {
         MessageStatus currentStatus = getLatestState();
-        return currentStatus.equals(MessageStatus.PURGED) || currentStatus.equals(MessageStatus.DELETED)
-                || currentStatus.equals(MessageStatus.EXPIRED);
+        return currentStatus.equals(MessageStatus.PURGED)
+                || currentStatus.equals(MessageStatus.EXPIRED)
+                || currentStatus.equals(MessageStatus.DELETED);
     }
 
     /**
@@ -358,6 +359,14 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
      */
     public void markAsPurgedMessage() {
         addMessageStatus(MessageStatus.PURGED);
+    }
+
+    /**
+     * Mark message as prepared to be removed. Usually Andes kernel has asynchronous processes to remove messages.
+     * Once scheduled to be removed this state is set.
+     */
+    public void markAsPreparedToDelete() {
+        addMessageStatus(MessageStatus.PREPARED_TO_DELETE);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ExpiredMessageHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ExpiredMessageHandler.java
@@ -39,7 +39,7 @@ public class ExpiredMessageHandler extends DeliveryResponsibility {
      *
      * @param task deletion task
      */
-    public void setExpiryMessageDeletionTask(PreDeliveryExpiryMessageDeletionTask task) {
+    void setExpiryMessageDeletionTask(PreDeliveryExpiryMessageDeletionTask task) {
         this.preDeliveryExpiryMessageDeletionTask = task;
     }
 
@@ -60,7 +60,7 @@ public class ExpiredMessageHandler extends DeliveryResponsibility {
             // Since this message is not going to be delivered, no point in wait for ack.
             message.getSlot().decrementPendingMessageCount();
             // Add the expired messages to a list for a batch delete
-            preDeliveryExpiryMessageDeletionTask.addMessageIdToExpiredQueue(message.getMessageID());
+            preDeliveryExpiryMessageDeletionTask.addMessageIdToExpiredQueue(message);
             MessageTracer.trace(message, MessageTracer.EXPIRED_MESSAGE_DETECTED_AND_QUEUED);
             isOkayToProceed = false;
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
@@ -73,6 +73,11 @@ public enum MessageStatus {
     PURGED,
 
     /**
+     * Message is prepared to delete.
+     */
+    PREPARED_TO_DELETE,
+
+    /**
      * Message is deleted from the store
      */
     DELETED,
@@ -125,23 +130,28 @@ public enum MessageStatus {
         SCHEDULED_TO_SEND.next = EnumSet.of(EXPIRED, ACKED_BY_ALL, BUFFERED, DLC_MESSAGE, SLOT_RETURNED);
         SCHEDULED_TO_SEND.previous = EnumSet.of(BUFFERED);
 
-        ACKED_BY_ALL.next = EnumSet.of(DELETED, SLOT_RETURNED);
+        ACKED_BY_ALL.next = EnumSet.of(PREPARED_TO_DELETE, SLOT_RETURNED);
         ACKED_BY_ALL.previous = EnumSet.of(SCHEDULED_TO_SEND);
 
-        EXPIRED.next = EnumSet.of(DELETED, SLOT_RETURNED);
+        EXPIRED.next = EnumSet.of(PREPARED_TO_DELETE, SLOT_RETURNED);
         EXPIRED.previous = EnumSet.allOf(MessageStatus.class);
 
         DLC_MESSAGE.next = EnumSet.of(EXPIRED, BUFFERED, SLOT_REMOVED, SLOT_RETURNED);
         DLC_MESSAGE.previous = EnumSet.of(SCHEDULED_TO_SEND);
 
-        PURGED.next = EnumSet.of(DELETED, SLOT_RETURNED);
+        PURGED.next = EnumSet.of(PREPARED_TO_DELETE, SLOT_RETURNED);
         PURGED.previous = EnumSet.allOf(MessageStatus.class);
 
-        DELETED.next = EnumSet.of(SLOT_REMOVED, SLOT_RETURNED);
-        DELETED.previous = EnumSet.of(EXPIRED, DLC_MESSAGE, PURGED);
+        PREPARED_TO_DELETE.next = EnumSet.of(DELETED, SLOT_REMOVED);
+        PREPARED_TO_DELETE.previous = EnumSet.of(EXPIRED, DLC_MESSAGE, PURGED);
 
-        SLOT_REMOVED.next = EnumSet.complementOf(EnumSet.allOf(MessageStatus.class));
-        SLOT_REMOVED.previous = EnumSet.of(DELETED);
+        DELETED.next = EnumSet.of(SLOT_REMOVED, SLOT_RETURNED);
+        DELETED.previous = EnumSet.of(PREPARED_TO_DELETE, SLOT_REMOVED);
+
+        //TODO: ideally this should be EnumSet.complementOf(EnumSet.allOf(MessageStatus.class)) but we need to solve
+        //TODO: concurrency problem between slot removal task and message deleting task
+        SLOT_REMOVED.next = EnumSet.of(DELETED);
+        SLOT_REMOVED.previous = EnumSet.of(PREPARED_TO_DELETE, DELETED);
 
         /*
          * next status of slot return status can be any state due to subscription could close at any given moment.


### PR DESCRIPTION
Introduced new message status "PREPARED_TO_DELETE"

PREPARED_TO_DELETE.next = EnumSet.of(DELETED, SLOT_REMOVED);
PREPARED_TO_DELETE.previous = EnumSet.of(EXPIRED, DLC_MESSAGE, PURGED);

This is to solve asynchronous message deletion and asynchronous slot deletion performed. 