### PR TITLE
[MB-1908] Fixed issue with empty slot

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -393,7 +393,7 @@ public enum AndesConfiguration implements ConfigurationProperty {
      * NOTE : specified in milliseconds.
      */
     PERFORMANCE_TUNING_SLOTS_MESSAGE_ACCUMULATION_TIMEOUT("performanceTuning/slots" +
-            "/messageAccumulationTimeout", "1000", Long.class, PERFORMANCE_TUNING_SLOTS_SLOT_RETAIN_TIME_IN_MEMORY),
+            "/messageAccumulationTimeout", "2000", Long.class, PERFORMANCE_TUNING_SLOTS_SLOT_RETAIN_TIME_IN_MEMORY),
 
     /**
      * Rough estimate for size of a slot. e.g. If the slot window size is 1000, given 3 nodes, it can expand up to 3000.
@@ -432,7 +432,7 @@ public enum AndesConfiguration implements ConfigurationProperty {
      * (- slots which have a aged more than 'messageAccumulationTimeout')
      */
     PERFORMANCE_TUNING_MAX_SLOT_SUBMIT_DELAY(
-            "performanceTuning/slots/maxSubmitDelay", "3000", Integer.class, PERFORMANCE_TUNING_SUBMIT_SLOT_TIMEOUT),
+            "performanceTuning/slots/maxSubmitDelay", "1000", Integer.class, PERFORMANCE_TUNING_SUBMIT_SLOT_TIMEOUT),
 
     /**
      * Number of parallel threads to execute slot deletion task. Increasing this value will remove slots

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -108,7 +108,8 @@ public class Andes {
     /**
      * Interval in milliseconds above update call should trigger
      */
-    private static final int safeZoneUpdateTriggerInterval = 3000;
+    private static final int safeZoneUpdateTriggerInterval = AndesConfigurationManager.readValue(AndesConfiguration
+            .PERFORMANCE_TUNING_MAX_SLOT_SUBMIT_DELAY);
 
     /**
      * Maximum batch size for a transaction. Limit is set for content size of the batch.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSMessageStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSMessageStoreImpl.java
@@ -904,7 +904,9 @@ public class RDBMSMessageStoreImpl implements MessageStore {
                                                     lastStatPublishTime);
             }
 
-            if (currentBatchCount < messageLimitPerSlot) {
+            // The slot map should be initialized only if there are messages. Or else, this will result in a slot
+            // submit with last assgined messsage id set to zero.
+            if ((currentBatchCount > 0) && (currentBatchCount < messageLimitPerSlot)) {
                 restoreMessagesCounter = restoreMessagesCounter + currentBatchCount;
                 callBack.initializeSlotMapForQueue(storageQueueName, batchStartMessageID, currentMessageId,
                                                    messageLimitPerSlot);


### PR DESCRIPTION
Fixes the issue reported at https://wso2.org/jira/browse/MB-1908

An empty slot was created when node that has no publishers connected gets killed, restarted and gets connected to consumers. 

This was caused by the fact that the last published message id in the was updated according to the number of messages for a given queue(which in this case, is zero). The slots were created according to the last published message id for each queue, hence ended up having a slot with the end message id as zero. This resulted in an invalid slot which was never removed even though there were no messages in it.

The fix was to not update the last published message id, if there are no messages for a queue.