### PR TITLE
Re-assigend overlapped slot when member leaves

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextStore.java
@@ -273,6 +273,16 @@ public interface AndesContextStore extends HealthAwareStore {
             throws AndesException;
 
     /**
+     * Delete a non-overlapping slot from store.
+     *
+     * @param startMessageId start message id of slot
+     * @param endMessageId   end message id of slot
+     * @return True if slot deletion successful
+     * @throws AndesException
+     */
+    boolean deleteNonOverlappingSlot(long startMessageId, long endMessageId) throws AndesException;
+
+    /**
      * Delete a slot from store.
      *
      * @param startMessageId start message id of slot
@@ -441,6 +451,15 @@ public interface AndesContextStore extends HealthAwareStore {
      * @throws AndesException
      */
     TreeSet<Slot> getAssignedSlotsByNodeId(String nodeId) throws AndesException;
+
+    /**
+     * Get all overlapped slots for give node.
+     *
+     * @param nodeId id of node
+     * @return set of overlapped slot objects
+     * @throws AndesException
+     */
+    TreeSet<Slot> getOverlappedSlotsByNodeId(String nodeId) throws AndesException;
 
     /**
      * Get all slots for a give queue.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/SlotAgent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/SlotAgent.java
@@ -41,10 +41,19 @@ public interface SlotAgent {
 							throws AndesException;
 
 	/**
-	 * Delete a slot from database
+	 * Delete a slot that is not overlapping, from database.
 	 *
 	 * @param nodeId id of the node
 	 * @param queueName queue name
+	 * @param startMessageId start message id
+	 * @param endMessageId end message id
+	 */
+    boolean deleteNonOverlappingSlot(String nodeId, String queueName, long startMessageId, long endMessageId)
+            throws AndesException;
+
+	/**
+	 * Delete a slot from database.
+	 *
 	 * @param startMessageId start message id
 	 * @param endMessageId end message id
 	 */
@@ -205,6 +214,15 @@ public interface SlotAgent {
 	 * @throws org.wso2.andes.kernel.AndesException
 	 */
 	TreeSet<Slot> getAssignedSlotsByNodeId(String nodeId) throws AndesException;
+
+    /**
+     * Get all overlapped slots for a given node id.
+     *
+     * @param nodeId id of node
+     * @return set of assigned slot objects
+     * @throws org.wso2.andes.kernel.AndesException
+     */
+    TreeSet<Slot> getOverlappedSlotsByNodeId(String nodeId) throws AndesException;
 
 	/**
 	 * Get all slots for a given queue

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingAndesContextStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingAndesContextStore.java
@@ -440,6 +440,19 @@ public class FailureObservingAndesContextStore extends FailureObservingStore<And
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean deleteNonOverlappingSlot(long startMessageId, long endMessageId) throws AndesException {
+        try {
+            return wrappedInstance.deleteNonOverlappingSlot(startMessageId, endMessageId);
+        } catch (AndesStoreUnavailableException exception) {
+            notifyFailures(exception);
+            throw exception;
+        }
+    }
+
+    /**
      * Delete a slot from store
      *
      * @param startMessageId start message id of slot
@@ -747,6 +760,19 @@ public class FailureObservingAndesContextStore extends FailureObservingStore<And
     public TreeSet<Slot> getAssignedSlotsByNodeId(String nodeId) throws AndesException {
         try {
             return wrappedInstance.getAssignedSlotsByNodeId(nodeId);
+        } catch (AndesStoreUnavailableException exception) {
+            notifyFailures(exception);
+            throw exception;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TreeSet<Slot> getOverlappedSlotsByNodeId(String nodeId) throws AndesException {
+        try {
+            return wrappedInstance.getOverlappedSlotsByNodeId(nodeId);
         } catch (AndesStoreUnavailableException exception) {
             notifyFailures(exception);
             throw exception;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -596,6 +596,14 @@ public class RDBMSConstants {
     /**
      * Prepared statement to delete a slot from database
      */
+    protected static final String PS_DELETE_SLOT =
+            "DELETE FROM " + SLOT_TABLE
+            + " WHERE " + START_MESSAGE_ID + "=?"
+            + " AND " + END_MESSAGE_ID + "=?";
+
+    /**
+     * Prepared statement to delete a slot from database
+     */
     protected static final String PS_DELETE_NON_OVERLAPPING_SLOT =
             "DELETE FROM " + SLOT_TABLE
             + " WHERE " + START_MESSAGE_ID + "=?"
@@ -650,6 +658,16 @@ public class RDBMSConstants {
             + " FROM " + SLOT_TABLE
             + " WHERE " + ASSIGNED_NODE_ID + "=?"
             + " AND " + SLOT_STATE + "=" + SlotState.ASSIGNED.getCode()
+            + " ORDER BY " + SLOT_ID;
+
+    /**
+     * Prepared statement to get slots assigned to a give node
+     */
+    protected static final String PS_GET_OVERLAPPED_SLOTS_BY_NODE_ID =
+            "SELECT " + START_MESSAGE_ID + "," + END_MESSAGE_ID + "," + STORAGE_QUEUE_NAME
+            + " FROM " + SLOT_TABLE
+            + " WHERE " + ASSIGNED_NODE_ID + "=?"
+            + " AND " + SLOT_STATE + "=" + SlotState.OVERLAPPED.getCode()
             + " ORDER BY " + SLOT_ID;
 
     /**
@@ -1234,6 +1252,7 @@ public class RDBMSConstants {
     protected static final String TASK_DELETE_MESSAGE_ID = "deleting message ids";
     protected static final String TASK_GET_MESSAGE_IDS = "getting message ids";
     protected static final String TASK_GET_ASSIGNED_SLOTS_BY_NODE_ID = "getting assigned slots by node id";
+    protected static final String TASK_GET_OVERLAPPED_SLOTS_BY_NODE_ID = "getting assigned slots by node id";
     protected static final String TASK_GET_ALL_SLOTS_BY_QUEUE_NAME = "getting all slots by queue name";
     protected static final String TASK_GET_OVERLAPPED_SLOT = "getting overlapped slot";
     protected static final String TASK_GET_ALL_QUEUES = "getting all queues";


### PR DESCRIPTION
This addresses the issue (reported at https://wso2.org/jira/browse/MB-1916) of some slots being remained in the database in a 2 node cluster fail-over scenario where an overlapped slot was destined to the killed node. The fix was to either delete such overlapped slots(if empty) or to re-assing (if not empty) when a member removed event is received by the coordinator.