### PR TITLE
MB1737 - Add new admin services to retrieve messages without content to increase performance.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -860,5 +860,33 @@ public class Andes {
     public ArrayList<Xid> getPreparedDtxTransactions() {
         return dtxRegistry.getPreparedTransactions();
     }
+
+    /**
+     * Get message IDs in dlc for a queue for a given number of messages starting from the specified id.
+     *
+     * @param sourceQueue    name of the queue
+     * @param dlcQueueName   name of the dead letter channel queue
+     * @param startMessageId starting message id
+     * @param messageLimit   maximum num of messages to return in one invocation.
+     * @return List<Long> of message IDs
+     * @throws AndesException if an error occurs while reading message IDs from database.
+     */
+    public List<Long> getNextNMessageIdsInDLCForQueue(final String sourceQueue, final String dlcQueueName,
+                                                      long startMessageId, int messageLimit) throws AndesException {
+        return MessagingEngine.getInstance().getNextNMessageIdsInDLCForQueue(sourceQueue, dlcQueueName, startMessageId, messageLimit);
+    }
+
+    /***
+     * Get message IDs in DLC starting from given startMessageId up to the given message count.
+     *
+     * @param dlcQueueName Queue name of the Dead Letter Channel
+     * @param startMessageId last message ID returned from invoking this method.
+     * @return List<Long> of message IDs moved to the DLC from the sourceQueue.
+     * @throws AndesException if an error occurs while reading messages from the database.
+     */
+    public List<Long> getNextNMessageIdsInDLC(final String dlcQueueName, long startMessageId, int messageLimit)
+            throws AndesException {
+        return MessagingEngine.getInstance().getNextNMessageIdsInDLC(dlcQueueName, startMessageId, messageLimit);
+    }
 }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStore.java
@@ -424,11 +424,36 @@ public interface MessageStore extends HealthAwareStore {
      */
     DeliverableAndesMetadata getRetainedMetadata(String destination) throws AndesException;
 
+    /***
+     * Get message IDs in DLC from sourceQueue starting from given startMessageId up to the given message count.
+     *
+     * @param sourceQueueName intended destination queue of the messages
+     * @param dlcQueueName Queue name of the Dead Letter Channel
+     * @param startMessageId last message ID returned from invoking this method.
+     * @return List<Long> of message IDs moved to the DLC from the sourceQueue.
+     * @throws AndesException if an error occurs while reading messages from the database.
+     */
+    List<Long> getMessageIdsInDLCForQueue(String sourceQueueName, String dlcQueueName, long startMessageId,
+                                          int messageLimit) throws AndesException;
+
+    /***
+     * Get message IDs in DLC starting from given startMessageId up to the given message count.
+     *
+     * @param dlcQueueName Queue name of the Dead Letter Channel
+     * @param startMessageId last message ID returned from invoking this method.
+     * @return List<Long> of message IDs moved to the DLC from the sourceQueue.
+     * @throws AndesException if an error occurs while reading messages from the database.
+     */
+    List<Long> getMessageIdsInDLC(String dlcQueueName, long startMessageId, int messageLimit) throws AndesException;
+
+
     /**
      * close the message store
      */
     void close();
 
     DtxStore getDtxStore();
+
+
 
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -663,4 +663,33 @@ public class MessagingEngine {
         }
         return lastMessageId;
     }
+
+
+    /**
+     * Get message IDs from queue starting from given startMessageId up to the given message count.
+     *
+     * @param sourceQueue    name of the queue
+     * @param dlcQueueName   name of the dead letter channel queue
+     * @param startMessageId starting message id
+     * @param messageLimit   maximum num of messages to return in one invocation.
+     * @return List<Long> of message IDs
+     * @throws AndesException if an error occurs while reading message IDs from the database.
+     */
+    public List<Long> getNextNMessageIdsInDLCForQueue(final String sourceQueue, final String dlcQueueName,
+                                                      long startMessageId, int messageLimit) throws AndesException {
+        return messageStore.getMessageIdsInDLCForQueue(sourceQueue, dlcQueueName, startMessageId, messageLimit);
+    }
+
+    /***
+     * Get message IDs in DLC starting from given startMessageId up to the given message count.
+     *
+     * @param dlcQueueName Queue name of the Dead Letter Channel
+     * @param startMessageId last message ID returned from invoking this method.
+     * @return List<Long> of message IDs moved to the DLC from the sourceQueue.
+     * @throws AndesException if an error occurs while reading messages from the database.
+     */
+    public List<Long> getNextNMessageIdsInDLC(final String dlcQueueName, long startMessageId, int messageLimit)
+            throws AndesException {
+        return messageStore.getMessageIdsInDLC(dlcQueueName, startMessageId, messageLimit);
+    }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
@@ -639,4 +639,33 @@ public class FailureObservingMessageStore extends FailureObservingStore<MessageS
         return failureObservingDtxStore;
     }
 
+    /***
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Long> getMessageIdsInDLCForQueue(String sourceQueueName, String dlcQueueName, long startMessageId,
+                                                 int messageLimit) throws AndesException {
+        try {
+            return wrappedInstance.getMessageIdsInDLCForQueue(sourceQueueName, dlcQueueName, startMessageId, messageLimit);
+        } catch (AndesStoreUnavailableException exception) {
+            notifyFailures(exception);
+            throw exception;
+        }
+    }
+
+    /***
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Long> getMessageIdsInDLC(String dlcQueueName, long startMessageId, int messageLimit)
+            throws AndesException {
+        try {
+            return wrappedInstance.getMessageIdsInDLC(dlcQueueName, startMessageId, messageLimit);
+        } catch (AndesStoreUnavailableException exception) {
+            notifyFailures(exception);
+            throw exception;
+        }
+    }
+
+
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -1134,6 +1134,21 @@ public class RDBMSConstants {
                     + " FROM " + DTX_CONTENT_ENQUEUE_TABLE
                     + " WHERE " + INTERNAL_XID + "=?";
 
+    protected static final String PS_SELECT_MESSAGE_IDS_IN_DLC_FROM_METADATA_FOR_QUEUE =
+            "SELECT " + MESSAGE_ID
+                    + " FROM " + METADATA_TABLE
+                    + " WHERE " + QUEUE_ID + "=?"
+                    + " AND " + MESSAGE_ID + ">?"
+                    + " AND " + DLC_QUEUE_ID + "=? "
+                    + " ORDER BY " + MESSAGE_ID ;
+
+    protected static final String PS_SELECT_MESSAGE_IDS_IN_DLC_FROM_METADATA =
+            "SELECT " + MESSAGE_ID
+                    + " FROM " + METADATA_TABLE
+                    + " WHERE " + MESSAGE_ID + ">?"
+                    + " AND " + DLC_QUEUE_ID + "=? "
+                    + " ORDER BY " + MESSAGE_ID ;
+
     // Message Store related jdbc tasks executed
     protected static final String TASK_STORING_MESSAGE_PARTS = "storing message parts.";
     protected static final String TASK_DELETING_MESSAGE_PARTS = "deleting message parts.";
@@ -1249,6 +1264,10 @@ public class RDBMSConstants {
 
     protected static final String TASK_REMOVE_NODE_HEARTBEAT = "removing node heartbeat entry";
     protected static final String TASK_MARK_NODE_NOT_NEW = "marking node as not new";
+    protected static final String TASK_RETRIEVING_NEXT_N_MESSAGE_IDS_IN_DLC_OF_QUEUE = "retrieving message ID list " +
+            "in DLC from queue. ";
+    protected static final String TASK_RETRIEVING_NEXT_N_MESSAGE_IDS_IN_DLC = "retrieving message ID list in DLC.";
+
     /**
      * Messages related to checking message store is operational.
      */

--- a/modules/andes-core/management/common/src/main/java/org/wso2/andes/management/common/mbeans/QueueManagementInformation.java
+++ b/modules/andes-core/management/common/src/main/java/org/wso2/andes/management/common/mbeans/QueueManagementInformation.java
@@ -151,34 +151,39 @@ public interface QueueManagementInformation {
             description = "The Dead Letter Queue Name for the selected tenant") String destinationQueueName);
 
     /**
-     * Restore a given browser message Id list from the Dead Letter Queue to the same queue it was previous in before
-     * moving to the Dead Letter Queue
-     * and remove them from the Dead Letter Queue.
-     *
-     * @param andesMetadataIDs     The browser message Ids
-     * @param destinationQueueName The Dead Letter Queue Name for the tenant
+     * Restore a given message id list from the Dead Letter Channel to the same queue it was previously in before
+     * moving to the Dead Letter Channel and remove them from the Dead Letter Channel.
+     * @param andesMessageIds       The andes message Id list
+     * @param destinationQueueName  Original destination queue of these messages.
      * @return unavailable message count
      */
-    @MBeanAttribute(name = " Restore Back a Specific set of Messages ", description = "Will Restore a Specific Set of Messages Back to Its Original Queue")
-    long restoreMessagesFromDeadLetterQueue(@MBeanOperationParameter(name = "andesMetadataIDs",
-            description = "IDs of the Messages to Be Restored") long[] andesMetadataIDs, @MBeanOperationParameter(name = "destinationQueueName",
-            description = "The Dead Letter Queue Name for the selected tenant") String destinationQueueName);
-
+    @MBeanAttribute(name = "restoreSelectedMessagesFromDeadLetterChannel", description = "Will restore a specific set of"
+            + " messages back to their original queue")
+    void restoreSelectedMessagesFromDeadLetterChannel(
+            @MBeanOperationParameter(name = "andesMessageIds",
+                    description = "IDs of the Messages to Be restored") long[] andesMessageIds,
+            @MBeanOperationParameter(name = "destinationQueueName",
+                    description = "Original destination queue of the messages") String destinationQueueName)
+            throws MBeanException;
     /**
-     * Restore a given browser message Id list from the Dead Letter Queue to a different given queue in the same
-     * tenant and remove them from the Dead Letter Queue.
+     * Reroute a given message Id list from the Dead Letter Channel to a different queue in the same
+     * tenant and remove the old messages from the Dead Letter Channel.
      *
-     * @param destinationQueueName    The Dead Letter Queue Name for the tenant
-     * @param andesMetadataIDs        The browser message Ids
-     * @param newDestinationQueueName The new destination
+     * @param sourceQueue       The Dead Letter Queue Name for the tenant
+     * @param andesMessageIds   The browser message Ids
+     * @param targetQueue       The new destination
      * @return unavailable message count
      */
-    @MBeanAttribute(name = " Restore Back a Specific set of Messages ", description = "Will Restore a Specific Set of Messages Back to a Queue differnt from the original")
-    long restoreMessagesFromDeadLetterQueue(@MBeanOperationParameter(name = "andesMetadataIDs",
-            description = "IDs of the Messages to Be Restored") long[] andesMetadataIDs,@MBeanOperationParameter(name = "destination",
-            description = "Destination of the message to be restored") String newDestinationQueueName, @MBeanOperationParameter(name = "deadLetterQueueName",
-            description = "The Dead Letter Queue Name for the selected tenant") String destinationQueueName);
-
+    @MBeanAttribute(name = "rerouteSelectedMessagesFromDeadLetterChannel", description = "Will reroute a specific set"
+            + " of Messages of QueueA in DLC to a new target QueueB")
+    void rerouteSelectedMessagesFromDeadLetterChannel(
+            @MBeanOperationParameter(name = "andesMessageIds",
+                    description = "IDs of the Messages to Be Restored") long[] andesMessageIds,
+            @MBeanOperationParameter(name = "sourceQueue",
+                    description = "The  original queue name of the messages") String sourceQueue,
+            @MBeanOperationParameter(name = "targetQueue",
+                    description = "New destination queue for the messages") String targetQueue)
+            throws MBeanException;
     /**
      * Browse queue for given id starting from last message id until it meet max message count
      *
@@ -220,12 +225,53 @@ public interface QueueManagementInformation {
      * @return list of messages
      */
     @MBeanAttribute(name = "MessageInDLCForQueue", description = "Browse messages of given queue")
-    CompositeData[] getMessageInDLCForQueue(
+    CompositeData[] getMessagesInDLCForQueue(
             @MBeanOperationParameter(name = "queueName", description = "Name of queue to browse " +
                                                                "in DLC messages") String queueName,
             @MBeanOperationParameter(name = "lastMsgId", description = "Browse message this " +
                                                                        "onwards") long nextMsgId,
             @MBeanOperationParameter(name = "maxMessageCount", description = "Maximum message " +
                                                          "count per request") int maxMessageCount)
+            throws MBeanException;
+
+
+    /**
+     * Returns a paginated list of message metadata which are destined for the targetQueue, but currently living in the
+     * Dead Letter Channel.
+     *
+     * @param targetQueue    Name of the destination queue
+     * @param startMessageId Message Id to start the resultset with.
+     * @param pageLimit      Maximum message count required in a single response
+     * @return Array of {@link CompositeData}
+     */
+    @MBeanAttribute(name = "getMessageMetadataInDeadLetterChannel",
+            description = "List Message Metadata that live in Dead Letter Channel for a given queue.")
+    CompositeData[] getMessageMetadataInDeadLetterChannel(
+            @MBeanOperationParameter(name = "targetQueue",
+                    description = "Name of destination queue ") String targetQueue,
+            @MBeanOperationParameter(name = "startMessageId",
+                    description = "Message Id to start the resultset with.") long startMessageId,
+            @MBeanOperationParameter(name = "pageLimit",
+                    description = "Maximum message count required in a single response") int pageLimit)
+            throws MBeanException;
+
+    /**
+     * Restore messages destined for the input sourceQueue into a different targetQueue.
+     * If the sourceQueue is DLCQueue, all messages in the DLC will be restored to the targetQueue.
+     *
+     * @param sourceQueue Name of the source queue
+     * @param targetQueue Name of the target queue.
+     * @param internalBatchSize even with this method, the MB server will internally read messages in DLC in batches,
+     *                          and simulate each batch as a new message list to the targetQueue. internalBatchSize
+     *                          controls the number of messages processed in a single batch internally.
+     * @throws MBeanException if an exception occurs while moving messages from the sourceQueue.
+     */
+    @MBeanAttribute(name = "rerouteAllMessagesInDeadLetterChannelForQueue", description = "Restore messages destined for "
+            + "the input sourceQueue into a different targetQueue.")
+    int rerouteAllMessagesInDeadLetterChannelForQueue(
+            @MBeanOperationParameter(name = "sourceQueue", description = "Name of the source queue") String sourceQueue,
+            @MBeanOperationParameter(name = "targetQueue", description = "Name of the source queue") String targetQueue,
+            @MBeanOperationParameter(name = "internalBatchSize", description = "Number of messages processed in a "
+                    + "single database call.") int internalBatchSize)
             throws MBeanException;
 }


### PR DESCRIPTION
provides 2 new Admin services with regard to DLC operations within the server.

1. getMessageMetadataInDeadLetterChannel

     Returns a paginated list of message metadata destined for the targetQueue but currently living in the
     Dead Letter Channel.
     
     @param targetQueue    Name of the destination queue
     @param startMessageId Start point of the queue message id to start reading
     @param pageLimit      Maximum number of messages required in a single response

2. rerouteAllMessagesFromDeadLetterChannelForQueue

	 Move messages destined for the input sourceQueue into a different targetQueue.
	 If the sourceQueue is DLCQueue, all messages in the DLC will be restored to the targetQueue.

	 @param sourceQueue       Name of the source queue
	 @param targetQueue       Name of the target queue.
	 @param internalBatchSize even with this method, the MB server will internally read messages in DLC in batches,
	                          and simulate each batch as a new message list to the targetQueue. "internalBatchSize"
	                          controls the number of messages processed in a single batch internally.