### PR TITLE
[MB-1912] issue in non-durable subscription failover

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionManager.java
@@ -260,7 +260,8 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
     }
 
     /**
-     * Remove non-local subscription from registry, unbind subscription from queue and remove from database.
+     * Remove non-local subscription from registry, remove from the database and delete queue if it is the last
+     * non-durable subscription for its queue.
      *
      * @param subscription AndesSubscription to close
      * @throws AndesException if any error is occurred when unbinding subscription or deleting the queue
@@ -281,7 +282,8 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
 
         StorageQueue storageQueue = subscription.getStorageQueue();
         // If there are no subscriptions for this queue, then delete it
-        if (!storageQueue.isDurable() && storageQueue.getBoundSubscriptions().isEmpty()) {
+        if (!storageQueue.isDurable()
+            && (0 == numberOfSubscriptionsInCluster(storageQueue.getName(), subscription.getProtocolType()))) {
 
             AndesContextInformationManager contextInformationManager = AndesContext.getInstance()
                     .getAndesContextInformationManager();
@@ -293,7 +295,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
     }
 
     /**
-     * Remove non-local subscription from registry and unbind subscription from queue.
+     * Remove non-local subscription from registry.
      *
      * @param subscription AndesSubscription to close
      * @throws AndesException if any error is occurred when unbinding subscription or deleting the queue


### PR DESCRIPTION
The issue is tracked at https://wso2.org/jira/browse/MB-1912

The issue was caused by the fact that subscriptions are not bound to storage queues if the subscription is a remote one. Hence when a node with non-durable subscriptions get killed, newly appointed coordiantor would delete the bound queue upon removal of the first subscription itself. The resolution was get the actuall subscription count across the cluster from the subscription registry prior to deleting the queue