### PR TITLE
[MB-1909] fixed issue in safe zone update

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -37,6 +37,7 @@ import org.wso2.andes.kernel.disruptor.inbound.InboundTransactionEvent;
 import org.wso2.andes.kernel.disruptor.inbound.PubAckHandler;
 import org.wso2.andes.kernel.dtx.DistributedTransaction;
 import org.wso2.andes.kernel.dtx.DtxRegistry;
+import org.wso2.andes.kernel.slot.SlotMessageCounter;
 import org.wso2.andes.kernel.subscription.AndesSubscription;
 import org.wso2.andes.kernel.subscription.AndesSubscriptionManager;
 import org.wso2.andes.kernel.subscription.StorageQueue;
@@ -205,13 +206,15 @@ public class Andes {
      * Start the safe zone calculation worker. The safe zone is used to decide if a slot can be safely deleted,
      * assuming all messages in the slot range has been delivered.
      */
-    public void startSafeZoneAnalysisWorker() {
+    public void startSafeZoneUpdateWorkers() {
         SafeZoneUpdateEventTriggeringTask safeZoneUpdateTask = new SafeZoneUpdateEventTriggeringTask(
                 inboundEventManager);
 
         log.info("Starting Safe Zone Calculator for slots.");
         safeZoneUpdateScheduler
                 .scheduleAtFixedRate(safeZoneUpdateTask, 5, safeZoneUpdateTriggerInterval, TimeUnit.MILLISECONDS);
+
+        SlotMessageCounter.getInstance().scheduleSubmitSlotToCoordinatorTimer();
 
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
@@ -128,7 +128,7 @@ public class AndesKernelBoot {
         syncNodeWithClusterState();
         registerMBeans();
         startThriftServer();
-        Andes.getInstance().startSafeZoneAnalysisWorker();
+        Andes.getInstance().startSafeZoneUpdateWorkers();
         int slotDeletingWorkerCount = AndesConfigurationManager.readValue
                 (AndesConfiguration.PERFORMANCE_TUNING_SLOT_DELETE_WORKER_COUNT);
         int maxNumberOfPendingSlotsToDelete = AndesConfigurationManager.readValue


### PR DESCRIPTION
Fixes the issue of the safe zone not getting updated in a fail-over scenario reported at https://wso2.org/jira/browse/MB-1909

The issue was due to the fact that 'slotSubmitLoopSkipCount' in SlotMessageCounter(which is compared with SLOT_SUBMIT_LOOP_SKIP_COUNT_THRESHOLD to update the safezone) is not being reset when a connection exception occurs when the coordinator goes down. 

Removed 'slotSubmitLoopSkipCount' itself since the operation to update the safe zone already happens as a scheduled task.