### PR TITLE
Bind adding to already bound durable topic issue fixed.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueBindHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueBindHandler.java
@@ -119,7 +119,7 @@ public class QueueBindHandler implements StateAwareMethodListener<QueueBindBody>
                 }
             }
 
-            if (!exch.isBound(routingKey, body.getArguments(), queue))
+            if (!exch.isBound(routingKey, null, queue))
             {
                 String bindingKey = String.valueOf(routingKey);
                 Map<String,Object> arguments = FieldTable.convertToMap(body.getArguments());


### PR DESCRIPTION
When adding durable topic subscriber for the first time, binding added to QPID registry. Once restart the server, these details read from the db and feed to QPID. But we do not persist FieldTable arguments to the database. Therefore, adding a durable topic subscriber to the restart server will adding binding each time it connects. These arguments are not used in any places and only use to do equal check at adding a subscription. All the other places passed null as the value. To avoid add binding again, I have passed null as argument.