### PR TITLE
Message tracing for local transactions

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundEventManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundEventManager.java
@@ -212,7 +212,7 @@ public class InboundEventManager {
     public void ackReceived(AndesAckData ackData) {
         //For metrics
         ackedMessageCount.getAndIncrement();
-        
+
         // Publishers claim events in sequence
         long sequence = ringBuffer.next();
         InboundEventContainer event = ringBuffer.get(sequence);
@@ -314,12 +314,16 @@ public class InboundEventManager {
             eventContainer.setChannel(channel);
             eventContainer.addMessage(message, channel);
             eventContainer.pubAckHandler = disablePubAck;
-
         } finally {
             ringBuffer.publish(sequence);
+
+            //Tracing message activity
+            MessageTracer.traceTransaction(message, channel, MessageTracer
+                    .ENQUEUE_EVENT_PUBLISHED_TO_INBOUND_DISRUPTOR);
+
             if (log.isDebugEnabled()) {
                 log.debug("[ Sequence: " + sequence + " ] " + eventContainer.getEventType() +
-                        "' published to Disruptor");
+                          "' published to Disruptor");
             }
         }
     }
@@ -332,6 +336,10 @@ public class InboundEventManager {
      */
     public void requestTransactionCommitEvent(InboundTransactionEvent transactionEvent, AndesChannel channel) {
         requestTransactionEvent(transactionEvent, TRANSACTION_COMMIT_EVENT, channel);
+
+        //Tracing message activity
+        MessageTracer.traceTransaction(channel, transactionEvent.getQueuedMessages().size(), MessageTracer
+                .TRANSACTION_COMMIT_EVENT_PUBLISHED_TO_INBOUND_DISRUPTOR);
     }
 
     /**
@@ -341,6 +349,10 @@ public class InboundEventManager {
      */
     public void requestTransactionRollbackEvent(InboundTransactionEvent transactionEvent, AndesChannel channel) {
         requestTransactionEvent(transactionEvent, TRANSACTION_ROLLBACK_EVENT, channel);
+
+        //Tracing message activity
+        MessageTracer.traceTransaction(channel, transactionEvent.getQueuedMessages().size(), MessageTracer
+                .TRANSACTION_ROLLBACK_EVENT_PUBLISHED_TO_INBOUND_DISRUPTOR);
     }
 
     /**
@@ -350,6 +362,10 @@ public class InboundEventManager {
      */
     public void requestTransactionCloseEvent(InboundTransactionEvent transactionEvent, AndesChannel channel) {
         requestTransactionEvent(transactionEvent, TRANSACTION_CLOSE_EVENT, channel);
+
+        //Tracing message activity
+        MessageTracer.traceTransaction(channel, transactionEvent.getQueuedMessages().size(), MessageTracer
+                .TRANSACTION_CLOSE_EVENT_PUBLISHED_TO_INBOUND_DISRUPTOR);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundEventManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundEventManager.java
@@ -189,19 +189,22 @@ public class InboundEventManager {
         // Publishers claim events in sequence
         long sequence = ringBuffer.next();
         InboundEventContainer event = ringBuffer.get(sequence);
-        event.setEventType(MESSAGE_EVENT);
-        event.setChannel(andesChannel);
-        event.addMessage(message,andesChannel);
-        event.pubAckHandler = pubAckHandler;
+        try {
+            event.setEventType(MESSAGE_EVENT);
+            event.setChannel(andesChannel);
+            event.addMessage(message, andesChannel);
+            event.pubAckHandler = pubAckHandler;
+        } finally {
+            // make the event available to EventProcessors
+            ringBuffer.publish(sequence);
 
-        // make the event available to EventProcessors
-        ringBuffer.publish(sequence);
+            //Tracing message activity
+            MessageTracer.trace(message, MessageTracer.PUBLISHED_TO_INBOUND_DISRUPTOR);
 
-        //Tracing message activity
-        MessageTracer.trace(message, MessageTracer.PUBLISHED_TO_INBOUND_DISRUPTOR);
-
-        if (log.isDebugEnabled()) {
-            log.debug("[ sequence: " + sequence + " ] Message published to disruptor.");
+            if (log.isDebugEnabled()) {
+                log.debug("[ sequence: " + sequence + " ] Message published to disruptor. Message id: "
+                          + message.getMetadata().getMessageID());
+            }
         }
     }
 
@@ -216,21 +219,23 @@ public class InboundEventManager {
         // Publishers claim events in sequence
         long sequence = ringBuffer.next();
         InboundEventContainer event = ringBuffer.get(sequence);
+        try {
+            event.setEventType(ACKNOWLEDGEMENT_EVENT);
+            event.ackData = ackData;
+        } finally {
+            // make the event available to EventProcessors
+            ringBuffer.publish(sequence);
 
-        event.setEventType(ACKNOWLEDGEMENT_EVENT);
-        event.ackData = ackData;
-        // make the event available to EventProcessors
-        ringBuffer.publish(sequence);
+            //Tracing message
+            if (MessageTracer.isEnabled()) {
+                MessageTracer.trace(ackData.getAcknowledgedMessage().getMessageID(), ackData.getAcknowledgedMessage()
+                        .getDestination(), MessageTracer.ACK_PUBLISHED_TO_DISRUPTOR);
+            }
 
-        //Tracing message
-        if (MessageTracer.isEnabled()) {
-            MessageTracer.trace(ackData.getAcknowledgedMessage().getMessageID(), ackData.getAcknowledgedMessage()
-                    .getDestination(), MessageTracer.ACK_PUBLISHED_TO_DISRUPTOR);
-        }
-
-        if (log.isDebugEnabled()) {
-            log.debug("[ sequence: " + sequence + " ] Message acknowledgement published to disruptor. Message id " +
-                    ackData.getAcknowledgedMessage().getMessageID());
+            if (log.isDebugEnabled()) {
+                log.debug("[ sequence: " + sequence + " ] Message acknowledgement published to disruptor. Message id " +
+                          ackData.getAcknowledgedMessage().getMessageID());
+            }
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/tools/utils/MessageTracer.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/tools/utils/MessageTracer.java
@@ -21,6 +21,7 @@ package org.wso2.andes.tools.utils;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.AndesChannel;
 import org.wso2.andes.kernel.AndesMessage;
 import org.wso2.andes.kernel.AndesMessageMetadata;
 
@@ -32,9 +33,20 @@ public class MessageTracer {
     private static Log log = LogFactory.getLog(MessageTracer.class);
 
     public static final String REACHED_ANDES_CORE = "reached andes core";
-    public static final String PUBLISHED_TO_INBOUND_DISRUPTOR = "submitted to inbound disruptor";
+    public static final String PUBLISHED_TO_INBOUND_DISRUPTOR = "messaging event submitted to inbound disruptor";
+    public static final String ENQUEUE_EVENT_PUBLISHED_TO_INBOUND_DISRUPTOR = "enqueue event submitted to inbound "
+                                                                              + "disruptor";
     public static final String MESSAGE_ID_MAPPED = "mapped to andes message";
     public static final String MESSAGE_CLONED = "cloned with message id";
+    public static final String TRANSACTION_COMMIT_EVENT_PUBLISHED_TO_INBOUND_DISRUPTOR = "transaction commit event "
+                                                                                         + "submitted to inbound "
+                                                                                         + "disruptor";
+    public static final String TRANSACTION_ROLLBACK_EVENT_PUBLISHED_TO_INBOUND_DISRUPTOR = "transaction rollback "
+                                                                                           + "event submitted to inbound "
+                                                                                           + "disruptor";
+    public static final String TRANSACTION_CLOSE_EVENT_PUBLISHED_TO_INBOUND_DISRUPTOR = "transaction close "
+                                                                                           + "event submitted to inbound "
+                                                                                           + "disruptor";
     public static final String CONTENT_WRITTEN_TO_DB = "content written to database";
     public static final String SLOT_INFO_UPDATED = "slot information updated";
     public static final String PUBLISHED_TO_OUTBOUND_DISRUPTOR = "submitted to outbound disruptor";
@@ -65,9 +77,9 @@ public class MessageTracer {
      * message id, destination name and activity message
      * @param messageId Andes message id
      * @param destination destination name
-     * @param content message activity
+     * @param description message activity
      */
-    public static void trace(long messageId, String destination, String content) {
+    public static void trace(long messageId, String destination, String description) {
         if (log.isTraceEnabled()) {
 	        StringBuilder messageContent = new StringBuilder();
 	        messageContent.append("Message { Destination: ");
@@ -77,7 +89,7 @@ public class MessageTracer {
 	            messageContent.append(messageId);
             }
             messageContent.append(" } ");
-	        messageContent.append(content);
+	        messageContent.append(description);
             log.trace(messageContent.toString());
         }
     }
@@ -86,29 +98,87 @@ public class MessageTracer {
 	 * This method will print debug logs for message activities. This will accept andes message as
 	 * a parameter
 	 * @param message Andes message
-	 * @param content Message activity
+	 * @param description Message activity
 	 */
-    public static void trace(AndesMessage message, String content) {
-        trace(message.getMetadata().getMessageID(), message.getMetadata().getDestination(), content);
+    public static void trace(AndesMessage message, String description) {
+        trace(message.getMetadata().getMessageID(), message.getMetadata().getDestination(), description);
     }
 
 	/**
 	 * This method will print debug logs for message activities. This will accept metadata as
 	 * a parameter
 	 * @param metadata andes metadata object
-	 * @param content message activity
+	 * @param description message activity
 	 */
-    public static void trace(AndesMessageMetadata metadata, String content) {
-        trace(metadata.getMessageID(), metadata.getDestination(), content);
+    public static void trace(AndesMessageMetadata metadata, String description) {
+        trace(metadata.getMessageID(), metadata.getDestination(), description);
     }
 
-	/**
+    /**
 	 * This method will check if trace logs are enabled. This method can be used when performing
 	 * operations inside trace() method parameters
 	 * @return Status of MessageTracer
 	 */
     public static boolean isEnabled() {
         return log.isTraceEnabled();
+    }
+
+    /**
+     * This method will trace a message in a transaction with the given details and a predefined description.
+     *
+     * @param messageId   the id of the message
+     * @param destination the destination for which the message is bound
+     * @param channelId   the identifier of the channel from the message was originated. Used to track the transaction
+     * @param description     messaging activity
+     */
+    private static void traceTransaction(long messageId, String destination, String channelId, String description) {
+        if (log.isTraceEnabled()) {
+            StringBuilder messageContent = new StringBuilder();
+            messageContent.append("Message { Destination: ");
+            messageContent.append(destination);
+            // Check if andes message id is assigned, else ignore
+            if (messageId > 0) {
+                messageContent.append(" , Id: ");
+                messageContent.append(messageId);
+            }
+            messageContent.append(" , ChannelId: ");
+            messageContent.append(channelId);
+
+            messageContent.append(" } ");
+            messageContent.append(description);
+            log.trace(messageContent.toString());
+        }
+    }
+
+    /**
+     * This method will trace a transaction given the channel for which the transaction belongs to, the
+     * number of messages in the transaction and a predefined description of the operation that is being done.
+     *
+     * @param channel the channel from the message was originated. Used to track the transaction
+     * @param size    number of messages in the transaction
+     * @param description messaging activity
+     */
+    public static void traceTransaction(AndesChannel channel, int size, String description) {
+        if (log.isTraceEnabled()) {
+            String messageContent = "Transaction { "
+                                    + " ChannelID: " + channel.getIdentifier()
+                                    + " , BatchSize: " + size
+                                    + "} " + description;
+            log.trace(messageContent);
+        }
+    }
+
+    /**
+     * This method will trace a message in a transaction given the message and the channel from which the
+     * message is received and a predefined message.
+     *
+     * @param message the andes message to trace
+     * @param channel the channel from the message was originated. Used to track the transaction
+     * @param description messaging activity
+     */
+    public static void traceTransaction(AndesMessage message, AndesChannel channel, String description) {
+        traceTransaction(message.getMetadata().getMessageID(), message.getMetadata().getDestination(),
+                channel.getIdentifier(), description);
     }
 
 }


### PR DESCRIPTION
Added tracing for transactions when messages are enqueued and when a transactions id commited/rollbacked/closed.

The issue is tracked at https://wso2.org/jira/browse/MB-1907