### PR TITLE
[MB-1914] Fix : Adding queue mappings twice in sync nodes

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
@@ -408,8 +408,6 @@ public class AndesContextInformationManager {
 
         boolean queueAlreadyBound = queueToBind.bindQueueToMessageRouter(binding.getBindingKey(), messageRouter);
         if (!queueAlreadyBound) {
-            messageRouter.addMapping(binding.getBindingKey(), queueToBind);
-
             amqpConstructStore.addBinding(binding, false);
             //add binding inside qpid
             ClusterResourceHolder.getInstance().getVirtualHostConfigSynchronizer().clusterBindingAdded(binding);


### PR DESCRIPTION
In a cluster setup thought a queue is deleted, it is still listed in the UI even after the 'Queue sync [delete]' logged.
This is due to adding queue mappings twice inside AndesContextInformationManager::syncCreateBinding(). To fix this, removed one addMapping() call.