### PR TITLE
MB-1901 issue fixed.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
@@ -91,8 +91,7 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
             try {
                 if (deliveryEventData.isErrorOccurred()) {
                     onSendError(message, subscription);
-                    
-                    routeMessageToDLC(message, subscription, deliveryEventData.isErrorOccurred());
+                    routeMessageToDLC(message, subscription);
                     return;
                 }
                 if (!message.isStale()) {
@@ -131,7 +130,7 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
                 }
             } catch (ProtocolDeliveryRulesFailureException e) {
                 onSendError(message, subscription);
-                routeMessageToDLC(message, subscription, false);
+                routeMessageToDLC(message, subscription);
 
             } catch (SubscriptionAlreadyClosedException ex) {
                 //we do not log the error as subscriber is closing this is an expected exception.
@@ -235,13 +234,12 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
      * @param message Meta data for the message
      */
     private void routeMessageToDLC(DeliverableAndesMetadata message,
-                                   AndesSubscription subscription,
-                                   boolean internalErrorOccurred)
+                                   AndesSubscription subscription)
                                    throws AndesException {
 
         // If message is a queue message we move the message to the Dead Letter Channel
         // since topics doesn't have a Dead Letter Channel
-        if ((!internalErrorOccurred) && subscription.isDurable()) {
+        if (subscription.isDurable()) {
             log.warn("Moving message to Dead Letter Channel Due to Send Error. Message ID " + message.getMessageID());
             try {
                 Andes.getInstance().moveMessageToDeadLetterChannel(message, message.getDestination());


### PR DESCRIPTION
If durable queue/topic subscriber got an error while sending the message, then it is routed to the DLC.
But in the current implementation, if any error occurred, the message got deleted instead of routing to DLC.
The reason is we are setting internalErrorOccurred to true. This PR modified routeMessageToDLC method
by removing the above-mentioned parameter. Now messages will be routed to DCL in a case of error
situation while sending. Only nondurable topic subscriber messages will be discarded.