### PR TITLE
XA transactions fail-over testing fixes

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/XASession_9_1.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/XASession_9_1.java
@@ -231,6 +231,7 @@ class XASession_9_1 extends AMQSession_0_8 implements XASession, XAQueueSession,
      * @throws AMQException      if server sends back a error response
      */
     public XaStatus forget(Xid xid) throws FailoverException, AMQException, XAException {
+
         throwErrorIfClosed();
 
         DtxForgetBody dtxForgetBody = methodRegistry

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/XASession_9_1.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/XASession_9_1.java
@@ -62,6 +62,7 @@ import javax.jms.TopicSession;
 import javax.jms.XAQueueSession;
 import javax.jms.XASession;
 import javax.jms.XATopicSession;
+import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
@@ -131,7 +132,9 @@ class XASession_9_1 extends AMQSession_0_8 implements XASession, XAQueueSession,
      * @throws FailoverException when a connection issue is detected
      * @throws AMQException      when an error is detected in AMQ state manager
      */
-    XaStatus startDtx(Xid xid, int flag) throws FailoverException, AMQException {
+    XaStatus startDtx(Xid xid, int flag) throws FailoverException, AMQException, XAException {
+
+        throwErrorIfClosed();
 
         DtxStartBody dtxStartBody = methodRegistry
                 .createDtxStartBody(xid.getFormatId(), xid.getGlobalTransactionId(), xid.getBranchQualifier(),
@@ -154,7 +157,10 @@ class XASession_9_1 extends AMQSession_0_8 implements XASession, XAQueueSession,
      * @throws FailoverException when a connection issue is detected
      * @throws AMQException      when an error is detected in AMQ state manager
      */
-    public XaStatus endDtx(Xid xid, int flag) throws FailoverException, AMQException {
+    public XaStatus endDtx(Xid xid, int flag) throws FailoverException, AMQException, XAException {
+
+        throwErrorIfClosed();
+
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Sending dtx.end for channel " + _channelId + ", xid " + xid);
         }
@@ -171,7 +177,10 @@ class XASession_9_1 extends AMQSession_0_8 implements XASession, XAQueueSession,
         return XaStatus.valueOf(response.getXaResult());
     }
 
-    public XaStatus prepareDtx(Xid xid) throws FailoverException, AMQException {
+    public XaStatus prepareDtx(Xid xid) throws FailoverException, AMQException, XAException {
+
+        throwErrorIfClosed();
+
         DtxPrepareBody dtxPrepareBody = methodRegistry
                 .createDtxPrepareBody(xid.getFormatId(), xid.getGlobalTransactionId(), xid.getBranchQualifier());
 
@@ -183,7 +192,10 @@ class XASession_9_1 extends AMQSession_0_8 implements XASession, XAQueueSession,
         return XaStatus.valueOf(response.getXaResult());
     }
 
-    public XaStatus commitDtx(Xid xid, boolean onePhase) throws FailoverException, AMQException {
+    public XaStatus commitDtx(Xid xid, boolean onePhase) throws FailoverException, AMQException, XAException {
+
+        throwErrorIfClosed();
+
         DtxCommitBody dtxCommitBody = methodRegistry
                 .createDtxCommitBody(xid.getFormatId(), xid.getGlobalTransactionId(), xid.getBranchQualifier(), onePhase);
 
@@ -195,7 +207,10 @@ class XASession_9_1 extends AMQSession_0_8 implements XASession, XAQueueSession,
         return XaStatus.valueOf(response.getXaResult());
     }
 
-    public XaStatus rollbackDtx(Xid xid) throws FailoverException, AMQException {
+    public XaStatus rollbackDtx(Xid xid) throws FailoverException, AMQException, XAException {
+
+        throwErrorIfClosed();
+
         DtxRollbackBody dtxRollbackBody = methodRegistry
                 .createDtxRollbackBody(xid.getFormatId(), xid.getGlobalTransactionId(), xid.getBranchQualifier());
 
@@ -215,7 +230,9 @@ class XASession_9_1 extends AMQSession_0_8 implements XASession, XAQueueSession,
      * @throws FailoverException if failover process started during communication with server
      * @throws AMQException      if server sends back a error response
      */
-    public XaStatus forget(Xid xid) throws FailoverException, AMQException {
+    public XaStatus forget(Xid xid) throws FailoverException, AMQException, XAException {
+        throwErrorIfClosed();
+
         DtxForgetBody dtxForgetBody = methodRegistry
                 .createDtxForgetBody(xid.getFormatId(), xid.getGlobalTransactionId(), xid.getBranchQualifier());
 
@@ -236,7 +253,10 @@ class XASession_9_1 extends AMQSession_0_8 implements XASession, XAQueueSession,
      * @throws FailoverException if failover process started during communication with server
      * @throws AMQException      if server sends back a error response
      */
-    public XaStatus setDtxTimeout(Xid xid, int timeout) throws FailoverException, AMQException {
+    public XaStatus setDtxTimeout(Xid xid, int timeout) throws FailoverException, AMQException, XAException {
+
+        throwErrorIfClosed();
+
         DtxSetTimeoutBody dtxSetTimeoutBody = methodRegistry
                 .createDtxSetTimeoutBody(xid.getFormatId(), xid.getGlobalTransactionId(), xid.getBranchQualifier(),
                                          timeout);
@@ -256,7 +276,10 @@ class XASession_9_1 extends AMQSession_0_8 implements XASession, XAQueueSession,
      * @throws FailoverException if failover process started during communication with server
      * @throws AMQException      if server sends back a error response
      */
-    public List<Xid> recoverDtxTransactions() throws FailoverException, AMQException {
+    public List<Xid> recoverDtxTransactions() throws FailoverException, AMQException, XAException {
+
+        throwErrorIfClosed();
+
         DtxRecoverBody dtxRecoverBody = methodRegistry.createDtxRecoverBody();
 
         AMQMethodEvent amqMethodEvent = _connection._protocolHandler
@@ -294,4 +317,18 @@ class XASession_9_1 extends AMQSession_0_8 implements XASession, XAQueueSession,
     public TopicSession getTopicSession() throws JMSException {
         return (TopicSession) getSession();
     }
+
+    /**
+     * Throw {@link XAException} if the connection is closed
+     *
+     * @throws XAException if connection not active
+     */
+    private void throwErrorIfClosed() throws XAException {
+        if (isClosed()) {
+            XAException xaException = new XAException("Session is already closed");
+            xaException.errorCode = XAException.XA_RBCOMMFAIL;
+            throw xaException;
+        }
+    }
+
 }

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/jms/FailoverPolicy.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/jms/FailoverPolicy.java
@@ -22,6 +22,7 @@ package org.wso2.andes.jms;
 
 import org.wso2.andes.jms.failover.FailoverExchangeMethod;
 import org.wso2.andes.jms.failover.FailoverMethod;
+import org.wso2.andes.jms.failover.FailoverOneTime;
 import org.wso2.andes.jms.failover.FailoverRoundRobinServers;
 import org.wso2.andes.jms.failover.FailoverSingleServer;
 import org.wso2.andes.jms.failover.NoFailover;
@@ -86,20 +87,19 @@ public class FailoverPolicy
             }
             else
             {
-                if (failoverMethod.equals(FailoverMethod.ROUND_ROBIN))
-                {
+                if (failoverMethod.equals(FailoverMethod.ROUND_ROBIN)) {
                     method = new FailoverRoundRobinServers(connectionDetails);
-                }
-                else if (failoverMethod.equals(FailoverMethod.FAILOVER_EXCHANGE))
-                {
+
+                } else if (failoverMethod.equals(FailoverMethod.FAILOVER_EXCHANGE)) {
                     method = new FailoverExchangeMethod(connectionDetails, conn);
-                }
-                else if (failoverMethod.equals(FailoverMethod.NO_FAILOVER))
-                {
+
+                } else if (failoverMethod.equals(FailoverMethod.NO_FAILOVER)) {
                     method = new NoFailover(connectionDetails);
-                }
-                else
-                {
+
+                } else if (failoverMethod.equals(FailoverMethod.ONE_TIME)) {
+                    method = new FailoverOneTime(connectionDetails);
+
+                } else {
                     try
                     {
                         Class[] constructorSpec = { ConnectionURL.class };

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/jms/failover/FailoverMethod.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/jms/failover/FailoverMethod.java
@@ -27,6 +27,7 @@ public interface FailoverMethod
 {
     public static final String SINGLE_BROKER = "singlebroker";
     public static final String ROUND_ROBIN = "roundrobin";
+    public static final String ONE_TIME = "onetime";
     public static final String FAILOVER_EXCHANGE= "failover_exchange";
     public static final String RANDOM = "random";
     public static final String NO_FAILOVER = "nofailover";

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/jms/failover/FailoverOneTime.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/jms/failover/FailoverOneTime.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.jms.failover;
+
+import org.wso2.andes.jms.ConnectionURL;
+
+/**
+ * Extend the Round Robin Failover Model to gain retry functionality but once connected do not attempt to failover.
+ */
+public class FailoverOneTime extends FailoverRoundRobinServers {
+    private boolean _connected = false;
+
+    public FailoverOneTime(ConnectionURL connectionDetails) {
+        super(connectionDetails);
+    }
+
+    @Override
+    public void attainedConnection() {
+        _connected = true;
+        _currentCycleRetries = _cycleRetries;
+        _currentServerRetry = _serverRetries;
+    }
+
+    @Override
+    public String methodName() {
+        return "OneTimeFailover";
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + (_connected ? "Connection attained." : "Never connected.") + "\n";
+    }
+
+}

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/jms/failover/FailoverRoundRobinServers.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/jms/failover/FailoverRoundRobinServers.java
@@ -35,16 +35,16 @@ public class FailoverRoundRobinServers implements FailoverMethod
     private int _currentBrokerIndex = 0;
 
     /** The number of times to retry connecting for each server */
-    private int _serverRetries;
+    int _serverRetries;
 
     /** The current number of retry attempts made */
-    private int _currentServerRetry = 0;
+    int _currentServerRetry = 0;
 
     /** The number of times to cycle through the servers */
-    private int _cycleRetries;
+    int _cycleRetries;
 
     /** The current number of cycles performed. */
-    private int _currentCycleRetries = 0;
+    int _currentCycleRetries = 0;
 
     /** Array of BrokerDetail used to make connections. */
     protected ConnectionURL _connectionDetails;


### PR DESCRIPTION
Suggestions for a different failover policy name is welcomed. :smiley: Currently we use the name "onetime". Broker URL will look something like below.

```
connectionfactory.QueueConnectionFactory = amqp://admin:admin@clientID/carbon?failover='onetime'&cyclecount='2'&brokerlist='tcp://localhost:5673?retries='5'&connectdelay='50';tcp://localhost:5674?retries='5'&connectdelay='50';tcp://localhost:5675?retries='5'&connectdelay='50''
```