### PR TITLE
[MB-1895] - Fix Message ordering issue with local JMS transactions

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
@@ -304,11 +304,12 @@ public class QpidAndesBridge {
      */
     public static void rejectMessage(AMQMessage message, AMQChannel channel, boolean reQueue) throws AMQException {
         try {
-            channel.setLastRejectedMessageId(message.getMessageNumber());
             boolean isMessageBeyondLastRollback = channel.isMessageBeyondLastRollback(message.getMessageNumber());
 
             log.info("Reject received id = " + message.getMessageId() + " channel id= " + channel.getChannelId()
                     + "regueue = " + reQueue);
+
+            channel.setLastRejectedMessageId(message.getMessageNumber());
 
             Andes.getInstance().messageRejected(message.getMessageId(), channel.getId(),
                     reQueue, isMessageBeyondLastRollback);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.amqp.AMQPUtils;
 import org.wso2.andes.kernel.subscription.AndesSubscription;
 import org.wso2.andes.kernel.subscription.StorageQueue;
+import org.wso2.andes.tools.utils.MessageTracer;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -87,6 +88,7 @@ public class FlowControlledQueueMessageDeliveryImpl implements MessageDeliverySt
                             subscriberWithMatchingSelectorFound = false;
                             continue; // continue on to match selectors of other subscribers
                         }
+
                         if (log.isDebugEnabled()) {
                             log.debug("Scheduled to send message id = " + message.getMessageID() +
                                     " to subscription id= " + localSubscription.getSubscriptionId());

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.kernel.subscription.AndesSubscription;
 import org.wso2.andes.kernel.subscription.StorageQueue;
+import org.wso2.andes.tools.utils.MessageTracer;
 
 import java.util.*;
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ProtocolDeliveryFailureOnRollbackException.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/ProtocolDeliveryFailureOnRollbackException.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+/**
+ * When sending messages during a JMS rollback event, we should not queue up any new messages to the subscriber
+ * channel until we have completely re-queued all messages rejected by the subscriber side.
+ * This exception will be thrown if any new messages are about to be re-queued in the middle of a rollback.
+ */
+public class ProtocolDeliveryFailureOnRollbackException extends AndesException {
+
+    /***
+     * Constructor
+     * @param message descriptive message
+     * @param errorCode one of the above defined constants that classifies the error.
+     * @param cause reference to the exception for reference.
+     */
+    public ProtocolDeliveryFailureOnRollbackException(String message, String errorCode, Throwable cause){
+        super(message, errorCode, cause);
+    }
+
+    /***
+     * Constructor
+     * @param message descriptive message
+     * @param cause reference to the exception for reference.
+     */
+    public ProtocolDeliveryFailureOnRollbackException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructor
+     * @param message descriptive message
+     */
+    public ProtocolDeliveryFailureOnRollbackException(String message) {
+        super(message);
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.kernel.subscription.AndesSubscription;
 import org.wso2.andes.kernel.subscription.StorageQueue;
+import org.wso2.andes.tools.utils.MessageTracer;
 
 import java.util.*;
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
@@ -20,12 +20,14 @@ package org.wso2.andes.kernel.disruptor.delivery;
 
 import com.lmax.disruptor.EventHandler;
 import org.apache.log4j.Logger;
+import org.wso2.andes.api.Message;
 import org.wso2.andes.kernel.Andes;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.DeliverableAndesMetadata;
 import org.wso2.andes.kernel.MessageStatus;
 import org.wso2.andes.kernel.MessagingEngine;
 import org.wso2.andes.kernel.ProtocolDeliveryFailureException;
+import org.wso2.andes.kernel.ProtocolDeliveryFailureOnRollbackException;
 import org.wso2.andes.kernel.ProtocolDeliveryRulesFailureException;
 import org.wso2.andes.kernel.ProtocolMessage;
 import org.wso2.andes.kernel.SubscriptionAlreadyClosedException;
@@ -142,6 +144,10 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
                 // we log the exception earlier. Hence logging is not required here. We increase delivery count so max
                 // send count delivery rule is evaluated and message is sent to DLC if failure is consistent
                 onDeliveryException(message, subscription);
+                reQueueMessageIfDurable(message, subscription);
+
+            } catch (ProtocolDeliveryFailureOnRollbackException ex) {
+                onSendError(message, subscription);
                 reQueueMessageIfDurable(message, subscription);
 
             } catch (Throwable e) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/NullSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/NullSubscription.java
@@ -69,4 +69,9 @@ public class NullSubscription implements OutboundSubscription {
         throw new UnsupportedOperationException("Invalid operation for retrieve protocol name.");
     }
 
+    @Override
+    public boolean isJMSRollbackInProgress() {
+        throw new UnsupportedOperationException("Invalid operation for retrieve if rollback is in progress.");
+    }
+
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/OutboundSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/OutboundSubscription.java
@@ -84,4 +84,10 @@ public interface OutboundSubscription {
      * @return name of the queue set by protocol
      */
     String getProtocolQueueName();
+
+    /**
+     *
+     * @return true if a JMS session rollback is in progress for this subscriber.
+     */
+    boolean isJMSRollbackInProgress();
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/SubscriberConnection.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/SubscriberConnection.java
@@ -311,4 +311,11 @@ public class SubscriberConnection {
         return encodeAsString();
     }
 
+    /**
+     * @return true if a JMS Session.Rollback is in progress.
+     */
+    public boolean isJMSRollbackInProgress() {
+        return outboundSubscription.isJMSRollbackInProgress();
+    }
+
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/mqtt/MQTTLocalSubscription.java
@@ -254,4 +254,10 @@ public class MQTTLocalSubscription implements OutboundSubscription {
     public boolean isDurable() {
         return isDurable;
     }
+
+    @Override
+    public boolean isJMSRollbackInProgress() {
+        // Not relevant for MQTT therefore default to false.
+        return false;
+    }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/ServerMethodDispatcherImpl_0_91.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/ServerMethodDispatcherImpl_0_91.java
@@ -58,6 +58,7 @@ import org.wso2.andes.framing.MessageResumeBody;
 import org.wso2.andes.framing.MessageTransferBody;
 import org.wso2.andes.framing.QueueUnbindBody;
 import org.wso2.andes.framing.QueueUnbindOkBody;
+import org.wso2.andes.framing.TxRollbackWithContextBody;
 import org.wso2.andes.framing.amqp_0_91.DtxCommitBodyImpl;
 import org.wso2.andes.framing.amqp_0_91.DtxEndBodyImpl;
 import org.wso2.andes.framing.amqp_0_91.DtxForgetBodyImpl;
@@ -79,6 +80,8 @@ public class ServerMethodDispatcherImpl_0_91
             BasicRecoverSyncMethodHandler.getInstance();
     private static final QueueUnbindHandler _queueUnbindHandler =
             QueueUnbindHandler.getInstance();
+    private static final TxRollbackWithContextHandler _txRollbackWithContextHandler =
+            TxRollbackWithContextHandler.getInstance();
 
     private static final DtxSelectHandler dtxSelectHandler = DtxSelectHandler.getInstance();
     private static final DtxStartHandler dtxStartHandler = DtxStartHandler.getInstance();
@@ -306,6 +309,12 @@ public class ServerMethodDispatcherImpl_0_91
     public boolean dispatchQueueUnbind(QueueUnbindBody body, int channelId) throws AMQException
     {
         _queueUnbindHandler.methodReceived(getStateManager(),body,channelId);
+        return true;
+    }
+
+    @Override
+    public boolean dispatchTxRollbackWithContext(TxRollbackWithContextBody body, int channelId) throws AMQException {
+        _txRollbackWithContextHandler.methodReceived(getStateManager(), body, channelId);
         return true;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/TxRollbackHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/TxRollbackHandler.java
@@ -54,8 +54,6 @@ public class TxRollbackHandler implements StateAwareMethodListener<TxRollbackBod
                 throw body.getChannelNotFoundException(channelId);
             }
 
-            channel.setLastRollbackedMessageId();
-
             final MethodRegistry methodRegistry = session.getMethodRegistry();
             final AMQMethodBody responseBody = methodRegistry.createTxRollbackOkBody();
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/TxRollbackWithContextHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/TxRollbackWithContextHandler.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wso2.andes.server.handler;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.AMQException;
+import org.wso2.andes.framing.AMQMethodBody;
+import org.wso2.andes.framing.AMQShortString;
+import org.wso2.andes.framing.MethodRegistry;
+import org.wso2.andes.framing.TxRollbackWithContextBody;
+import org.wso2.andes.server.AMQChannel;
+import org.wso2.andes.server.protocol.AMQProtocolSession;
+import org.wso2.andes.server.queue.QueueEntry;
+import org.wso2.andes.server.state.AMQStateManager;
+import org.wso2.andes.server.state.StateAwareMethodListener;
+
+/**
+ * This will handle the custom rollback frame which includes the last dispatched message ID on the client side.
+ */
+public class TxRollbackWithContextHandler implements StateAwareMethodListener<TxRollbackWithContextBody> {
+
+    private static Log log = LogFactory.getLog(TxRollbackWithContextHandler.class);
+
+    private static TxRollbackWithContextHandler _instance = new TxRollbackWithContextHandler();
+
+    public static TxRollbackWithContextHandler getInstance() {
+        return _instance;
+    }
+
+    @Override
+    public void methodReceived(AMQStateManager stateManager, TxRollbackWithContextBody body, final int channelId)
+            throws AMQException {
+
+        final AMQProtocolSession session = stateManager.getProtocolSession();
+
+        if (log.isDebugEnabled()) {
+            log.debug("Rollback frame received with lastDispatchedDeliveryTag: " + body.getLastDispatchedDeliveryTag());
+        }
+
+        try {
+            AMQChannel channel = session.getChannel(channelId);
+
+            if (channel == null) {
+                throw body.getChannelNotFoundException(channelId);
+            }
+
+            QueueEntry message = channel.getUnacknowledgedMessageMap().get(body.getLastDispatchedDeliveryTag());
+
+            channel.getSubscription(body.getConsumerTag()).setJMSRollbackInProgress(true);
+
+            if (null != message) {
+                channel.setLastRollbackedMessageId(message.getMessage().getMessageNumber());
+            }
+
+            final MethodRegistry methodRegistry = session.getMethodRegistry();
+            final AMQMethodBody responseBody = methodRegistry.createTxRollbackOkBody();
+
+            Runnable task = new Runnable() {
+
+                public void run() {
+                    session.writeFrame(responseBody.generateFrame(channelId));
+                }
+            };
+
+            channel.rollback(task);
+
+        } catch (AMQException e) {
+            throw body.getChannelException(e.getErrorCode(), "Failed to rollback: " + e.getMessage());
+        }
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/QueueEntryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/QueueEntryImpl.java
@@ -359,7 +359,8 @@ public class QueueEntryImpl implements QueueEntry
         }
         else
         {
-            _log.warn("Requesting rejection by null subscriber:" + this);
+            _log.warn("Requesting rejection by null subscriber for message ID : " + getMessage().getMessageNumber() +
+                    " . hashcode : " + this);
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/Subscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/Subscription.java
@@ -113,4 +113,17 @@ public interface Subscription
      * @return isNoLocal true / false
      */
     public boolean isNoLocal();
+
+    /**
+     *
+     * @return true if a JMS rollback is in progress for this subscription.
+     */
+    boolean isJMSRollbackInProgress();
+
+    /**
+     * Set to true if the subscriber is handling a rollback event. Until the rollback is finished, we should not
+     * queue-up any new messages other than what we have already sent to this subscriber (client-side).
+     * @param jmsRollbackInProgress
+     */
+    void setJMSRollbackInProgress(boolean jmsRollbackInProgress);
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/SubscriptionImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/SubscriptionImpl.java
@@ -31,7 +31,6 @@ import org.wso2.andes.configuration.qpid.SubscriptionConfigType;
 import org.wso2.andes.framing.AMQShortString;
 import org.wso2.andes.framing.FieldTable;
 import org.wso2.andes.kernel.AndesUtils;
-import org.wso2.andes.kernel.ProtocolDeliveryFailureException;
 import org.wso2.andes.kernel.SubscriptionAlreadyClosedException;
 import org.wso2.andes.protocol.AMQConstant;
 import org.wso2.andes.server.AMQChannel;
@@ -102,6 +101,10 @@ public abstract class SubscriptionImpl implements Subscription, FlowCreditManage
     private final AtomicLong _deliveredCount = new AtomicLong(0);
     private long _createTime = System.currentTimeMillis();
 
+    /**
+     * State variable to detect if this subscription is handling a JMS session rollback at a given moment.
+     */
+    private AtomicBoolean isJMSRollbackInProgress = new AtomicBoolean(false);
 
     public static final class BrowserSubscription extends SubscriptionImpl
     {
@@ -859,5 +862,23 @@ public abstract class SubscriptionImpl implements Subscription, FlowCreditManage
     @Override
     public boolean isNoLocal() {
         return _noLocal;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return
+     */
+    @Override
+    public boolean isJMSRollbackInProgress() {
+        return isJMSRollbackInProgress.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @param jmsRollbackInProgress
+     */
+    @Override
+    public void setJMSRollbackInProgress(boolean jmsRollbackInProgress) {
+        isJMSRollbackInProgress.set(jmsRollbackInProgress);
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/Subscription_0_10.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/Subscription_0_10.java
@@ -939,4 +939,16 @@ public class Subscription_0_10 implements Subscription, FlowCreditManager.FlowCr
         return (LogSubject) this;
     }
 
+    @Override
+    public boolean isJMSRollbackInProgress() {
+        // todo JMS rollback not implemented with AMQP 0.10
+        return false;
+    }
+
+
+    @Override
+    public void setJMSRollbackInProgress(boolean jmsRollbackInProgress) {
+        // todo JMS rollback not implemented with AMQP 0.10
+    }
+
 }

--- a/modules/andes-core/broker/src/test/java/org/wso2/andes/server/subscription/MockSubscription.java
+++ b/modules/andes-core/broker/src/test/java/org/wso2/andes/server/subscription/MockSubscription.java
@@ -270,4 +270,14 @@ public class MockSubscription implements Subscription
     public boolean isNoLocal() {
         return false;
     }
+
+    public boolean isJMSRollbackInProgress() {
+        return false;
+    }
+
+    @Override
+    public void setJMSRollbackInProgress(boolean jmsRollbackInProgress)
+    {
+        //Not Implemented
+    }
 }

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession_0_10.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession_0_10.java
@@ -1381,5 +1381,12 @@ public class AMQSession_0_10 extends AMQSession<BasicMessageConsumer_0_10, Basic
         sb.append(">");
         return sb.toString();
     }
+
+    @Override
+    public void sendRollbackWithContext(long lastDispatchedDeliveryTag, int consumerTag) throws AMQException,
+            FailoverException {
+        // todo rollback with context for AMQP 0_10 is Not implemented. So using normal rollback.
+        sendRollback();
+    }
     
 }

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession_0_8.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession_0_8.java
@@ -68,6 +68,7 @@ import org.wso2.andes.framing.QueueDeleteOkBody;
 import org.wso2.andes.framing.TxCommitOkBody;
 import org.wso2.andes.framing.TxRollbackBody;
 import org.wso2.andes.framing.TxRollbackOkBody;
+import org.wso2.andes.framing.TxRollbackWithContextBody;
 import org.wso2.andes.framing.amqp_0_9.MethodRegistry_0_9;
 import org.wso2.andes.framing.amqp_0_91.MethodRegistry_0_91;
 import org.wso2.andes.jms.Session;
@@ -633,6 +634,18 @@ public class AMQSession_0_8 extends AMQSession<BasicMessageConsumer_0_8, BasicMe
         {
             return null;
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void sendRollbackWithContext(long lastDispatchedDeliveryTag, int consumerTag) throws FailoverException,
+            AMQException {
+
+        TxRollbackWithContextBody body = ((MethodRegistry_0_91)getMethodRegistry()).createTxRollbackWithContextBody
+                (lastDispatchedDeliveryTag, AMQShortString.valueOf(consumerTag));
+        AMQFrame frame = body.generateFrame(getChannelId());
+        getProtocolHandler().syncWrite(frame, TxRollbackOkBody.class);
     }
 
 }

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/handler/ClientMethodDispatcherImpl_0_91.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/handler/ClientMethodDispatcherImpl_0_91.java
@@ -67,6 +67,7 @@ import org.wso2.andes.framing.QueueUnbindBody;
 import org.wso2.andes.framing.QueueUnbindOkBody;
 import org.wso2.andes.framing.amqp_0_91.DtxStartOkBodyImpl;
 import org.wso2.andes.framing.amqp_0_91.MethodDispatcher_0_91;
+import org.wso2.andes.framing.TxRollbackWithContextBody;
 
 public class ClientMethodDispatcherImpl_0_91 extends ClientMethodDispatcherImpl implements MethodDispatcher_0_91
 {
@@ -296,6 +297,11 @@ public class ClientMethodDispatcherImpl_0_91 extends ClientMethodDispatcherImpl 
 
     @Override
     public boolean dispatchDtxSetTimeout(DtxSetTimeoutBody body, int channelId) throws AMQException {
+        return false;
+    }
+
+    @Override
+    public boolean dispatchTxRollbackWithContext(TxRollbackWithContextBody body, int channelId) throws AMQException {
         return false;
     }
 

--- a/modules/andes-core/client/src/test/java/org/wso2/andes/unit/message/TestAMQSession.java
+++ b/modules/andes-core/client/src/test/java/org/wso2/andes/unit/message/TestAMQSession.java
@@ -207,4 +207,14 @@ public class TestAMQSession extends AMQSession<BasicMessageConsumer_0_8, BasicMe
     {
         return null;
     }
+
+    public void sendRollbackWithContext(long lastRollbackedMessageId, int consumerTag) throws FailoverException,
+            AMQException {
+
+    }
+
+    public void sendRollbackComplete(int consumerTag) throws AMQException, FailoverException {
+        // todo rollback with context for tests is Not implemented. So not doing anything here.
+
+    }
 }

--- a/modules/andes-core/systests/src/main/java/org/wso2/andes/server/queue/SubscriptionTestHelper.java
+++ b/modules/andes-core/systests/src/main/java/org/wso2/andes/server/queue/SubscriptionTestHelper.java
@@ -301,4 +301,13 @@ public class SubscriptionTestHelper implements Subscription
     public boolean isNoLocal() {
         return false;
     }
+
+    public boolean isJMSRollbackInProgress() {
+        return false;
+    }
+
+    public void setJMSRollbackInProgress(boolean jmsRollbackInProgress)
+    {
+        //Not Implemented
+    }
 }

--- a/modules/specs/amqp0-9-1.stripped.xml
+++ b/modules/specs/amqp0-9-1.stripped.xml
@@ -470,6 +470,12 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <chassis name="server" implement="MUST"/>
       <response name="rollback-ok"/>
     </method>
+    <method name="rollback-with-context" synchronous="1" index="40">
+      <chassis name="server" implement="MUST"/>
+      <response name="rollback-ok"/>
+      <field name="last-dispatched-delivery-tag" type="long" />
+      <field name="consumer-tag" type="shortstr" />
+    </method>
     <method name="rollback-ok" synchronous="1" index="31">
       <chassis name="client" implement="MUST"/>
     </method>


### PR DESCRIPTION
Client side - 

When rolling back messages not yet seen by the application, iteration of the DelayedQueue will cause jumbling of message order. Therefore used a while -> take/pull loop. 

After all messages are rejected, client side must wait until all rejected messages arrive in order to release the rollback lock. Used a CountdownLatch for this purpose. 

Server Side : 

Server must know the last seen message ID by the application, and should only increase the message.deliveryCount if the requeing message ID <= to the lastSeenMessageID. Wrote a custom RollbackWithContext frame for this (to replace AMQP "rollback" frame). So, when using JMS transactions with our java andes client, this new frame will be used. When using any other AMQP client, the existing "rollback" flow will execute. 

* In amqp-0-91 section 2.2.9, The rollback behavior does not guarantee redelivery of the messages, but relies on client's acknowledgement. In JMS, the message order should be guaranteed. Hence, this new frame. 

While the server is handling the rollback event from client side, no new messages should be dispatched to the client. In our case, the MessageFlusher will asynchronously queue such new messages regardless of rollback. Used a kind of a delivery rule to avoid new messages being queued until rollback is complete.



