### PR TITLE
[MB-1887] Fix message recover issue

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/AMQPLocalSubscription.java
@@ -26,7 +26,6 @@ import org.wso2.andes.kernel.AndesAckData;
 import org.wso2.andes.kernel.AndesContent;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesMessageMetadata;
-import org.wso2.andes.kernel.AndesUtils;
 import org.wso2.andes.kernel.ProtocolDeliveryFailureException;
 import org.wso2.andes.kernel.ProtocolDeliveryRulesFailureException;
 import org.wso2.andes.kernel.ProtocolMessage;
@@ -243,22 +242,23 @@ public class AMQPLocalSubscription implements OutboundSubscription {
             if (amqpSubscription instanceof SubscriptionImpl.AckSubscription) {
 
                 MessageTracer.trace(messageID, "",
-                                    "Sending message " + msgHeaderStringID + " messageID-" + messageID + "-to channel "
-                                    + getChannelID());
-
+                                    "Sending message " + msgHeaderStringID
+                                            + "-to "
+                                            + "channel " + getChannelID());
                 amqpSubscription.send(queueEntry);
+
             } else if (amqpSubscription instanceof SubscriptionImpl.NoAckSubscription) {
-                MessageTracer.trace(messageID, "",
-                                    "Sending message " + msgHeaderStringID + " messageID-" + messageID + "-to channel "
-                                    + getChannelID());
+
+                MessageTracer.trace(messageID, "", "Sending message "
+                        + msgHeaderStringID + "-to channel " + getChannelID());
 
                 amqpSubscription.send(queueEntry);
 
                 // After sending message we simulate acknowledgment for NoAckSubscription
                 UUID channelID = ((SubscriptionImpl.NoAckSubscription) amqpSubscription).getChannel().getId();
-                AndesAckData andesAckData = AndesUtils.generateAndesAckMessage(channelID, messageID);
-
+                AndesAckData andesAckData = new AndesAckData(channelID, messageID);
                 Andes.getInstance().ackReceived(andesAckData);
+
             } else {
                 throw new AndesException("Error occurred while delivering message. Unexpected Subscription type for "
                         + "message with ID : " + msgHeaderStringID);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
@@ -27,6 +27,7 @@ import org.wso2.andes.framing.AMQShortString;
 import org.wso2.andes.framing.abstraction.ContentChunk;
 import org.wso2.andes.kernel.Andes;
 import org.wso2.andes.kernel.AndesAckData;
+import org.wso2.andes.kernel.AndesAckEvent;
 import org.wso2.andes.kernel.AndesChannel;
 import org.wso2.andes.kernel.AndesContext;
 import org.wso2.andes.kernel.AndesException;
@@ -34,19 +35,18 @@ import org.wso2.andes.kernel.AndesMessage;
 import org.wso2.andes.kernel.AndesMessageMetadata;
 import org.wso2.andes.kernel.AndesMessagePart;
 import org.wso2.andes.kernel.AndesUtils;
-import org.wso2.andes.kernel.DeliverableAndesMetadata;
 import org.wso2.andes.kernel.DisablePubAckImpl;
 import org.wso2.andes.kernel.MessagingEngine;
 import org.wso2.andes.kernel.ProtocolType;
 import org.wso2.andes.kernel.QueueBrowserMessageFlusher;
 import org.wso2.andes.kernel.SubscriptionAlreadyExistsException;
+import org.wso2.andes.kernel.disruptor.DisruptorEventCallback;
 import org.wso2.andes.kernel.disruptor.inbound.InboundBindingEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundExchangeEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundQueueEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundSubscriptionEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundTransactionEvent;
 import org.wso2.andes.kernel.disruptor.inbound.PubAckHandler;
-import org.wso2.andes.kernel.subscription.AndesSubscription;
 import org.wso2.andes.kernel.subscription.OutboundSubscription;
 import org.wso2.andes.kernel.subscription.StorageQueue;
 import org.wso2.andes.kernel.subscription.SubscriberConnection;
@@ -58,14 +58,13 @@ import org.wso2.andes.server.exchange.Exchange;
 import org.wso2.andes.server.message.AMQMessage;
 import org.wso2.andes.server.queue.AMQQueue;
 import org.wso2.andes.server.queue.IncomingMessage;
-import org.wso2.andes.server.queue.QueueEntry;
 import org.wso2.andes.server.store.StorableMessageMetaData;
 import org.wso2.andes.server.subscription.Subscription;
 import org.wso2.andes.server.subscription.SubscriptionImpl;
+import org.wso2.andes.tools.utils.MessageTracer;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -89,71 +88,23 @@ public class QpidAndesBridge {
     /**
      * Ignore pub acknowledgements in AMQP. AMQP doesn't have pub acks
      */
-    public static PubAckHandler pubAckHandler;
+    private static PubAckHandler pubAckHandler;
 
     /**
-     * Recover messages
+     * Recover messages of AMQP channel
      *
-     * @param messages
-     *         messages subjected to recover
-     * @param channel
-     * @throws AMQException
+     * @param channel           AMQP channel to recover messages
+     * @param recoverOKCallback Callback to send recover-ok
+     * @throws AMQException exception on recovering messages of channel
      */
-    //TODO: review and fix this method. Both qpid and andes track un-acked messages. Giving control to Andes
-    public static void recover(Collection<QueueEntry> messages, AMQChannel channel) throws AMQException {
+    public static void recoverMessagesOfChannel(AMQChannel channel,
+                                                DisruptorEventCallback recoverOKCallback) throws AMQException {
         try {
             UUID channelID = channel.getId();
-//            AndesSubscription localSubscription = AndesContext.getInstance().
-//                    getAndesSubscriptionManager().getSubscriptionByProtocolChannel(channel.getId());
-//
-//            if (null == localSubscription) {
-//                log.warn("Cannot handle recover. Subscription not found for channel " + channelID);
-//                return;
-//            }
-//
-//            ArrayList<DeliverableAndesMetadata> recoveredMetadataList = new ArrayList<>(messages.size());
-//
-//            for (QueueEntry message : messages) {
-//                ServerMessage serverMessage = message.getMessage();
-//                if (serverMessage instanceof AMQMessage) {
-//                    DeliverableAndesMetadata messageMetadata = getDeliverableAndesMetadata(localSubscription,
-//                                                                                           (AMQMessage) serverMessage);
-//
-//                    messageMetadata.markAsNackedByClient(channel.getId());
-//                    recoveredMetadataList.add(messageMetadata);
-//
-//                    if (log.isDebugEnabled()) {
-//                        log.debug("AMQP BRIDGE: recovered message id= " + messageMetadata.getMessageID() + " channel = "
-//                                  + channelID);
-//                    }
-//
-//                } else {
-//                    log.warn("Cannot recover message since server message is not AMQMessage type. Message ID: "
-//                             + serverMessage.getMessageNumber());
-//                }
-//            }
-            Andes.getInstance().recoverMessage(channelID);
+            Andes.getInstance().recoverMessagesOfChannel(channelID, recoverOKCallback);
         } catch (AndesException e) {
             throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error while handling recovered message", e);
         }
-    }
-
-    /**
-     * Get matching DeliverableAndesMetadata for the serverMessage
-     *
-     * @param localSubscription
-     *         subscription used to send the message
-     * @param message
-     *         message
-     * @return DeliverableAndesMetadata
-     */
-    private static DeliverableAndesMetadata getDeliverableAndesMetadata(AndesSubscription localSubscription,
-                                                                        AMQMessage message) {
-        return localSubscription.getSubscriberConnection().getUnAckedMessage(message.getMessageId());
-    }
-
-    static {
-        pubAckHandler = new DisablePubAckImpl();
     }
 
     /**
@@ -161,6 +112,10 @@ public class QpidAndesBridge {
      * Andes. And the class doesn't store any state information
      */
     private QpidAndesBridge() {
+    }
+
+    static {
+        pubAckHandler = new DisablePubAckImpl();
     }
 
     /**
@@ -305,64 +260,62 @@ public class QpidAndesBridge {
     /**
      * Read a message content chunk form store
      *
-     * @param messageID       id of the message
+     * @param messageId       id of the message
      * @param offsetInMessage offset to be read
      * @param dst             buffer to be filled by content bytes
      * @return written content length
      * @throws AMQException
      */
-    public static int getMessageContentChunk(long messageID, int offsetInMessage, ByteBuffer dst) throws AMQException {
+    public static int getMessageContentChunk(long messageId, int offsetInMessage, ByteBuffer dst) throws AMQException {
         int contentLenWritten;
         try {
-            contentLenWritten = AMQPUtils.fillBufferFromContent(messageID, offsetInMessage, dst);
+            contentLenWritten = AMQPUtils.fillBufferFromContent(messageId, offsetInMessage, dst);
         } catch (AndesException e) {
             log.error("Error in getting message content", e);
-            throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error in getting message content chunk messageID " + messageID + " offset=" + offsetInMessage, e);
+            throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error in getting message content chunk messageId "
+                    + messageId + " offset=" + offsetInMessage, e);
         }
         return contentLenWritten;
     }
 
-    public static void ackReceived(UUID channelID, long messageID)
+    public static void ackReceived(UUID channelId, long messageId)
             throws AMQException {
         try {
             if (log.isDebugEnabled()) {
-                log.debug("ack received for message id= " + messageID + " channelId= " + channelID);
+                log.debug("ack received for message id= " + messageId + " channelId= " + channelId);
             }
-            //This can be different from routing key in hierarchical topic case
-            AndesAckData andesAckData = AndesUtils.generateAndesAckMessage(channelID, messageID);
-            if(null == andesAckData) {
-                return;
-            }
+            //Tracing Message
+            MessageTracer.trace(messageId, MessageTracer.ACK_RECEIVED_FROM_PROTOCOL);
+            AndesAckData andesAckData = new AndesAckData(channelId, messageId);
             Andes.getInstance().ackReceived(andesAckData);
         } catch (AndesException e) {
             log.error("Exception occurred while handling ack", e);
-            throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error in getting handling ack for " + messageID, e);
+            throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error in getting handling ack for " + messageId, e);
         }
     }
 
     /**
      * Reject message is received
+     *
      * @param message message subjected to rejection
      * @param channel channel by which reject message is received
-     * @throws AMQException
+     * @param reQueue true if message should be re-queued to subscriber
+     * @throws AMQException on a message re-schedule issue
      */
-    public static void rejectMessage(AMQMessage message, AMQChannel channel) throws AMQException {
+    public static void rejectMessage(AMQMessage message, AMQChannel channel, boolean reQueue) throws AMQException {
         try {
-            AndesSubscription localSubscription = AndesContext.getInstance().
-                    getAndesSubscriptionManager().getSubscriptionByProtocolChannel(channel.getId());
-
-            DeliverableAndesMetadata rejectedMessage = localSubscription.getSubscriberConnection()
-                    .getUnAckedMessage(message.getMessageId());
-
             channel.setLastRejectedMessageId(message.getMessageNumber());
+            boolean isMessageBeyondLastRollback = channel.isMessageBeyondLastRollback(message.getMessageNumber());
 
-            rejectedMessage.setIsBeyondLastRollbackedMessage(channel.isMessageBeyondLastRollback(message.getMessageId()));
+            log.info("Reject received id = " + message.getMessageId() + " channel id= " + channel.getChannelId()
+                    + "regueue = " + reQueue);
 
-            log.debug("AMQP BRIDGE: rejected message id= " + rejectedMessage.getMessageID()
-                    + " channel = " + channel.getId());
-
-            Andes.getInstance().messageRejected(rejectedMessage, channel.getId());
-
+            Andes.getInstance().messageRejected(message.getMessageId(), channel.getId(),
+                    reQueue, isMessageBeyondLastRollback);
+            if (log.isDebugEnabled()) {
+                log.debug("AMQP BRIDGE: rejected message id= " + message.getMessageId()
+                        + " channel = " + channel.getId() + " reQueue= " + reQueue);
+            }
         } catch (AndesException e) {
             throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error while handling rejected message", e);
         }
@@ -690,14 +643,4 @@ public class QpidAndesBridge {
             }
         }
     }
-
-    /**
-     * Channel closed. Clear status
-     *
-     * @param channelID id of the closed channel
-     */
-    public static void channelIsClosing(UUID channelID) {
-        Andes.getInstance().clientConnectionClosed(channelID);
-    }
-
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesAckData.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesAckData.java
@@ -1,87 +1,64 @@
 /*
- * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *
- * WSO2 Inc. licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License.
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.wso2.andes.kernel;
 
+
 import java.util.UUID;
 
 /**
- * Wrapper class of message acknowledgment data publish to disruptor
+ * Container class to hold acknowledge information from protocols
  */
 public class AndesAckData {
 
     /**
-     * Acknowledged message
+     * Id of acknowledged message
      */
-    private DeliverableAndesMetadata acknowledgedMessage;
+    private long messageId;
 
     /**
-     * ID of the channel acknowledge is received
+     * Id of the channel acknowledge is received
      */
-    private UUID channelID;
+    private UUID channelId;
 
     /**
-     * Holds if acknowledged message is ready to be removed. If all channels
-     * acknowledged it becomes removable. Message reference cannot be used here
-     * as we need to keep it in disruptor data holder
+     * Generate AndesAckData object.
+     *
+     * @param channelId ID of the channel ack is received
+     * @param messageId Id of the message being acknowledged
      */
-    private boolean isBaringMessageRemovable = false;
-
-    /**
-     * Generate AndesAckData object. This holds acknowledge event in disruptor
-     * @param channelID ID of the channel ack is received
-     * @param acknowledgedMessage message being acknowledged
-     */
-    public AndesAckData(UUID channelID, DeliverableAndesMetadata acknowledgedMessage) {
-        this.channelID = channelID;
-        this.acknowledgedMessage = acknowledgedMessage;
+    public AndesAckData(UUID channelId, long messageId) {
+        this.channelId = channelId;
+        this.messageId = messageId;
     }
 
     /**
-     * Get the reference of the message being acknowledged
+     * Get the id of the message being acknowledged
+     *
      * @return Metadata of the acknowledged message
      */
-    public DeliverableAndesMetadata getAcknowledgedMessage() {
-        return acknowledgedMessage;
+    public long getMessageId() {
+        return messageId;
     }
 
     /**
-     * Get ID of the channel acknowledgement is received
+     * Get Id of the channel acknowledgement is received
+     *
      * @return channel ID
      */
-    public UUID getChannelID() {
-        return channelID;
+    public UUID getChannelId() {
+        return channelId;
     }
-
-    /**
-     * Check if message being acknowledged is ready to be removed
-     * @return true if removable
-     */
-    public boolean isBaringMessageRemovable() {
-        return isBaringMessageRemovable;
-    }
-
-    /**
-     * Set message being acknowledged is ready to be removed. This happens
-     * if acknowledgements are received from all channels
-     */
-    public void setBaringMessageRemovable() {
-        this.isBaringMessageRemovable = true;
-    }
-
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesAckEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesAckEvent.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.subscription.AndesSubscription;
+import org.wso2.andes.metrics.MetricsConstants;
+import org.wso2.andes.tools.utils.MessageTracer;
+import org.wso2.carbon.metrics.manager.Counter;
+import org.wso2.carbon.metrics.manager.Level;
+import org.wso2.carbon.metrics.manager.Meter;
+import org.wso2.carbon.metrics.manager.MetricManager;
+
+/**
+ * Wrapper class of message acknowledgment data publish to disruptor
+ */
+public class AndesAckEvent {
+
+    private static Log log = LogFactory.getLog(AndesAckEvent.class);
+    /**
+     * Acknowledgement information form protocol
+     */
+    private AndesAckData ackData;
+
+    /**
+     * Holds DeliverableAndesMetadata object reference to match with acknowledged message
+     */
+    private DeliverableAndesMetadata metadataReference;
+
+    /**
+     * Holds if acknowledged message is ready to be removed. If all channels
+     * acknowledged it becomes removable. Message reference cannot be used here
+     * as we need to keep it in disruptor data holder
+     */
+    private boolean isBaringMessageRemovable = false;
+
+    /**
+     * Generate AndesAckEvent object. This holds acknowledge event in disruptor
+     *
+     * @param ackData acknowledge information from channel
+     */
+    public AndesAckEvent(AndesAckData ackData) {
+        this.ackData = ackData;
+    }
+
+    /**
+     * Look up and set reference of message acknowledged. Should be called only via a disruptor handler.
+     *
+     * @throws AndesException in case of message reference is not found
+     */
+    public void setMetadataReference() throws AndesException {
+        AndesSubscription localSubscription = AndesContext.getInstance().
+                getAndesSubscriptionManager().getSubscriptionByProtocolChannel(ackData.getChannelId());
+        if (null == localSubscription) {
+            throw new AndesException("Cannot handle acknowledgement for message ID = "
+                    + ackData.getMessageId() + " as subscription is closed "
+                    + "channelID= " + "" + ackData.getChannelId());
+        } else {
+            this.metadataReference = localSubscription.
+                    getSubscriberConnection().getUnAckedMessage(ackData.getMessageId());
+
+        }
+        addTraceLog();
+    }
+
+    /**
+     * Get reference to DeliverableAndesMetadata object that is acknowledged
+     *
+     * @return DeliverableAndesMetadata object being acknowledged
+     */
+    public DeliverableAndesMetadata getMetadataReference() {
+        return metadataReference;
+    }
+
+    /**
+     * Process the acknowledgement event. This call will update message status, return message
+     * if eligible to be removed. For topics message is shared. If all acknowledgements are
+     * received only we should remove message
+     *
+     * @return true if eligible to delete
+     * @throws AndesException on an issue removing the message from store
+     */
+    public boolean processEvent() throws AndesException {
+        // For topics message is shared. If all acknowledgements are received only we should remove message
+        boolean deleteMessage = metadataReference.markAsAcknowledgedByChannel(ackData.getChannelId());
+
+        AndesSubscription subscription = AndesContext.getInstance().getAndesSubscriptionManager()
+                .getSubscriptionByProtocolChannel(ackData.getChannelId());
+
+        subscription.onMessageAck(ackData.getMessageId());
+
+        if (deleteMessage) {
+            if (log.isDebugEnabled()) {
+                log.debug("Ok to delete message id " + ackData.getMessageId());
+            }
+            //it is a must to set this to event container. Otherwise, multiple event handlers will see the status
+            this.isBaringMessageRemovable = true;
+        }
+
+        return deleteMessage;
+    }
+
+    /**
+     * Check if message being acknowledged is ready to be removed
+     *
+     * @return true if removable
+     */
+    public boolean isBaringMessageRemovable() {
+        return isBaringMessageRemovable;
+    }
+
+    /**
+     * Add trace log to message
+     */
+    private void addTraceLog() {
+        //Tracing Message
+        MessageTracer.trace(metadataReference.messageID,
+                metadataReference.getDestination(), MessageTracer.ACK_MESSAGE_REFERENCE_SET_BY_DISRUPTOR);
+
+        //Adding metrics meter for ack rate
+        Meter ackMeter = MetricManager.meter(MetricsConstants.ACK_RECEIVE_RATE
+                + MetricsConstants.METRICS_NAME_SEPARATOR
+                + metadataReference.getMessageRouterName() + MetricsConstants.METRICS_NAME_SEPARATOR
+                + metadataReference.getDestination(), Level.INFO);
+        ackMeter.mark();
+
+        //Adding metrics counter for ack messages
+        Counter counter = MetricManager.counter(MetricsConstants.ACK_MESSAGES + MetricsConstants.METRICS_NAME_SEPARATOR
+                + metadataReference.getMessageRouterName() + MetricsConstants.METRICS_NAME_SEPARATOR
+                + metadataReference.getDestination(), Level.INFO);
+        counter.inc();
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
@@ -348,7 +348,7 @@ public class AndesKernelBoot {
         AndesContext.getInstance().setAndesContextInformationManager(contextInformationManager);
 
         //Create an inbound event manager. This will prepare inbound events to disruptor
-        InboundEventManager inboundEventManager =  new InboundEventManager(subscriptionManager, messagingEngine);
+        InboundEventManager inboundEventManager =  new InboundEventManager(messagingEngine);
         AndesContext.getInstance().setInboundEventManager(inboundEventManager);
 
         DtxRegistry dtxRegistry = new DtxRegistry(messageStore.getDtxStore(), messagingEngine, inboundEventManager);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ChannelMessageStatus.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ChannelMessageStatus.java
@@ -31,61 +31,46 @@ public enum  ChannelMessageStatus {
     /**
      * Message has been dispatched to subscriber
      */
-    DISPATCHED(1),
+    DISPATCHED,
 
     /**
      * Message has been failed to send to its routed consumer
      */
-    SEND_FAILED(2),
+    SEND_FAILED,
 
     /**
      * The consumer has acknowledged receipt of the message
      */
-    ACKED(3),
+    ACKED,
 
     /**
      * Consumer has rejected (NACKED) the message ad it has been buffered again for
      * delivery (possibly to another waiting consumer)
      */
-    NACKED(4),
+    NACKED,
 
     /**
      * Consumer has rejected (NACKED)  the message repeatedly. Consider message is rejected
      * permanently by client. No need to consider for delivery again.
      */
-    CLIENT_REJECTED(5),
+    CLIENT_REJECTED,
+
+    /**
+     * Channel is recovered. Messages will be flushed to some channel again
+     */
+    RECOVERED,
 
     /**
      * Consumer is closed
      */
-    CLOSED(6);
+    CLOSED;
 
-
-    private int code;
 
     //keep next possible states
     private EnumSet<ChannelMessageStatus> next;
 
     //keep previous possible states
     private EnumSet<ChannelMessageStatus> previous;
-
-    /**
-     * Define a message state
-     *
-     * @param code integer representing state
-     */
-    ChannelMessageStatus(int code) {
-        this.code = code;
-    }
-
-    /**
-     * Get code of the state
-     *
-     * @return integer representing state
-     */
-    public int getCode() {
-        return code;
-    }
 
     /**
      * Check if submitted state is an allowed state as per state model
@@ -107,36 +92,28 @@ public enum  ChannelMessageStatus {
         return previous.contains(previousState);
     }
 
-    static ChannelMessageStatus parseSlotState(int state) {
-
-        for (ChannelMessageStatus s : ChannelMessageStatus.values()) {
-            if (s.code == state) {
-                return s;
-            }
-        }
-
-        throw new IllegalArgumentException("Invalid channel message state argument specified: " + state);
-    }
-
     static {
 
         //Channel wise message status begins at DISPATCHED state.
         //If message CLOSED there is no next state for message.
 
-        DISPATCHED.next = EnumSet.of(SEND_FAILED, ACKED, NACKED, CLOSED);
+        DISPATCHED.next = EnumSet.of(SEND_FAILED, ACKED, NACKED, RECOVERED, CLOSED);
         DISPATCHED.previous = EnumSet.complementOf(EnumSet.allOf(ChannelMessageStatus.class));
 
         SEND_FAILED.next = EnumSet.of(DISPATCHED, CLIENT_REJECTED, CLOSED);
         SEND_FAILED.previous = EnumSet.of(DISPATCHED);
 
-        ACKED.next = EnumSet.of(CLOSED);
+        ACKED.next = EnumSet.of(RECOVERED, CLOSED);
         ACKED.previous = EnumSet.of(DISPATCHED);
 
-        NACKED.next = EnumSet.of(DISPATCHED, CLOSED);
+        NACKED.next = EnumSet.of(DISPATCHED, RECOVERED, CLOSED);
         NACKED.previous = EnumSet.of(DISPATCHED);
 
         CLIENT_REJECTED.next = EnumSet.complementOf(EnumSet.allOf(ChannelMessageStatus.class));
         CLIENT_REJECTED.previous = EnumSet.of(SEND_FAILED);
+
+        RECOVERED.next = EnumSet.of(DISPATCHED, CLOSED);
+        RECOVERED.previous = EnumSet.of(DISPATCHED, ACKED, NACKED);
 
         //this is because we directly mark close on channel close
         CLOSED.next = EnumSet.of(SEND_FAILED, CLOSED);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
@@ -191,6 +191,16 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
     }
 
     /**
+     * Rollback message delivery on the channel. It should
+     * not be recorded as a success delivery attempt.
+     *
+     * @param channelID ID of the subscriber channel delivery should be rollback
+     */
+    public void rollbackDelivery(UUID channelID) {
+        channelDeliveryInfo.get(channelID).decrementDeliveryCount();
+    }
+
+    /**
      * Mark the message as buffered. Buffered messages will be scheduled to the subscribers.
      */
     public void markAsBuffered() {
@@ -275,6 +285,16 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
     public void markAsNackedByClient(UUID channelID) {
         ChannelInformation channelInformation = channelDeliveryInfo.get(channelID);
         channelInformation.addChannelStatus(ChannelMessageStatus.NACKED);
+    }
+
+    /**
+     * Record channel recovery
+     *
+     * @param channelID ID of the channel
+     */
+    public void markAsRecoveredByClient(UUID channelID) {
+        ChannelInformation channelInformation = channelDeliveryInfo.get(channelID);
+        channelInformation.addChannelStatus(ChannelMessageStatus.RECOVERED);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
@@ -28,86 +28,65 @@ public enum MessageStatus {
     /**
      * Message has been read from store
      */
-    READ(1),
+    READ,
 
     /**
      * Message has been buffered for delivery
      */
-    BUFFERED(2),
+    BUFFERED,
 
     /**
      * Message has been added to the final async delivery queue (deliverAsynchronously method has been called for
      * the message.)
      */
-    SCHEDULED_TO_SEND(3),
+    SCHEDULED_TO_SEND,
 
     /**
      * In a topic scenario, all subscribed consumers have acknowledged receipt of message
      */
-    ACKED_BY_ALL(4),
+    ACKED_BY_ALL,
 
 
     /**
      * All messages of the slot containing this message have been handled successfully, causing it to be removed
      */
-    SLOT_REMOVED(5),
+    SLOT_REMOVED,
 
     /**
      * Message has expired (JMS Expiration duration sent with the message has passed)
      */
-    EXPIRED(6),
+    EXPIRED,
 
     /**
      * Message is discarded as no valid subscriber to send
      */
-    NO_MATCHING_CONSUMER(7),
+    NO_MATCHING_CONSUMER,
 
     /**
      * Message is moved to the DLC queue
      */
-    DLC_MESSAGE(8),
+    DLC_MESSAGE,
 
     /**
      * Message has been cleared from delivery due to a queue purge event.
      */
-    PURGED(9),
+    PURGED,
 
     /**
      * Message is deleted from the store
      */
-    DELETED(10),
+    DELETED,
 
     /**
      * Slot of the message is returned back to the coordinator, causing message to remove from memory
      */
-    SLOT_RETURNED(11);
-
-
-    private int code;
+    SLOT_RETURNED;
 
     //keep next possible states
     private EnumSet<MessageStatus> next;
 
     //keep previous possible states
     private EnumSet<MessageStatus> previous;
-
-    /**
-     * Define a message state
-     *
-     * @param code integer representing state
-     */
-    MessageStatus(int code) {
-        this.code = code;
-    }
-
-    /**
-     * Get code of the state
-     *
-     * @return integer representing state
-     */
-    public int getCode() {
-        return code;
-    }
 
     /**
      * Check if submitted state is an allowed state as per state model
@@ -128,18 +107,6 @@ public enum MessageStatus {
     public boolean isValidPreviousState(MessageStatus previousState) {
         return previous.contains(previousState);
     }
-
-    static MessageStatus parseMessageState(int state) {
-
-        for (MessageStatus s : MessageStatus.values()) {
-            if (s.code == state) {
-                return s;
-            }
-        }
-
-        throw new IllegalArgumentException("Invalid message state argument specified: " + state);
-    }
-
 
     static {
 
@@ -176,7 +143,7 @@ public enum MessageStatus {
         SLOT_REMOVED.next = EnumSet.complementOf(EnumSet.allOf(MessageStatus.class));
         SLOT_REMOVED.previous = EnumSet.of(DELETED);
 
-        /**
+        /*
          * next status of slot return status can be any state due to subscription could close at any given moment.
          */
         SLOT_RETURNED.next = EnumSet.allOf(MessageStatus.class);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/AckEventBatchHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/AckEventBatchHandler.java
@@ -20,7 +20,7 @@ package org.wso2.andes.kernel.disruptor.inbound;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.andes.kernel.AndesAckData;
+import org.wso2.andes.kernel.AndesAckEvent;
 import org.wso2.andes.kernel.disruptor.InboundEventHandler;
 
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ public class AckEventBatchHandler extends InboundEventHandler {
     /**
      * Batched acknowledgments event list.
      */
-    private final List<AndesAckData> ackDataList;
+    private final List<AndesAckEvent> ackDataList;
 
     /**
      * Number assigned to this handler. Value is less than the groupCount. If the turn value is equal to

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundEventContainer.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundEventContainer.java
@@ -19,7 +19,7 @@
 package org.wso2.andes.kernel.disruptor.inbound;
 
 import com.lmax.disruptor.EventFactory;
-import org.wso2.andes.kernel.AndesAckData;
+import org.wso2.andes.kernel.AndesAckEvent;
 import org.wso2.andes.kernel.AndesChannel;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesMessage;
@@ -68,7 +68,7 @@ public class InboundEventContainer {
     /**
      * Acknowledgments received to disruptor
      */
-    public AndesAckData ackData;
+    public AndesAckEvent ackData;
 
     /**
      * When content chunk processed this boolean is set to false

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundMessageRejectEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundMessageRejectEvent.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.andes.kernel.disruptor.inbound;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.AndesContext;
+import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.kernel.DeliverableAndesMetadata;
+import org.wso2.andes.kernel.subscription.AndesSubscription;
+import org.wso2.andes.tools.utils.MessageTracer;
+
+import java.util.UUID;
+
+/**
+ * Disruptor event handling message reject
+ */
+public class InboundMessageRejectEvent implements AndesInboundStateEvent {
+
+
+    private static Log log = LogFactory.getLog(InboundMessageRejectEvent.class);
+    /**
+     * Channel event type handle by the event object
+     */
+    private EventType eventType;
+
+    /**
+     * Id of the message rejected by client
+     */
+    private long messageId;
+
+    /**
+     * Id of the channel reject is received
+     */
+    private UUID channelId;
+
+    /**
+     * Whether to re-queue the message back to the subscriber
+     */
+    private boolean reQueue;
+
+    /**
+     * This is to handle the messages beyond the actual rollback event, which are rejected from the client side
+     * message buffer. True if the message was rejected after the last rollback event.
+     */
+    private boolean isMessageBeyondLastRollback;
+
+    /**
+     * Supported state events
+     */
+    public enum EventType {
+        /**
+         * Specific client channel close event
+         */
+        MESSAGE_REJECT_EVENT,
+    }
+
+    /**
+     * Create an instance of message reject event
+     *
+     * @param messageId Id of the message rejected
+     * @param channelId Id of the channel message reject received
+     * @param reQueue   whether to re queue message back to subscriber
+     */
+    public InboundMessageRejectEvent(long messageId, UUID channelId, boolean reQueue) {
+        this.messageId = messageId;
+        this.channelId = channelId;
+        this.reQueue = reQueue;
+    }
+
+    /**
+     * Prepare to reject message. This is done prior to inset the
+     * event to disruptor
+     *
+     * @param isMessageBeyondLastRollback True if the message was rejected after the last rollback event.
+     */
+    public void prepareToRejectMessage(boolean isMessageBeyondLastRollback) {
+        this.isMessageBeyondLastRollback = isMessageBeyondLastRollback;
+        this.eventType = EventType.MESSAGE_REJECT_EVENT;
+    }
+
+    @Override
+    public void updateState() throws AndesException {
+        AndesSubscription subscription = AndesContext.getInstance().
+                getAndesSubscriptionManager().getSubscriptionByProtocolChannel(channelId);
+        if (subscription != null) {
+            DeliverableAndesMetadata rejectedMessage = subscription.onMessageReject(messageId, reQueue);
+            rejectedMessage.setIsBeyondLastRollbackedMessage(isMessageBeyondLastRollback);
+            //Tracing message activity
+            MessageTracer.trace(rejectedMessage, MessageTracer.MESSAGE_REJECTED);
+        } else {
+            log.warn("Cannot handle reject. Subscription not found for channel "
+                    + channelId + "Dropping message id= " + messageId);
+        }
+    }
+
+    @Override
+    public String eventInfo() {
+        return eventType.toString();
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/StateEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/StateEventHandler.java
@@ -80,7 +80,7 @@ public class StateEventHandler implements EventHandler<InboundEventContainer> {
     }
 
     private void updateTrackerWithAck(InboundEventContainer event) throws AndesException {
-        DeliverableAndesMetadata acknowledgedMessage = event.ackData.getAcknowledgedMessage();
+        DeliverableAndesMetadata acknowledgedMessage = event.ackData.getMetadataReference();
         //we need both conditions to prevent multiple events seeing that message is deleted
         if (acknowledgedMessage.getLatestState().equals(MessageStatus.DELETED)
                 && event.ackData.isBaringMessageRemovable()) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionFactory.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionFactory.java
@@ -82,12 +82,12 @@ public class AndesSubscriptionFactory {
 
         if(messageRouterName.equals(AMQPUtils.TOPIC_EXCHANGE_NAME)
                 && isBoundQueueDurable) {
-            DurableTopicSubscriber durableTopicSubscriber =
-                    new DurableTopicSubscriber(subscriptionId, subscriptionIdentifier, storageQueue,
+
+            return new DurableTopicSubscriber(subscriptionId, subscriptionIdentifier, storageQueue,
                             protocol, subscriberConnection);
-            durableTopicSubscriber.addConnection(subscriberConnection);
-            return durableTopicSubscriber;
+
         } else {
+
             return new AndesSubscription(subscriptionId, storageQueue, protocol,
                     subscriberConnection);
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/DurableTopicSubscriber.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/DurableTopicSubscriber.java
@@ -43,29 +43,9 @@ public class DurableTopicSubscriber extends AndesSubscription {
     public DurableTopicSubscriber(String subscriptionID, String clientID, StorageQueue storageQueue, ProtocolType
             protocol, SubscriberConnection connectionInfo) {
         super(subscriptionID, storageQueue, protocol, connectionInfo);
-        this.isActive = false;
+        this.isActive = true;
         this.clientID = clientID;
     }
-
-    /**
-     * Update the connection information of the subscriber. Also mark the subscriber
-     * as ACTIVE
-     *
-     * @param connectionInfo new connection information
-     */
-    public void addConnection(SubscriberConnection connectionInfo) throws SubscriptionException {
-        if (isActive) {
-            //An active subscription already exists. Creating another is not permitted
-            throw new SubscriptionAlreadyExistsException("An active subscription already exists with same "
-                    + "subscription id " + getSubscriptionId()
-                    + " bound to " + getStorageQueue()
-                    .getMessageRouterBindingKey());
-        } else {
-            this.subscriberConnection = connectionInfo;
-            isActive = true;
-        }
-    }
-
 
     /**
      * Upon closing subscription underlying connection is removed

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/InactiveSubscriber.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/InactiveSubscriber.java
@@ -42,18 +42,6 @@ public class InactiveSubscriber extends DurableTopicSubscriber{
         isActive = false;
     }
 
-
-    /**
-     * Update the connection information of the subscriber. For mock subscriber
-     * this method is not supported
-     *
-     * @param connectionInfo new connection information
-     */
-    public void addConnection(SubscriberConnection connectionInfo) throws SubscriptionException {
-        throw new UnsupportedOperationException("This operation is not supported for inactive subscriber");
-    }
-
-
     /**
      * Upon closing subscription underlying connection is removed. For mock
      * subscriber there is no underlying connection

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/SubscriberConnection.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/SubscriberConnection.java
@@ -25,6 +25,7 @@ import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesMessageMetadata;
 import org.wso2.andes.kernel.DeliverableAndesMetadata;
 import org.wso2.andes.kernel.ProtocolMessage;
+import org.wso2.andes.kernel.disruptor.DisruptorEventCallback;
 
 import java.util.List;
 import java.util.UUID;
@@ -172,7 +173,7 @@ public class SubscriberConnection {
      * @return true if the send is a success
      * @throws AndesException on an issue writing message to the protocol
      */
-    public boolean writeMessageToConnection(ProtocolMessage messageMetadata, AndesContent content)
+    public synchronized boolean writeMessageToConnection(ProtocolMessage messageMetadata, AndesContent content)
             throws AndesException {
 
         //It is needed to add the message reference to the tracker and increase un-ack message count BEFORE
@@ -247,6 +248,17 @@ public class SubscriberConnection {
     }
 
     /**
+     * Clear tracked sent but un-acknowledged messages. Return the messages of the same view
+     * at the moment it was cleared. While this operation is performed, no new
+     * message will be added to the list.
+     *
+     * @return list of messages tracked when cleaned up
+     */
+    public synchronized List<DeliverableAndesMetadata> clearAndReturnUnackedMessages() {
+        return outBoundMessageTracker.clearAndReturnUnackedMessages();
+    }
+
+    /**
      * Is the underlying protocol connection active and can accept
      * messages
      *
@@ -274,13 +286,13 @@ public class SubscriberConnection {
     }
 
     /**
-     * Perform on reject receive for a message
+     * Perform on reject receive for a message. This will remove message from messages tracked by the connection.
+     *
      * @param messageID id of the message acknowledged
      * @return  DeliverableAndesMetadata reference of message rejected
-     * @throws AndesException
      */
-    public DeliverableAndesMetadata onMessageReject(long messageID) throws AndesException{
-        DeliverableAndesMetadata rejectedMessage = getUnAckedMessage(messageID);
+    public DeliverableAndesMetadata onMessageReject(long messageID) {
+        DeliverableAndesMetadata rejectedMessage = outBoundMessageTracker.removeSentMessageFromTracker(messageID);
         rejectedMessage.markAsNackedByClient(protocolChannelID);
         if (log.isDebugEnabled()) {
             log.debug("Message id= " + messageID + " is rejected by connection " + this);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTopicManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTopicManager.java
@@ -370,15 +370,15 @@ public class MQTTopicManager {
     /**
      * Called by the process of sending rejection for messages which have not being acked
      *
-     * @param metadata which holds information regarding the messages which has not being acked
+     * @param idOfNackedMessage id of the message which has not being acked
      * @param channelID Id of the subscription channel NAC is received
      */
-    private void onMessageNack(DeliverableAndesMetadata metadata, UUID channelID) {
+    private void onMessageNack(long idOfNackedMessage, UUID channelID) {
         try {
-            connector.messageNack(metadata, channelID);
+            connector.messageNack(idOfNackedMessage, channelID);
         } catch (AndesException e) {
             //We do not throw this any further
-            String message = "Error occurred while sending a rejection ack for message " + metadata.getMessageID();
+            String message = "Error occurred while sending a rejection ack for message " + idOfNackedMessage;
             log.error(message, e);
         }
     }
@@ -451,9 +451,7 @@ public class MQTTopicManager {
 
             for (Integer messageID : unackedMessages) {
                 MQTTSubscription subscription = mqtTopics.getSubscription(messageID);
-                DeliverableAndesMetadata mataInformation = subscription.getMessageMetaInformation(messageID);
-                onMessageNack(mataInformation, subscription.getSubscriptionChannel());
-
+                onMessageNack(messageID, subscription.getSubscriptionChannel());
                 if(log.isDebugEnabled()){
                    log.debug("Message null ack sent to message id "+messageID);
                 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/InMemoryConnector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/InMemoryConnector.java
@@ -61,7 +61,7 @@ public class InMemoryConnector implements MQTTConnector {
     }
 
     @Override
-    public void messageNack(DeliverableAndesMetadata metadata, UUID channelID) {
+    public void messageNack(long messageId, UUID channelID) {
 
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/MQTTConnector.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/connectors/MQTTConnector.java
@@ -19,10 +19,7 @@ package org.wso2.andes.mqtt.connectors;
 
 import org.dna.mqtt.wso2.QOSLevel;
 import org.wso2.andes.kernel.AndesException;
-import org.wso2.andes.kernel.AndesMessageMetadata;
-import org.wso2.andes.kernel.DeliverableAndesMetadata;
 import org.wso2.andes.kernel.SubscriptionAlreadyExistsException;
-import org.wso2.andes.kernel.disruptor.inbound.PubAckHandler;
 import org.wso2.andes.mqtt.MQTTException;
 import org.wso2.andes.mqtt.MQTTMessageContext;
 import org.wso2.andes.mqtt.MQTTopicManager;
@@ -46,11 +43,11 @@ public interface MQTTConnector {
 
     /**
      * Triggers when a rejection ack is be initiated, this will be done as a result of ping request
-     * @param metadata the meta information of the message being rejected
+     * @param messageId the Id of the message being rejected
      * @param channelID the ID of the channel reject message is received
      * @throws org.wso2.andes.kernel.AndesException
      */
-    public void messageNack(DeliverableAndesMetadata metadata, UUID channelID) throws AndesException;
+    public void messageNack(long messageId, UUID channelID) throws AndesException;
 
     /**
      * Adds message to the connector to handle an incoming message

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRejectMethodHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/BasicRejectMethodHandler.java
@@ -20,10 +20,6 @@ package org.wso2.andes.server.handler;
 import org.wso2.andes.AMQException;
 import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.framing.BasicRejectBody;
-import org.wso2.andes.kernel.Andes;
-import org.wso2.andes.kernel.AndesException;
-import org.wso2.andes.kernel.AndesUtils;
-import org.wso2.andes.kernel.DeliverableAndesMetadata;
 import org.wso2.andes.protocol.AMQConstant;
 import org.wso2.andes.server.AMQChannel;
 import org.wso2.andes.server.message.AMQMessage;
@@ -112,7 +108,7 @@ public class BasicRejectMethodHandler implements StateAwareMethodListener<BasicR
                  * Inform kernel that message has been rejected by AMQP transport
                  */
                 try {
-                    QpidAndesBridge.rejectMessage((AMQMessage) message.getMessage(), channel);
+                    QpidAndesBridge.rejectMessage((AMQMessage) message.getMessage(), channel, body.getRequeue());
                 } catch (AMQException e) {
                     _logger.error("Error while rejecting message by kernel" , e);
                     throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error while rejecting message by kernel", e);
@@ -122,22 +118,8 @@ public class BasicRejectMethodHandler implements StateAwareMethodListener<BasicR
 
             if (body.getRequeue())
             {
-                //todo: we need to honour this
+                //remove message from maps
                 channel.requeue(deliveryTag);
-            }
-            else
-            {
-                try {
-                    DeliverableAndesMetadata andesMetadata = AndesUtils.lookupDeliveredMessage(message.getMessage()
-                            .getMessageNumber(), channel.getId());
-                    Andes.getInstance().moveMessageToDeadLetterChannel(andesMetadata, message
-                            .getQueue()
-                            .getName());
-                } catch (AndesException e) {
-                    _logger.error("Error while moving message to DLC message Id = "
-                            + message.getMessage().getMessageNumber() , e);
-                    throw new AMQException(AMQConstant.INTERNAL_ERROR, "Error while moving message to DLC", e);
-                }
             }
         }
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/SubscriptionImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/SubscriptionImpl.java
@@ -289,7 +289,8 @@ public abstract class SubscriptionImpl implements Subscription, FlowCreditManage
 							+ " Slot = " + ((AMQMessage)entry.getMessage()).getAndesMetadataReference()
 							.getMessage().getSlot().getId()
 							+ " JMSMessageId " + ": " + entry.getMessageHeader().getMessageId()
-							+ " channel=" + getChannel().getId());
+							+ " channel=" + getChannel().getId()
+                            + "deliveryTag=" + deliveryTag);
                 }
 
                 sendToClient(entry, deliveryTag);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/txn/QpidDistributedTransaction.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/txn/QpidDistributedTransaction.java
@@ -21,10 +21,10 @@ import org.wso2.andes.AMQException;
 import org.wso2.andes.amqp.QpidAndesBridge;
 import org.wso2.andes.kernel.Andes;
 import org.wso2.andes.kernel.AndesAckData;
+import org.wso2.andes.kernel.AndesAckEvent;
 import org.wso2.andes.kernel.AndesChannel;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesMessage;
-import org.wso2.andes.kernel.AndesUtils;
 import org.wso2.andes.kernel.disruptor.DisruptorEventCallback;
 import org.wso2.andes.kernel.dtx.AlreadyKnownDtxException;
 import org.wso2.andes.kernel.dtx.DistributedTransaction;
@@ -101,11 +101,11 @@ public class QpidDistributedTransaction implements ServerTransaction {
         List<AndesAckData> ackList = new ArrayList<>(messages.size());
         try {
             for (QueueEntry entry : messages) {
-                ackList.add(AndesUtils.generateAndesAckMessage(channelID, entry.getMessage().getMessageNumber()));
+                ackList.add(new AndesAckData(channelID, entry.getMessage().getMessageNumber()));
             }
             distributedTransaction.dequeue(ackList);
         } catch (AndesException e) {
-            throw new AMQException("Error occurred while creating a AndesAckData ", e);
+            throw new AMQException("Error occurred while creating a AndesAckEvent ", e);
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/tools/utils/MessageTracer.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/tools/utils/MessageTracer.java
@@ -60,6 +60,7 @@ public class MessageTracer {
     public static final String MESSAGE_DELETED = "message deleted";
     public static final String ACK_RECEIVED_FROM_PROTOCOL = "ACK received from protocol";
     public static final String ACK_PUBLISHED_TO_DISRUPTOR = "ACK event submitted to disruptor";
+    public static final String ACK_MESSAGE_REFERENCE_SET_BY_DISRUPTOR = "ACK metadata reference set by disruptor";
     public static final String MESSAGE_REQUEUED_BUFFER = "message re-queued to buffer";
     public static final String CONTENT_DECOMPRESSION_HANDLER_MESSAGE = "Content decompressed";
     public static final String MESSAGE_BEYOND_LAST_ROLLBACK = "Message is beyond the last rollback point. Therefore " +
@@ -90,6 +91,25 @@ public class MessageTracer {
             }
             messageContent.append(" } ");
 	        messageContent.append(description);
+            log.trace(messageContent.toString());
+        }
+    }
+
+    /**
+     * Trace log on message activity. Accepts message Id and a description
+     *
+     * @param messageId Id of the message
+     * @param description Description to place in log on message activity
+     */
+    public static void trace(long messageId, String description) {
+        if (log.isTraceEnabled()) {
+            StringBuilder messageContent = new StringBuilder();
+            if (messageId > 0) { // Check if andes message id is assigned, else ignore
+                messageContent.append("Id: ");
+                messageContent.append(messageId);
+                messageContent.append(", ");
+            }
+            messageContent.append(description);
             log.trace(messageContent.toString());
         }
     }

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession.java
@@ -1787,9 +1787,15 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
      *
      * <ul>
      * <li>Stop message delivery.</li>
-     * <li>Mark all messages that might have been delivered but not acknowledged as "redelivered".
+     * <li>Mark all messages that have been delivered to the application but not acknowledged as "redelivered".
+     * <li>Send reject messages to all application consumed messages. For these messages "redelivered" flag will be
+     * set and from server side re-delivery count is increased. After max number of times increased these messages
+     * will be marked for Dead Letter Channel and removed from queue.
+     * </li>
+     * <li>Clear internal message buffers.</li>
      * <li>Restart the delivery sequence including all unacknowledged messages that had been previously delivered.
-     * Redelivered messages do not have to be delivered in exactly their original delivery order.</li>
+     * Redelivered messages do not have to be delivered in exactly their original delivery order. They may also go to
+     * other subscribers subscribed for the queue</li>
      * </ul>
      *
      * <p/>If the recover operation is interrupted by a fail-over, between asking that the broker begin recovery and
@@ -1832,6 +1838,11 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
             }
             
             syncDispatchQueue();
+
+            //do this before recovering dispatcher. Then only the list has application dispatched messages
+            for (Long messageTag : _unacknowledgedMessageTags) {
+                rejectMessage(messageTag, true);
+            }
             
             if (_dispatcher != null)
             {
@@ -1887,6 +1898,20 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
 
     }
 
+    /**
+     * Send amq.reject message to server
+     *
+     * @param deliveryTag delivery tag of the message
+     * @param reQueue whether to re-queue message
+     */
+    public abstract void sendReject(long deliveryTag, boolean reQueue);
+
+    /**
+     * Send amq.reject message to server. Here Acknowledgement patterns are also considered
+     *
+     * @param deliveryTag delivery tag of the message
+     * @param requeue whether to re-queue message
+     */
     public abstract void rejectMessage(long deliveryTag, boolean requeue);
 
     /**
@@ -3013,7 +3038,7 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
         _producers.put(new Long(producerId), producer);
     }
 
-    private void rejectAllMessages(boolean requeue)
+    void rejectAllMessages(boolean requeue)
     {
         rejectMessagesForConsumerTag(0, requeue, true);
     }
@@ -3021,7 +3046,7 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
     /**
      * @param consumerTag The consumerTag to prune from queue or all if null
      * @param requeue     Should the removed messages be requeued (or discarded. Possibly to DLQ)
-     * @param rejectAllConsumers
+     * @param rejectAllConsumers  if to force message rejecting
      */
 
     private void rejectMessagesForConsumerTag(int consumerTag, boolean requeue, boolean rejectAllConsumers)
@@ -3145,7 +3170,7 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
     }
 
     /** Signifies that the session has no pending sends to commit. */
-    public void markClean()
+    private void markClean()
     {
         _dirty = false;
         _failedOverDirty = false;
@@ -3363,14 +3388,8 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
 
                 for (C consumer : _consumers.values())
                 {
-                    List<Long> tags = consumer.drainReceiverQueueAndRetrieveDeliveryTags();
-                    _unacknowledgedMessageTags.addAll(tags);
-                    //add messages for ack wait timeout tracking
-                    for(long tag : tags) {
-                        ackWaitTimeOutTrackingMap.put(tag, System.currentTimeMillis());
-                    }
+                    consumer.drainReceiverQueueAndRetrieveDeliveryTags();
                 }
-
                 setConnectionStopped(isStopped);
             } finally {
                 dispatcherLock.unlock();
@@ -3476,14 +3495,13 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
                 if (!(message instanceof CloseConsumerMessage)
                     && tagLE(deliveryTag, _rollbackMark.get()))
                 {
-
                     rejectMessage(message, true);
                 }
                 else if (isInRecovery())
                 {
-                    _unacknowledgedMessageTags.add(deliveryTag);
-                    //add message for ack wait timeout tracking
-                    ackWaitTimeOutTrackingMap.put(deliveryTag, System.currentTimeMillis());
+                    if(log.isDebugEnabled()) {
+                        log.debug("Dropping message delivery tag " + deliveryTag + " as in recovery");
+                    }
                 }
                 else
                 {

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession_0_10.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession_0_10.java
@@ -279,7 +279,12 @@ public class AMQSession_0_10 extends AMQSession<BasicMessageConsumer_0_10, Basic
     {
         flushAcknowledgments(false);
     }
-    
+
+    @Override
+    public void sendReject(long deliveryTag, boolean reQueue) {
+        rejectMessage(deliveryTag, reQueue);
+    }
+
     void flushAcknowledgments(boolean setSyncBit)
     {
         synchronized (unacked)

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession_0_8.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession_0_8.java
@@ -199,7 +199,9 @@ public class AMQSession_0_8 extends AMQSession<BasicMessageConsumer_0_8, BasicMe
 
     public void sendRecover() throws AMQException, FailoverException
     {
+
         _unacknowledgedMessageTags.clear();
+
         ackWaitTimeOutTrackingMap.clear();
 
         if (isStrictAMQP())
@@ -263,16 +265,26 @@ public class AMQSession_0_8 extends AMQSession<BasicMessageConsumer_0_8, BasicMe
             || (_acknowledgeMode == CLIENT_ACKNOWLEDGE)
             || (_acknowledgeMode == SESSION_TRANSACTED))
         {
-            if (_logger.isDebugEnabled())
-            {
-                _logger.debug("Rejecting delivery tag:" + deliveryTag + ":SessionHC:" + this.hashCode());
-            }
-
-            BasicRejectBody body = getMethodRegistry().createBasicRejectBody(deliveryTag, requeue);
-            AMQFrame frame = body.generateFrame(_channelId);
-
-            _connection.getProtocolHandler().writeFrame(frame);
+            sendReject(deliveryTag, requeue);
         }
+    }
+
+    /**
+     * Send amq.reject message to server
+     *
+     * @param deliveryTag delivery tag of the message
+     * @param reQueue whether to re-queue message
+     */
+    public void sendReject(long deliveryTag, boolean reQueue) {
+        if (_logger.isDebugEnabled())
+        {
+            _logger.debug("Rejecting delivery tag:" + deliveryTag + ":SessionHC:" + this.hashCode());
+        }
+
+        BasicRejectBody body = getMethodRegistry().createBasicRejectBody(deliveryTag, reQueue);
+        AMQFrame frame = body.generateFrame(_channelId);
+
+        _connection.getProtocolHandler().writeFrame(frame);
     }
 
     public boolean isQueueBound(final AMQDestination destination) throws JMSException

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/BasicMessageConsumer.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/BasicMessageConsumer.java
@@ -796,7 +796,10 @@ public abstract class BasicMessageConsumer<U> extends Closeable implements Messa
                 } else {
                     _synchronousQueue.put(new DelayedObject(0, jmsMessage));
                 }
-                _logger.debug("dest="+ _destination.getQueueName()+  " added message " + _synchronousQueue.size() + "]");
+                if(_logger.isDebugEnabled()) {
+                    _logger.debug("dest="+ _destination.getQueueName()+  " added message "
+                            + _synchronousQueue.size() + "]");
+                }
             }
         }
         catch (Exception e)

--- a/modules/andes-core/client/src/test/java/org/wso2/andes/unit/message/TestAMQSession.java
+++ b/modules/andes-core/client/src/test/java/org/wso2/andes/unit/message/TestAMQSession.java
@@ -64,6 +64,10 @@ public class TestAMQSession extends AMQSession<BasicMessageConsumer_0_8, BasicMe
 
     }
 
+    public void sendReject(long deliveryTag, boolean reQueue) {
+
+    }
+
     public TopicSubscriber createDurableSubscriber(Topic topic, String name) throws JMSException
     {
         return null;


### PR DESCRIPTION
Changes included

>> Recover() event is brought into inbound disruptor
>> Reject() event is brought into inbound disruptor
>> Channel MessageStatus now has a RECOVERED state.
>> Client side message rejection at recover() call is changed.
>> Ack path is updated

Issue here is when messages are sent to client broker considers them as delivered messages. They get buffered in client side. Even if consumer application does not see these messages they are considered delivered once.

Now messages are rejected with reQueue=false when they are in the client-side buffer. There from server side the delivery counts are adjusted to consider they are not delivered.

During following test message status dump becomes as follows.

QueueConnectionFactory connFactory = (QueueConnectionFactory) ctx.lookup(CF_NAME);
QueueConnection queueConnection = connFactory.createQueueConnection();
queueConnection.start();
QueueSession queueSession =
queueConnection.createQueueSession(false,Session.CLIENT_ACKNOWLEDGE);

    //Receive message
    Queue queue =  (Queue) ctx.lookup(queueName);
    MessageConsumer queueReceiver = queueSession.createConsumer(queue);
// queueReceiver.setMessageListener(new SampleMessageListener(
// queueConnection, queueSession, queueReceiver,delay));
int currentMsgCount = 0;
while (currentMsgCount < messageCountToRead) {
TextMessage message = (TextMessage) queueReceiver.receive();
if(message != null) {
System.out.println("("+currentMsgCount+") "+"Got message ==>" + message.getText());
currentMsgCount++;
queueSession.recover();
try {
Thread.sleep(5000);
} catch (InterruptedException e) {
//silently ignore
}
}
}

hasithaQ,hasithaQ|51351268724310019-51351315732496384,Message ID 51351315721224193,Message Header null,Destination hasithaQ,Message status READ>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>BUFFERED>>SCHEDULED_TO_SEND>>,Slot Info { Id : hasithaQ|51351268724310019-51351315732496384 States : [CREATED] Is overlapping : false Destination : hasithaQ},Timestamp 1488865736943,Expiration time 0,Channels sent 546a7f1c-4d06-4c09-bac6-33a5fd0eac3b : DISPATCHED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>>NACKED>>RECOVERED>>DISPATCHED>> |