### PR TITLE
[MB-1887] Fix message recover issue. 

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPLocalSubscription.java
@@ -243,22 +243,24 @@ public class AMQPLocalSubscription implements OutboundSubscription {
             if (amqpSubscription instanceof SubscriptionImpl.AckSubscription) {
 
                 MessageTracer.trace(messageID, "",
-                                    "Sending message " + msgHeaderStringID + " messageID-" + messageID + "-to channel "
-                                    + getChannelID());
+                                    "Sending message " + msgHeaderStringID
+                                            + "-to "
+                                            + "channel " + getChannelID());
 
                 amqpSubscription.send(queueEntry);
+
             } else if (amqpSubscription instanceof SubscriptionImpl.NoAckSubscription) {
-                MessageTracer.trace(messageID, "",
-                                    "Sending message " + msgHeaderStringID + " messageID-" + messageID + "-to channel "
-                                    + getChannelID());
+
+                MessageTracer.trace(messageID, "", "Sending message "
+                        + msgHeaderStringID + "-to channel " + getChannelID());
 
                 amqpSubscription.send(queueEntry);
 
                 // After sending message we simulate acknowledgment for NoAckSubscription
                 UUID channelID = ((SubscriptionImpl.NoAckSubscription) amqpSubscription).getChannel().getId();
-                AndesAckData andesAckData = AndesUtils.generateAndesAckMessage(channelID, messageID);
-
+                AndesAckData andesAckData = new AndesAckData(channelID, messageID);
                 Andes.getInstance().ackReceived(andesAckData);
+
             } else {
                 throw new AndesException("Error occurred while delivering message. Unexpected Subscription type for "
                         + "message with ID : " + msgHeaderStringID);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -31,6 +31,7 @@ import org.wso2.andes.kernel.disruptor.inbound.InboundDeleteMessagesEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundEventManager;
 import org.wso2.andes.kernel.disruptor.inbound.InboundExchangeEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundKernelOpsEvent;
+import org.wso2.andes.kernel.disruptor.inbound.InboundMessageRejectEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundQueueEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundSubscriptionEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundTransactionEvent;
@@ -167,21 +168,14 @@ public class Andes {
     /**
      * Recover messages for the subscriber. Re-schedule sent but un-ackenowledged
      * messages back
+     *
      * @param channelID ID of the channel recover request is received
-     * @throws AndesException
+     * @throws AndesException in case of publishing event to the disruptor.
      */
-    public void recoverMessage(UUID channelID) throws AndesException {
-        AndesSubscription subscription  = AndesContext.getInstance().
-                getAndesSubscriptionManager().getSubscriptionByProtocolChannel(channelID);
-
-        // Subscription can be null if we send a recover call without subscribing. In this case we do not have
-        // to recover any messages. Therefore print a log and return.
-        if (null == subscription) {
-            log.warn("Cannot handle recover. No subscriptions found for channel " + channelID);
-            return;
-        }
-
-        subscription.recoverMessages();
+    public void recoverMessagesOfChannel(UUID channelID) throws AndesException {
+         InboundAndesChannelEvent inboundChannelEvent = new InboundAndesChannelEvent(channelID);
+         inboundChannelEvent.prepareForChannelRecover();
+         inboundEventManager.publishStateEvent(inboundChannelEvent);
     }
 
     /**
@@ -253,49 +247,7 @@ public class Andes {
      * @throws AndesException
      */
     public void ackReceived(AndesAckData ackData) throws AndesException {
-
-        //Tracing Message
-        MessageTracer.trace(ackData.getAcknowledgedMessage().getMessageID(),
-                ackData.getAcknowledgedMessage().getDestination(), MessageTracer.ACK_RECEIVED_FROM_PROTOCOL);
-
-        //Adding metrics meter for ack rate
-        Meter ackMeter = MetricManager.meter(MetricsConstants.ACK_RECEIVE_RATE + MetricsConstants.METRICS_NAME_SEPARATOR
-                + ackData.getAcknowledgedMessage().getMessageRouterName() + MetricsConstants.METRICS_NAME_SEPARATOR
-                + ackData.getAcknowledgedMessage().getDestination(), Level.INFO);
-        ackMeter.mark();
-
-        //Adding metrics counter for ack messages
-        Counter counter = MetricManager.counter(MetricsConstants.ACK_MESSAGES + MetricsConstants.METRICS_NAME_SEPARATOR
-                + ackData.getAcknowledgedMessage().getMessageRouterName() + MetricsConstants.METRICS_NAME_SEPARATOR
-                + ackData.getAcknowledgedMessage().getDestination(), Level.INFO);
-        counter.inc();
-
-        //We call this later as this call removes the ackData.getAcknowledgedMessage() message
         inboundEventManager.ackReceived(ackData);
-    }
-
-    /**
-     * Connection Client to client is closed.
-     *
-     * @param channelID id of the closed connection
-     */
-    //TODO: review: after publishing to disruptor done nothing
-    public void clientConnectionClosed(UUID channelID) {
-        InboundAndesChannelEvent channelEvent = new InboundAndesChannelEvent(channelID);
-        channelEvent.prepareForChannelClose();
-        inboundEventManager.publishStateEvent(channelEvent);
-    }
-
-    /**
-     * Notify client connection is opened. This is for message tracking purposes on Andes side.
-     *
-     * @param channelID channelID of the client connection
-     */
-    //TODO: review: after publishing to disruptor done nothing
-    public void clientConnectionCreated(UUID channelID) {
-        InboundAndesChannelEvent channelEvent = new InboundAndesChannelEvent(channelID);
-        channelEvent.prepareForChannelOpen();
-        inboundEventManager.publishStateEvent(channelEvent);
     }
 
     /**
@@ -507,25 +459,19 @@ public class Andes {
     }
 
     /**
-     * Message is rejected.
+     * Handle message reject.
      *
-     * @param metadata  message that is rejected.
-     * @param channelID ID of the connection channel reject is received
-     * @throws AndesException
+     * @param messageId  Id of message that is rejected.
+     * @param channelID Id of the connection channel reject is received
+     * @param reQueue true if message should be re-queued to subscriber
+     * @param isMessageBeyondLastRollback  true if the message was rejected after the last rollback event.
+     * @throws AndesException on a message re-schedule issue
      */
-    public void messageRejected(DeliverableAndesMetadata metadata, UUID channelID) throws AndesException {
-        AndesSubscription subscription = AndesContext.getInstance().
-                getAndesSubscriptionManager().getSubscriptionByProtocolChannel(channelID);
-        if (subscription != null) {
-            subscription.onMessageReject(metadata.getMessageID());
-        } else {
-            log.warn("Cannot handle reject. Subscription not found for channel "
-                    + channelID + "Dropping message id= "
-                    + metadata.getMessageID());
-            metadata.markDeliveredChannelAsClosed(channelID);
-        }
-        //Tracing message activity
-        MessageTracer.trace(metadata, MessageTracer.MESSAGE_REJECTED);
+    public void messageRejected(long messageId, UUID channelID, boolean reQueue,
+                                boolean isMessageBeyondLastRollback) throws AndesException {
+        InboundMessageRejectEvent messageRejectEvent = new InboundMessageRejectEvent(messageId, channelID, reQueue);
+        messageRejectEvent.prepareToRejectMessage(isMessageBeyondLastRollback);
+        inboundEventManager.publishStateEvent(messageRejectEvent);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesAckData.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesAckData.java
@@ -18,6 +18,16 @@
 
 package org.wso2.andes.kernel;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.subscription.AndesSubscription;
+import org.wso2.andes.metrics.MetricsConstants;
+import org.wso2.andes.tools.utils.MessageTracer;
+import org.wso2.carbon.metrics.manager.Counter;
+import org.wso2.carbon.metrics.manager.Level;
+import org.wso2.carbon.metrics.manager.Meter;
+import org.wso2.carbon.metrics.manager.MetricManager;
+
 import java.util.UUID;
 
 /**
@@ -25,10 +35,16 @@ import java.util.UUID;
  */
 public class AndesAckData {
 
+    private static Log log = LogFactory.getLog(AndesAckData.class);
     /**
-     * Acknowledged message
+     * Id of acknowledged message
      */
-    private DeliverableAndesMetadata acknowledgedMessage;
+    private long IdOfAcknowledgedMessage;
+
+    /**
+     * Keep Metadata object represented by IdOfAcknowledgedMessage
+     */
+    private DeliverableAndesMetadata metadataReference;
 
     /**
      * ID of the channel acknowledge is received
@@ -44,24 +60,27 @@ public class AndesAckData {
 
     /**
      * Generate AndesAckData object. This holds acknowledge event in disruptor
+     *
      * @param channelID ID of the channel ack is received
-     * @param acknowledgedMessage message being acknowledged
+     * @param messageId Id of the message being acknowledged
      */
-    public AndesAckData(UUID channelID, DeliverableAndesMetadata acknowledgedMessage) {
+    public AndesAckData(UUID channelID, long messageId) {
         this.channelID = channelID;
-        this.acknowledgedMessage = acknowledgedMessage;
+        this.IdOfAcknowledgedMessage = messageId;
     }
 
     /**
      * Get the reference of the message being acknowledged
+     *
      * @return Metadata of the acknowledged message
      */
-    public DeliverableAndesMetadata getAcknowledgedMessage() {
-        return acknowledgedMessage;
+    public long getIdOfAcknowledgedMessage() {
+        return IdOfAcknowledgedMessage;
     }
 
     /**
      * Get ID of the channel acknowledgement is received
+     *
      * @return channel ID
      */
     public UUID getChannelID() {
@@ -69,7 +88,36 @@ public class AndesAckData {
     }
 
     /**
+     * Set Reference to DeliverableAndesMetadata object being acknowledged.
+     * This MUST be set only within disruptor handler.
+     */
+    public void setMeradataReference() {
+        AndesSubscription localSubscription = AndesContext.getInstance().
+                getAndesSubscriptionManager().getSubscriptionByProtocolChannel(channelID);
+        if (null == localSubscription) {
+            log.error("Cannot handle acknowledgement for message ID = "
+                    + IdOfAcknowledgedMessage + " as subscription is closed "
+                    + "channelID= " + "" + channelID);
+            metadataReference = null;
+        } else {
+            metadataReference = localSubscription.
+                    getSubscriberConnection().getUnAckedMessage(IdOfAcknowledgedMessage);
+            trace();
+        }
+    }
+
+    /**
+     * Get reference to DeliverableAndesMetadata object that is acknowledged
+     *
+     * @return DeliverableAndesMetadata object being acknowledged
+     */
+    public DeliverableAndesMetadata getMetadataReference() {
+        return metadataReference;
+    }
+
+    /**
      * Check if message being acknowledged is ready to be removed
+     *
      * @return true if removable
      */
     public boolean isBaringMessageRemovable() {
@@ -82,6 +130,28 @@ public class AndesAckData {
      */
     public void setBaringMessageRemovable() {
         this.isBaringMessageRemovable = true;
+    }
+
+    /**
+     * Trace the acknowledgement
+     */
+    private void trace() {
+        //Tracing Message
+        MessageTracer.trace(IdOfAcknowledgedMessage,
+                metadataReference.getDestination(), MessageTracer.ACK_RECEIVED_FROM_PROTOCOL);
+
+        //Adding metrics meter for ack rate
+        Meter ackMeter = MetricManager.meter(MetricsConstants.ACK_RECEIVE_RATE
+                + MetricsConstants.METRICS_NAME_SEPARATOR
+                + metadataReference.getMessageRouterName() + MetricsConstants.METRICS_NAME_SEPARATOR
+                + metadataReference.getDestination(), Level.INFO);
+        ackMeter.mark();
+
+        //Adding metrics counter for ack messages
+        Counter counter = MetricManager.counter(MetricsConstants.ACK_MESSAGES + MetricsConstants.METRICS_NAME_SEPARATOR
+                + metadataReference.getMessageRouterName() + MetricsConstants.METRICS_NAME_SEPARATOR
+                + metadataReference.getDestination(), Level.INFO);
+        counter.inc();
     }
 
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
@@ -348,7 +348,7 @@ public class AndesKernelBoot {
         AndesContext.getInstance().setAndesContextInformationManager(contextInformationManager);
 
         //Create an inbound event manager. This will prepare inbound events to disruptor
-        InboundEventManager inboundEventManager =  new InboundEventManager(subscriptionManager, messagingEngine);
+        InboundEventManager inboundEventManager =  new InboundEventManager(messagingEngine);
         AndesContext.getInstance().setInboundEventManager(inboundEventManager);
 
         DtxRegistry dtxRegistry = new DtxRegistry(messageStore.getDtxStore(), messagingEngine, inboundEventManager);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesUtils.java
@@ -112,21 +112,6 @@ public class AndesUtils {
         return andesMessageId;
     }
 
-    public static void writeToFile(String whatToWrite, String filePath) {
-        try {
-            if (printWriterGlobal == null) {
-                BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter(filePath));
-                printWriterGlobal = new PrintWriter(bufferedWriter);
-            }
-
-            printWriterGlobal.println(whatToWrite);
-
-        } catch (IOException e) {
-            System.out.println("Error. File to print received messages is not provided" + e);
-        }
-
-    }
-
     /**
      * Generate storage queue name for given internal queue information
      * @param routingKey    routing key by which queue is bound
@@ -159,26 +144,6 @@ public class AndesUtils {
             storageQueueName = queueName;
         }
         return storageQueueName;
-    }
-
-    /**
-     * create andes ack data message
-     *
-     * @param channelID id of the connection message was received
-     * @param messageID id of the message
-     * @return Andes Ack Data
-     */
-    public static AndesAckData generateAndesAckMessage(UUID channelID, long messageID) throws AndesException {
-        org.wso2.andes.kernel.subscription.AndesSubscription localSubscription = AndesContext.getInstance().
-                getAndesSubscriptionManager().getSubscriptionByProtocolChannel(channelID);
-        if (null == localSubscription) {
-            log.error("Cannot handle acknowledgement for message ID = " + messageID + " as subscription is closed "
-                    + "channelID= " + "" + channelID);
-            return null;
-        }
-        DeliverableAndesMetadata metadata = localSubscription.
-                getSubscriberConnection().getUnAckedMessage(messageID);
-        return new AndesAckData(channelID, metadata);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ChannelMessageStatus.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ChannelMessageStatus.java
@@ -56,9 +56,14 @@ public enum  ChannelMessageStatus {
     CLIENT_REJECTED(5),
 
     /**
+     * Channel is recovered. Messages will be flushed to some channel again
+     */
+    RECOVERED(6),
+
+    /**
      * Consumer is closed
      */
-    CLOSED(6);
+    CLOSED(7);
 
 
     private int code;
@@ -123,20 +128,23 @@ public enum  ChannelMessageStatus {
         //Channel wise message status begins at DISPATCHED state.
         //If message CLOSED there is no next state for message.
 
-        DISPATCHED.next = EnumSet.of(SEND_FAILED, ACKED, NACKED, CLOSED);
+        DISPATCHED.next = EnumSet.of(SEND_FAILED, ACKED, NACKED, RECOVERED, CLOSED);
         DISPATCHED.previous = EnumSet.complementOf(EnumSet.allOf(ChannelMessageStatus.class));
 
         SEND_FAILED.next = EnumSet.of(DISPATCHED, CLIENT_REJECTED, CLOSED);
         SEND_FAILED.previous = EnumSet.of(DISPATCHED);
 
-        ACKED.next = EnumSet.of(CLOSED);
+        ACKED.next = EnumSet.of(RECOVERED, CLOSED);
         ACKED.previous = EnumSet.of(DISPATCHED);
 
-        NACKED.next = EnumSet.of(DISPATCHED, CLOSED);
+        NACKED.next = EnumSet.of(DISPATCHED, RECOVERED, CLOSED);
         NACKED.previous = EnumSet.of(DISPATCHED);
 
         CLIENT_REJECTED.next = EnumSet.complementOf(EnumSet.allOf(ChannelMessageStatus.class));
         CLIENT_REJECTED.previous = EnumSet.of(SEND_FAILED);
+
+        RECOVERED.next = EnumSet.of(DISPATCHED, CLOSED);
+        RECOVERED.previous = EnumSet.of(DISPATCHED, ACKED, NACKED);
 
         //this is because we directly mark close on channel close
         CLOSED.next = EnumSet.of(SEND_FAILED, CLOSED);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
@@ -191,6 +191,16 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
     }
 
     /**
+     * Rollback message delivery on the channel. It should
+     * not be recorded as a success delivery attempt.
+     *
+     * @param channelID ID of the subscriber channel delivery should be rollback
+     */
+    public void rollbackDelivery(UUID channelID) {
+        channelDeliveryInfo.get(channelID).decrementDeliveryCount();
+    }
+
+    /**
      * Mark the message as buffered. Buffered messages will be scheduled to the subscribers.
      */
     public void markAsBuffered() {
@@ -275,6 +285,16 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
     public void markAsNackedByClient(UUID channelID) {
         ChannelInformation channelInformation = channelDeliveryInfo.get(channelID);
         channelInformation.addChannelStatus(ChannelMessageStatus.NACKED);
+    }
+
+    /**
+     * Record channel recovery
+     *
+     * @param channelID ID of the channel
+     */
+    public void markAsRecoveredByClient(UUID channelID) {
+        ChannelInformation channelInformation = channelDeliveryInfo.get(channelID);
+        channelInformation.addChannelStatus(ChannelMessageStatus.RECOVERED);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -267,21 +267,23 @@ public class MessagingEngine {
         List<AndesPreparedMessageMetadata> messagesToRemove = new ArrayList<>(ackDataList.size());
         for (AndesAckData ack : ackDataList) {
 
+            ack.setMeradataReference();
+
             // For topics message is shared. If all acknowledgements are received only we should remove message
-            boolean deleteMessage = ack.getAcknowledgedMessage().markAsAcknowledgedByChannel(ack.getChannelID());
+            boolean deleteMessage = ack.getMetadataReference().markAsAcknowledgedByChannel(ack.getChannelID());
 
             AndesSubscription subscription = subscriptionManager.getSubscriptionByProtocolChannel(ack.getChannelID());
 
-            subscription.onMessageAck(ack.getAcknowledgedMessage().getMessageID());
+            subscription.onMessageAck(ack.getIdOfAcknowledgedMessage());
 
             if (deleteMessage) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Ok to delete message id " + ack.getAcknowledgedMessage().getMessageID());
+                    log.debug("Ok to delete message id " + ack.getIdOfAcknowledgedMessage());
                 }
                 //it is a must to set this to event container. Otherwise, multiple event handlers will see the status
                 ack.setBaringMessageRemovable();
                 AndesPreparedMessageMetadata rollbackMessageMetadata =
-                        new AndesPreparedMessageMetadata(ack.getAcknowledgedMessage());
+                        new AndesPreparedMessageMetadata(ack.getMetadataReference());
                 messagesToRemove.add(rollbackMessageMetadata);
             }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/AckHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/AckHandler.java
@@ -82,7 +82,7 @@ public class AckHandler implements StoreHealthListener {
         if (log.isTraceEnabled()) {
             StringBuilder messageIDsString = new StringBuilder();
             for (AndesAckData andesAckData : ackDataList) {
-                messageIDsString.append(andesAckData.getAcknowledgedMessage().getMessageID()).append(" , ");
+                messageIDsString.append(andesAckData.getIdOfAcknowledgedMessage()).append(" , ");
             }
             log.trace(ackDataList.size() + " messages received : " + messageIDsString);
         }
@@ -110,21 +110,23 @@ public class AckHandler implements StoreHealthListener {
         
         for (AndesAckData ack : ackDataList) {
 
+            ack.setMeradataReference();
+
             // For topics message is shared. If all acknowledgements are received only we should remove message
-            boolean deleteMessage = ack.getAcknowledgedMessage().markAsAcknowledgedByChannel(ack.getChannelID());
+            boolean deleteMessage = ack.getMetadataReference().markAsAcknowledgedByChannel(ack.getChannelID());
 
             AndesSubscription subscription = subscriptionManager
                     .getSubscriptionByProtocolChannel(ack.getChannelID());
 
-            subscription.onMessageAck(ack.getAcknowledgedMessage().getMessageID());
+            subscription.onMessageAck(ack.getIdOfAcknowledgedMessage());
 
             if (deleteMessage) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Ok to delete message id " + ack.getAcknowledgedMessage().getMessageID());
+                    log.debug("Ok to delete message id " + ack.getIdOfAcknowledgedMessage());
                 }
                 //it is a must to set this to event container. Otherwise, multiple event handlers will see the status
                 ack.setBaringMessageRemovable();
-                messagesToRemove.add(ack.getAcknowledgedMessage());
+                messagesToRemove.add(ack.getMetadataReference());
             }
             
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundAndesChannelEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundAndesChannelEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -20,7 +20,9 @@ package org.wso2.andes.kernel.disruptor.inbound;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.AndesContext;
 import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.kernel.subscription.AndesSubscription;
 
 import java.util.UUID;
 
@@ -38,12 +40,7 @@ public class InboundAndesChannelEvent implements AndesInboundStateEvent {
         /**
          * Specific client channel close event
          */
-        CHANNEL_CLOSE_EVENT,
-
-        /**
-         * New client connected and client channel is opened event
-         */
-        CHANNEL_OPEN_EVENT
+        CHANNEL_RECOVER_EVENT,
     }
 
     /**
@@ -63,9 +60,17 @@ public class InboundAndesChannelEvent implements AndesInboundStateEvent {
     @Override
     public void updateState() throws AndesException {
         switch (eventType) {
-            case CHANNEL_OPEN_EVENT:
-                break;
-            case CHANNEL_CLOSE_EVENT:
+            case CHANNEL_RECOVER_EVENT:
+                AndesSubscription subscription  = AndesContext.getInstance().
+                        getAndesSubscriptionManager().getSubscriptionByProtocolChannel(channelID);
+
+                // Subscription can be null if we send a recover call without subscribing. In this case we do not have
+                // to recover any messages. Therefore print a log and return.
+                if (null == subscription) {
+                    log.warn("Cannot handle recover. No subscriptions found for channel " + channelID);
+                    return;
+                }
+                subscription.recoverMessages();
                 break;
             default:
                 log.error("Event type not set properly " + eventType);
@@ -81,14 +86,7 @@ public class InboundAndesChannelEvent implements AndesInboundStateEvent {
     /**
      * Update event to a channel open event 
      */
-    public void prepareForChannelOpen() {
-        eventType = EventType.CHANNEL_OPEN_EVENT;
-    }
-
-    /**
-     * Update event to a channel close event 
-     */
-    public void prepareForChannelClose() {
-        eventType = EventType.CHANNEL_CLOSE_EVENT;
+    public void prepareForChannelRecover() {
+        eventType = EventType.CHANNEL_RECOVER_EVENT;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundEventManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundEventManager.java
@@ -80,8 +80,7 @@ public class InboundEventManager {
     private final DisablePubAckImpl disablePubAck;
     private LZ4CompressionHelper lz4CompressionHelper;
 
-    public InboundEventManager(AndesSubscriptionManager subscriptionManager,
-                               MessagingEngine messagingEngine) {
+    public InboundEventManager(MessagingEngine messagingEngine) {
 
         Integer bufferSize = AndesConfigurationManager.readValue(
                 PERFORMANCE_TUNING_PUBLISHING_BUFFER_SIZE);
@@ -181,6 +180,7 @@ public class InboundEventManager {
     /**
      * When a message is received from a transport it is handed over to MessagingEngine through the implementation of
      * inbound event manager. (e.g: through a disruptor ring buffer) Eventually the message will be stored
+     *
      * @param message AndesMessage
      * @param andesChannel AndesChannel
      * @param pubAckHandler PubAckHandler
@@ -210,6 +210,7 @@ public class InboundEventManager {
 
     /**
      * Acknowledgement received from clients for sent messages will be handled through this method
+     *
      * @param ackData AndesAckData
      */
     public void ackReceived(AndesAckData ackData) {
@@ -228,13 +229,13 @@ public class InboundEventManager {
 
             //Tracing message
             if (MessageTracer.isEnabled()) {
-                MessageTracer.trace(ackData.getAcknowledgedMessage().getMessageID(), ackData.getAcknowledgedMessage()
-                        .getDestination(), MessageTracer.ACK_PUBLISHED_TO_DISRUPTOR);
+                MessageTracer.trace(ackData.getIdOfAcknowledgedMessage(),
+                        MessageTracer.ACK_PUBLISHED_TO_DISRUPTOR + " Channel = " + ackData.getChannelID());
             }
 
             if (log.isDebugEnabled()) {
-                log.debug("[ sequence: " + sequence + " ] Message acknowledgement published to disruptor. Message id " +
-                          ackData.getAcknowledgedMessage().getMessageID());
+                log.debug("[ sequence: " + sequence + " ] Message acknowledgement published to disruptor. "
+                        + "Message id " + ackData.getIdOfAcknowledgedMessage());
             }
         }
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundMessageRejectEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundMessageRejectEvent.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.andes.kernel.disruptor.inbound;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.AndesContext;
+import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.kernel.DeliverableAndesMetadata;
+import org.wso2.andes.kernel.subscription.AndesSubscription;
+import org.wso2.andes.tools.utils.MessageTracer;
+
+import java.util.UUID;
+
+/**
+ * Disruptor event handling message reject
+ */
+public class InboundMessageRejectEvent implements AndesInboundStateEvent {
+
+
+    private static Log log = LogFactory.getLog(InboundMessageRejectEvent.class);
+    /**
+     * Channel event type handle by the event object
+     */
+    private EventType eventType;
+
+    /**
+     * Id of the message rejected by client
+     */
+    private long messageId;
+
+    /**
+     * Id of the channel reject is received
+     */
+    private UUID channelId;
+
+    /**
+     * Whether to re-queue the message back to the subscriber
+     */
+    private boolean reQueue;
+
+    /**
+     * This is to handle the messages beyond the actual rollback event, which are rejected from the client side
+     * message buffer. True if the message was rejected after the last rollback event.
+     */
+    private boolean isMessageBeyondLastRollback;
+
+    /**
+     * Supported state events
+     */
+    public enum EventType {
+        /**
+         * Specific client channel close event
+         */
+        MESSAGE_REJECT_EVENT,
+    }
+
+    /**
+     * Create an instance of message reject event
+     *
+     * @param messageId Id of the message rejected
+     * @param channelId Id of the channel message reject received
+     * @param reQueue   whether to re queue message back to subscriber
+     */
+    public InboundMessageRejectEvent(long messageId, UUID channelId, boolean reQueue) {
+        this.messageId = messageId;
+        this.channelId = channelId;
+        this.reQueue = reQueue;
+    }
+
+    /**
+     * Prepare to reject message. This is done prior to inset the
+     * event to disruptor
+     *
+     * @param isMessageBeyondLastRollback True if the message was rejected after the last rollback event.
+     */
+    public void prepareToRejectMessage(boolean isMessageBeyondLastRollback) {
+        this.isMessageBeyondLastRollback = isMessageBeyondLastRollback;
+        this.eventType = EventType.MESSAGE_REJECT_EVENT;
+    }
+
+    @Override
+    public void updateState() throws AndesException {
+        AndesSubscription subscription = AndesContext.getInstance().
+                getAndesSubscriptionManager().getSubscriptionByProtocolChannel(channelId);
+        if (subscription != null) {
+            DeliverableAndesMetadata rejectedMessage = subscription.onMessageReject(messageId, reQueue);
+            rejectedMessage.setIsBeyondLastRollbackedMessage(isMessageBeyondLastRollback);
+            //Tracing message activity
+            MessageTracer.trace(rejectedMessage, MessageTracer.MESSAGE_REJECTED);
+        } else {
+            log.warn("Cannot handle reject. Subscription not found for channel "
+                    + channelId + "Dropping message id= " + messageId);
+        }
+    }
+
+    @Override
+    public String eventInfo() {
+        return eventType.toString();
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/StateEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/StateEventHandler.java
@@ -80,7 +80,7 @@ public class StateEventHandler implements EventHandler<InboundEventContainer> {
     }
 
     private void updateTrackerWithAck(InboundEventContainer event) throws AndesException {
-        DeliverableAndesMetadata acknowledgedMessage = event.ackData.getAcknowledgedMessage();
+        DeliverableAndesMetadata acknowledgedMessage = event.ackData.getMetadataReference();
         //we need both conditions to prevent multiple events seeing that message is deleted
         if (acknowledgedMessage.getLatestState().equals(MessageStatus.DELETED)
                 && event.ackData.isBaringMessageRemovable()) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/OutBoundMessageTracker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/OutBoundMessageTracker.java
@@ -112,18 +112,25 @@ public class OutBoundMessageTracker {
         return new ArrayList<>(messageSendingTracker.values());
     }
 
+    /**
+     * Clear tracked sent but un-acknowledged messages. Return the messages in the same view.
+     * While this operation is performed, no new message will be added to the list.
+     *
+     * @return list of messages tracked when cleaned up
+     */
+    public synchronized List<DeliverableAndesMetadata> clearAndReturnUnackedMessages() {
+        List<DeliverableAndesMetadata> messages = getUnackedMessages();
+        messageSendingTracker.clear();
+        return messages;
+    }
 
     /**
      * Add message to sending tracker which keeps messages delivered to channel of associated subscriber
      *
      * @param messageData message to add
      */
-    public void addMessageToSendingTracker(ProtocolMessage messageData) {
-        DeliverableAndesMetadata messageDataToAdd = messageSendingTracker.get(messageData.getMessageID());
-        if (null == messageDataToAdd) {
-            //we need to put message reference to the sending tracker
-            messageSendingTracker.put(messageData.getMessageID(), messageData.getMessage());
-        }
+    public synchronized void addMessageToSendingTracker(ProtocolMessage messageData) {
+        messageSendingTracker.putIfAbsent(messageData.getMessageID(), messageData.getMessage());
     }
 
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/SubscriberConnection.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/SubscriberConnection.java
@@ -247,6 +247,17 @@ public class SubscriberConnection {
     }
 
     /**
+     * Clear tracked sent but un-acknowledged messages. Return the messages of the same view
+     * at the moment it was cleared. While this operation is performed, no new
+     * message will be added to the list.
+     *
+     * @return list of messages tracked when cleaned up
+     */
+    public List<DeliverableAndesMetadata> clearAndReturnUnackedMessages() {
+        return outBoundMessageTracker.clearAndReturnUnackedMessages();
+    }
+
+    /**
      * Is the underlying protocol connection active and can accept
      * messages
      *
@@ -276,10 +287,10 @@ public class SubscriberConnection {
     /**
      * Perform on reject receive for a message
      * @param messageID id of the message acknowledged
+     * @param reQueue true if message is to be delivered again
      * @return  DeliverableAndesMetadata reference of message rejected
-     * @throws AndesException
      */
-    public DeliverableAndesMetadata onMessageReject(long messageID) throws AndesException{
+    public DeliverableAndesMetadata onMessageReject(long messageID, boolean reQueue) {
         DeliverableAndesMetadata rejectedMessage = getUnAckedMessage(messageID);
         rejectedMessage.markAsNackedByClient(protocolChannelID);
         if (log.isDebugEnabled()) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTopicManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTopicManager.java
@@ -370,15 +370,15 @@ public class MQTTopicManager {
     /**
      * Called by the process of sending rejection for messages which have not being acked
      *
-     * @param metadata which holds information regarding the messages which has not being acked
+     * @param idOfNackedMessage id of the message which has not being acked
      * @param channelID Id of the subscription channel NAC is received
      */
-    private void onMessageNack(DeliverableAndesMetadata metadata, UUID channelID) {
+    private void onMessageNack(long idOfNackedMessage, UUID channelID) {
         try {
-            connector.messageNack(metadata, channelID);
+            connector.messageNack(idOfNackedMessage, channelID);
         } catch (AndesException e) {
             //We do not throw this any further
-            String message = "Error occurred while sending a rejection ack for message " + metadata.getMessageID();
+            String message = "Error occurred while sending a rejection ack for message " + idOfNackedMessage;
             log.error(message, e);
         }
     }
@@ -451,9 +451,7 @@ public class MQTTopicManager {
 
             for (Integer messageID : unackedMessages) {
                 MQTTSubscription subscription = mqtTopics.getSubscription(messageID);
-                DeliverableAndesMetadata mataInformation = subscription.getMessageMetaInformation(messageID);
-                onMessageNack(mataInformation, subscription.getSubscriptionChannel());
-
+                onMessageNack(messageID, subscription.getSubscriptionChannel());
                 if(log.isDebugEnabled()){
                    log.debug("Message null ack sent to message id "+messageID);
                 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/InMemoryConnector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/InMemoryConnector.java
@@ -61,7 +61,7 @@ public class InMemoryConnector implements MQTTConnector {
     }
 
     @Override
-    public void messageNack(DeliverableAndesMetadata metadata, UUID channelID) {
+    public void messageNack(long messageId, UUID channelID) {
 
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/MQTTConnector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/MQTTConnector.java
@@ -19,10 +19,7 @@ package org.wso2.andes.mqtt.connectors;
 
 import org.dna.mqtt.wso2.QOSLevel;
 import org.wso2.andes.kernel.AndesException;
-import org.wso2.andes.kernel.AndesMessageMetadata;
-import org.wso2.andes.kernel.DeliverableAndesMetadata;
 import org.wso2.andes.kernel.SubscriptionAlreadyExistsException;
-import org.wso2.andes.kernel.disruptor.inbound.PubAckHandler;
 import org.wso2.andes.mqtt.MQTTException;
 import org.wso2.andes.mqtt.MQTTMessageContext;
 import org.wso2.andes.mqtt.MQTTopicManager;
@@ -46,11 +43,11 @@ public interface MQTTConnector {
 
     /**
      * Triggers when a rejection ack is be initiated, this will be done as a result of ping request
-     * @param metadata the meta information of the message being rejected
+     * @param messageId the Id of the message being rejected
      * @param channelID the ID of the channel reject message is received
      * @throws org.wso2.andes.kernel.AndesException
      */
-    public void messageNack(DeliverableAndesMetadata metadata, UUID channelID) throws AndesException;
+    public void messageNack(long messageId, UUID channelID) throws AndesException;
 
     /**
      * Adds message to the connector to handle an incoming message

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
@@ -225,8 +225,6 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
         _id = UUID.randomUUID();
         _actor.message(ChannelMessages.CREATE());
 
-        // message tracking related to this channel is initialised
-        Andes.getInstance().clientConnectionCreated(_id);
         beginPublisherTransaction = false;
         
         //Set channel details
@@ -295,12 +293,10 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
 
     /**
      * Reschedule recovered messages to be resent
-     *
-     * @param recovererMsgs Map of recovered messages
      */
-    public void resendRecoveredMessages(Map<Long, QueueEntry> recovererMsgs) {
+    public void resendRecoveredMessages() {
         try {
-            QpidAndesBridge.recover(recovererMsgs.values(), this);
+            QpidAndesBridge.recoverMessagesOfChannel(this);
         } catch (AMQException e ) {
             _logger.error("Error while resending recovered messages.", e);
         }
@@ -756,7 +752,6 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
         } catch (AndesException e) {
             throw new AMQException("Exception occurred while closing channel " + _channelId, e);
         } finally {
-            QpidAndesBridge.channelIsClosing(this.getId());
             Andes.getInstance().deleteChannel(andesChannel);
         }
 
@@ -1907,7 +1902,8 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
     /**
      * Set the message ID of the last rejected message.
      * Currently called by QpidAndesBridge.rejectMessage.
-     * @param lastRejectedMessageId
+     *
+     * @param lastRejectedMessageId Id of message newly rejected by this channel
      */
     public void setLastRejectedMessageId(long lastRejectedMessageId) {
         this.lastRejectedMessageId = lastRejectedMessageId;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRecoverMethodHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRecoverMethodHandler.java
@@ -49,13 +49,10 @@ public class BasicRecoverMethodHandler implements StateAwareMethodListener<Basic
         _logger.debug("Recover received on protocol session " + session + " and channel " + channelId);
         AMQChannel channel = session.getChannel(channelId);
 
-
         if (channel == null)
         {
             throw body.getChannelNotFoundException(channelId);
         }
-
-        Map<Long, QueueEntry> recoveredMsgs = channel.recoverMessages(body.getRequeue());
 
         // Qpid 0-8 hacks a synchronous -ok onto recover.
         // In Qpid 0-9 we create a separate sync-recover, sync-recover-ok pair to be "more" compliant
@@ -67,6 +64,6 @@ public class BasicRecoverMethodHandler implements StateAwareMethodListener<Basic
 
         }
 
-        channel.resendRecoveredMessages(recoveredMsgs);
+        channel.resendRecoveredMessages();
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRecoverSyncMethodHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRecoverSyncMethodHandler.java
@@ -58,7 +58,7 @@ public class BasicRecoverSyncMethodHandler implements StateAwareMethodListener<B
             throw body.getChannelNotFoundException(channelId);
         }
 
-        Map<Long, QueueEntry> recoveredMsgs = channel.recoverMessages(body.getRequeue());
+        //Map<Long, QueueEntry> recoveredMsgs = channel.recoverMessages(body.getRequeue());
 
         // Qpid 0-8 hacks a synchronous -ok onto recover.
         // In Qpid 0-9 we create a separate sync-recover, sync-recover-ok pair to be "more" compliant
@@ -77,6 +77,6 @@ public class BasicRecoverSyncMethodHandler implements StateAwareMethodListener<B
 
         }
 
-        channel.resendRecoveredMessages(recoveredMsgs);
+        channel.resendRecoveredMessages();
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRejectMethodHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRejectMethodHandler.java
@@ -112,7 +112,7 @@ public class BasicRejectMethodHandler implements StateAwareMethodListener<BasicR
                  * Inform kernel that message has been rejected by AMQP transport
                  */
                 try {
-                    QpidAndesBridge.rejectMessage((AMQMessage) message.getMessage(), channel);
+                    QpidAndesBridge.rejectMessage((AMQMessage) message.getMessage(), channel, body.getRequeue());
                 } catch (AMQException e) {
                     _logger.error("Error while rejecting message by kernel" , e);
                     throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error while rejecting message by kernel", e);
@@ -122,22 +122,8 @@ public class BasicRejectMethodHandler implements StateAwareMethodListener<BasicR
 
             if (body.getRequeue())
             {
-                //todo: we need to honour this
+                //remove message from maps
                 channel.requeue(deliveryTag);
-            }
-            else
-            {
-                try {
-                    DeliverableAndesMetadata andesMetadata = AndesUtils.lookupDeliveredMessage(message.getMessage()
-                            .getMessageNumber(), channel.getId());
-                    Andes.getInstance().moveMessageToDeadLetterChannel(andesMetadata, message
-                            .getQueue()
-                            .getName());
-                } catch (AndesException e) {
-                    _logger.error("Error while moving message to DLC message Id = "
-                            + message.getMessage().getMessageNumber() , e);
-                    throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error while moving message to DLC", e);
-                }
             }
         }
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/txn/QpidDistributedTransaction.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/txn/QpidDistributedTransaction.java
@@ -101,7 +101,7 @@ public class QpidDistributedTransaction implements ServerTransaction {
         List<AndesAckData> ackList = new ArrayList<>(messages.size());
         try {
             for (QueueEntry entry : messages) {
-                ackList.add(AndesUtils.generateAndesAckMessage(channelID, entry.getMessage().getMessageNumber()));
+                ackList.add(new AndesAckData(channelID, entry.getMessage().getMessageNumber()));
             }
             distributedTransaction.dequeue(ackList);
         } catch (AndesException e) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/tools/utils/MessageTracer.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/tools/utils/MessageTracer.java
@@ -95,6 +95,25 @@ public class MessageTracer {
     }
 
     /**
+     * Trace log on message activity. Accepts message Id and a description
+     *
+     * @param messageId Id of the message
+     * @param description Description to place in log on message activity
+     */
+    public static void trace(long messageId, String description) {
+        if (log.isTraceEnabled()) {
+            StringBuilder messageContent = new StringBuilder();
+            if (messageId > 0) { // Check if andes message id is assigned, else ignore
+                messageContent.append("Id: ");
+                messageContent.append(messageId);
+                messageContent.append(", ");
+            }
+            messageContent.append(description);
+            log.trace(messageContent.toString());
+        }
+    }
+
+    /**
 	 * This method will print debug logs for message activities. This will accept andes message as
 	 * a parameter
 	 * @param message Andes message

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession_0_10.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession_0_10.java
@@ -279,7 +279,12 @@ public class AMQSession_0_10 extends AMQSession<BasicMessageConsumer_0_10, Basic
     {
         flushAcknowledgments(false);
     }
-    
+
+    @Override
+    public void sendReject(long deliveryTag, boolean reQueue) {
+        rejectMessage(deliveryTag, reQueue);
+    }
+
     void flushAcknowledgments(boolean setSyncBit)
     {
         synchronized (unacked)

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/BasicMessageConsumer.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/BasicMessageConsumer.java
@@ -796,7 +796,10 @@ public abstract class BasicMessageConsumer<U> extends Closeable implements Messa
                 } else {
                     _synchronousQueue.put(new DelayedObject(0, jmsMessage));
                 }
-                _logger.debug("dest="+ _destination.getQueueName()+  " added message " + _synchronousQueue.size() + "]");
+                if(_logger.isDebugEnabled()) {
+                    _logger.debug("dest="+ _destination.getQueueName()+  " added message "
+                            + _synchronousQueue.size() + "]");
+                }
             }
         }
         catch (Exception e)

--- a/modules/andes-core/client/src/test/java/org/wso2/andes/unit/message/TestAMQSession.java
+++ b/modules/andes-core/client/src/test/java/org/wso2/andes/unit/message/TestAMQSession.java
@@ -64,6 +64,10 @@ public class TestAMQSession extends AMQSession<BasicMessageConsumer_0_8, BasicMe
 
     }
 
+    public void sendReject(long deliveryTag, boolean reQueue) {
+
+    }
+
     public TopicSubscriber createDurableSubscriber(Topic topic, String name) throws JMSException
     {
         return null;


### PR DESCRIPTION
Changes included

1. Recover() event is brought into inbound disruptor
2. Reject() event is brought into inbound disruptor
3. Channel MessageStatus now has a RECOVERED state. 
4. Client side message rejection at recover() call is changed. 

Issue here is when messages are sent to client broker considers them as delivered messages. They get buffered in client side. Even if consumer application does not see these messages they are considered delivered once. 

Now messages are rejected with reQueue=false when they are in the client-side buffer. There from server side the delivery counts are adjusted to consider they are not delivered. 

During following test message status dump becomes as follows. 

 QueueConnectionFactory connFactory = (QueueConnectionFactory) ctx.lookup(CF_NAME);
        QueueConnection queueConnection = connFactory.createQueueConnection();
        queueConnection.start();
        QueueSession queueSession =
                queueConnection.createQueueSession(false,Session.CLIENT_ACKNOWLEDGE);

        //Receive message
        Queue queue =  (Queue) ctx.lookup(queueName);
        MessageConsumer queueReceiver = queueSession.createConsumer(queue);
//        queueReceiver.setMessageListener(new SampleMessageListener(
//                queueConnection, queueSession, queueReceiver,delay));
        int currentMsgCount = 0;
        while (currentMsgCount < messageCountToRead) {
            TextMessage message = (TextMessage) queueReceiver.receive();
            if(message != null) {
                System.out.println("("+currentMsgCount+") "+"Got message ==>" + message.getText());
                currentMsgCount++;
                queueSession.recover();
                try {
                    Thread.sleep(5000);
                } catch (InterruptedException e) {
                    //silently ignore
                }
            }
        }

hasithaQ,hasithaQ|51351268724310019-51351315732496384,Message ID 51351315721224193,Message Header null,Destination hasithaQ,Message status READ>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>,Slot Info { Id : hasithaQ|51351268724310019-51351315732496384 States : [CREATED] Is overlapping : false Destination : hasithaQ},Timestamp 1488865736943,Expiration time 0,Channels sent 546a7f1c-4d06-4c09-bac6-33a5fd0eac3b : DISPATCHED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>> |
