### PR TITLE
MB-1905 - Failover issues with 800 subscribers

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnection.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnection.java
@@ -389,12 +389,6 @@ public class AMQConnection extends Closeable implements Connection, QueueConnect
             _temporaryTopicExchangeName = connectionURL.getTemporaryTopicExchangeName();
         }
 
-        _protocolHandler = new AMQProtocolHandler(this);
-
-        if (_logger.isDebugEnabled()) {
-            _logger.debug("Connecting with ProtocolHandler Version:" + _protocolHandler.getProtocolVersion());
-        }
-
         // We are not currently connected
         _connected = false;
 
@@ -402,6 +396,12 @@ public class AMQConnection extends Closeable implements Connection, QueueConnect
         Exception connectionException = null;
         while (!_connected && retryAllowed && brokerDetails != null)
         {
+            _protocolHandler = new AMQProtocolHandler(this);
+
+            if (_logger.isDebugEnabled()) {
+                _logger.debug("Connecting with ProtocolHandler Version:" + _protocolHandler.getProtocolVersion() + " and object hashcode : " + _protocolHandler.hashCode());
+            }
+
             ProtocolVersion pe = null;
             try
             {

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionDelegate_8_0.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionDelegate_8_0.java
@@ -131,21 +131,24 @@ public class AMQConnectionDelegate_8_0 implements AMQConnectionDelegate
             }
         }
 
-
-        OutgoingNetworkTransport transport = Transport.getOutgoingTransportInstance(getProtocolVersion());
-        NetworkConnection network = transport.connect(settings,_conn._protocolHandler, null);
-        _conn._protocolHandler.setNetworkConnection(network);
-        _conn._protocolHandler.getProtocolSession().init();
-        // this blocks until the connection has been set up or when an error
-        // has prevented the connection being set up
-
         AMQState state = null;
+        NetworkConnection network = null;
+
         try {
+            OutgoingNetworkTransport transport = Transport.getOutgoingTransportInstance(getProtocolVersion());
+            network = transport.connect(settings,_conn._protocolHandler, null);
+            _conn._protocolHandler.setNetworkConnection(network);
+            _conn._protocolHandler.getProtocolSession().init();
+            // this blocks until the connection has been set up or when an error
+            // has prevented the connection being set up
+
             state = waiter.await();
-        } catch (AMQException e) {
-            //We need to close the network connection to shut down the IOProcessor created by Mina
-            network.close();
-            throw new AMQException("Error occurred while establishing a connection ", e);
+        } catch (Exception e) {
+
+            if(null != network){
+                   //We need to close the network connection to shut down the IOProcessor created by Mina
+                   network.close();
+            }
         }
 
         if(state == AMQState.CONNECTION_OPEN)

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionFactory.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionFactory.java
@@ -20,12 +20,20 @@
  */
 package org.wso2.andes.client;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wso2.andes.configuration.ClientProperties;
 import org.wso2.andes.jms.Connection;
+import org.wso2.andes.jms.ConnectionListener;
 import org.wso2.andes.jms.ConnectionURL;
 import org.wso2.andes.url.AMQBindingURL;
 import org.wso2.andes.url.URLSyntaxException;
 
+import javax.jms.*;
+import javax.naming.*;
+import javax.naming.spi.ObjectFactory;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.AccessController;
@@ -59,6 +67,8 @@ public class AMQConnectionFactory implements ConnectionFactory, QueueConnectionF
                                              ObjectFactory, Referenceable, XATopicConnectionFactory,
                                              XAQueueConnectionFactory, XAConnectionFactory
 {
+    private static final Logger logger = LoggerFactory.getLogger(AMQConnectionFactory.class);
+
     private String _host;
     private int _port;
     private String _defaultUsername;
@@ -68,7 +78,8 @@ public class AMQConnectionFactory implements ConnectionFactory, QueueConnectionF
     private ConnectionURL _connectionDetails;
     private SSLConfiguration _sslConfig;
 
-    private ThreadLocal<Boolean> removeBURL = new ThreadLocal<>();
+    private ConnectionListener connectionListener = null;
+    private ThreadLocal<Boolean> removeBURL = new ThreadLocal<Boolean>();
 
     public AMQConnectionFactory()
     {
@@ -343,12 +354,19 @@ public class AMQConnectionFactory implements ConnectionFactory, QueueConnectionF
                     _sslConfig.setTrustStorePassword(_connectionDetails.getTrustStorePassword());
 
                 }*/
-                return new AMQConnection(_connectionDetails, _sslConfig);
+                AMQConnection amqConnection = new AMQConnection(_connectionDetails, _sslConfig);
+                if (logger.isDebugEnabled()) {
+                    Throwable t = new Throwable();
+                    logger.debug("Setting connection listener to newly created connection from stack : " + displayStack(t).toString());
+                }
+                amqConnection.setConnectionListener(connectionListener);
+                return amqConnection;
             }
             else
             {
-                return new AMQConnection(_host, _port, _defaultUsername, _defaultPassword, getUniqueClientID(),
-                                         _virtualPath);
+                AMQConnection amqConnection = new AMQConnection(_host, _port, _defaultUsername, _defaultPassword, getUniqueClientID(), _virtualPath);
+                amqConnection.setConnectionListener(connectionListener);
+                return amqConnection;
             }
         }
         catch (Exception e)
@@ -370,6 +388,7 @@ public class AMQConnectionFactory implements ConnectionFactory, QueueConnectionF
     
     public Connection createConnection(String userName, String password, String id) throws JMSException
     {
+
         if (removeBURL == null) {
             removeBURL = new ThreadLocal<Boolean>();
             removeBURL.set(new Boolean(false));
@@ -402,11 +421,20 @@ public class AMQConnectionFactory implements ConnectionFactory, QueueConnectionF
                 {
                     _connectionDetails.setClientName(getUniqueClientID());
                 }
-                return new AMQConnection(_connectionDetails, _sslConfig);
+
+                AMQConnection amqConnection = new AMQConnection(_connectionDetails, _sslConfig);
+                if (logger.isDebugEnabled()) {
+                    Throwable t = new Throwable();
+                    logger.debug("Setting connection listener while creating connection from stack : " + displayStack(t).toString());
+                }
+                amqConnection.setConnectionListener(connectionListener);
+                return amqConnection;
             }
             else
             {
-                return new AMQConnection(_host, _port, userName, password, (id != null ? id : getUniqueClientID()), _virtualPath);
+                AMQConnection amqConnection = new AMQConnection(_host, _port, userName, password, (id != null ? id : getUniqueClientID()), _virtualPath);
+                amqConnection.setConnectionListener(connectionListener);
+                return amqConnection;
             }
         }
         catch (Exception e)
@@ -489,7 +517,9 @@ public class AMQConnectionFactory implements ConnectionFactory, QueueConnectionF
 
                 if (addr != null)
                 {
-                    return new AMQConnection((String) addr.getContent());
+                    AMQConnection amqConnection = new AMQConnection((String) addr.getContent());
+                    amqConnection.setConnectionListener(connectionListener);
+                    return amqConnection;
                 }
             }
 
@@ -660,5 +690,20 @@ public class AMQConnectionFactory implements ConnectionFactory, QueueConnectionF
     public XAQueueConnection createXAQueueConnection(String username, String password) throws JMSException
     {
         return (XAQueueConnection) createXAConnection(username, password);
+    }
+
+    public ConnectionListener getConnectionListener() {
+        return connectionListener;
+    }
+
+    public void setConnectionListener(ConnectionListener connectionListener) {
+        this.connectionListener = connectionListener;
+    }
+
+    private StringWriter displayStack(Throwable t) {
+         StringWriter errors = new StringWriter();
+         t.printStackTrace(new PrintWriter(errors));
+
+        return errors;
     }
 }

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/AMQProtocolHandler.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/AMQProtocolHandler.java
@@ -548,6 +548,7 @@ public class AMQProtocolHandler implements ProtocolEngine
         catch (AMQException e)
         {
             propagateExceptionToFrameListeners(e);
+
             exception(e);
         }
 


### PR DESCRIPTION
1. Enforce synchronized behaviour when writing frames to the channel from andes client side.

2. Allow custom connection listener through AMQConnectionFactory so that an external failover logic can take precedence over the in-built andes failover logic. Refer class at [1] for the ConnectionListener interface.

3. Use a new AMQProtocolHandler object when retrying to connect to the MB cluster. This will avoid any blockage from stale connection states from previous AMQProtocolHandler objects. 

4. Ensure closure of stale mina sockets when the connection times out or if an exception occurs during retry attempts. 