### PR TITLE
Avoid clearing clustering information at startup

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextStore.java
@@ -595,12 +595,6 @@ public interface AndesContextStore extends HealthAwareStore {
      */
     String getCoordinatorNodeId() throws AndesException;
 
-    /**
-     * Clear all heartbeat data present in the database. This is normally done when the cluster is restarted
-     *
-     * @throws AndesException when an error is detected while calling the store (mostly due to a DB error)
-     */
-    void clearHeartBeatData() throws AndesException;
 
     /*
      * ============================ Membership related methods =======================================
@@ -622,11 +616,6 @@ public interface AndesContextStore extends HealthAwareStore {
      * @param nodeID local node ID used to read event for current node
      */
     List<MembershipEvent> readMemberShipEvents(String nodeID) throws AndesException;
-
-    /**
-     * Method to remove all membership events from the store.
-     */
-    void clearMembershipEvents() throws AndesException;
 
     /**
      * Method to remove all membership events from the store for a particular node.
@@ -655,13 +644,6 @@ public interface AndesContextStore extends HealthAwareStore {
      * @throws AndesException
      */
     List<ClusterNotification> readClusterNotifications(String nodeID) throws AndesException;
-
-    /**
-     * Clears all cluster notifications.
-     *
-     * @throws AndesException
-     */
-    void clearClusterNotifications() throws AndesException;
 
     /**
      * Clears cluster notifications for a particular node.

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
@@ -154,9 +154,6 @@ public class AndesKernelBoot {
             try {
                 hazelcastAgent.acquireInitializationLock();
                 if (!hazelcastAgent.isClusterInitializedSuccessfully()) {
-                    contextStore.clearMembershipEvents();
-                    contextStore.clearHeartBeatData();
-                    clusterNotificationListenerManager.clearAllClusterNotifications();
                     clearSlotStorage();
 
                     // Initialize current node's last published ID

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/RDBMSCoordinationStrategy.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/RDBMSCoordinationStrategy.java
@@ -214,6 +214,7 @@ class RDBMSCoordinationStrategy implements CoordinationStrategy, RDBMSMembership
         // Clear old membership events for current node.
         try {
             contextStore.clearMembershipEvents(nodeId);
+            contextStore.removeNodeHeartbeat(nodeId);
         } catch (AndesException e) {
             logger.warn("Error while clearing old membership events for local node (" + nodeId + ")", e);
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/ClusterNotificationListenerManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/ClusterNotificationListenerManager.java
@@ -44,13 +44,6 @@ public interface ClusterNotificationListenerManager {
     void reInitializeListener() throws AndesException;
 
     /**
-     * Clears all persisted cluster notifications at server startup.
-     *
-     * @throws AndesException
-     */
-    void clearAllClusterNotifications() throws AndesException;
-
-    /**
      * Stops the cluster event listener.
      *
      * @throws AndesException

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HazelcastClusterNotificationListenerImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HazelcastClusterNotificationListenerImpl.java
@@ -112,11 +112,6 @@ public class HazelcastClusterNotificationListenerImpl implements ClusterNotifica
     }
 
     @Override
-    public void clearAllClusterNotifications() throws AndesException {
-        //Do nothing since this is handle by hazelcast itself
-    }
-
-    @Override
     public void stopListener() throws AndesException {
         //Do nothing, this will be handled by shutting down the hazelcast instance.
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/rdbms/RDBMSClusterNotificationListenerImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/rdbms/RDBMSClusterNotificationListenerImpl.java
@@ -198,14 +198,6 @@ public class RDBMSClusterNotificationListenerImpl implements ClusterNotification
      * {@inheritDoc}
      */
     @Override
-    public void clearAllClusterNotifications() throws AndesException {
-        andesContextStore.clearClusterNotifications();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public void stopListener() throws AndesException {
         scheduledExecutorService.shutdown();
         log.info("RDBMS cluster event listener stopped.");

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingAndesContextStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingAndesContextStore.java
@@ -994,16 +994,6 @@ public class FailureObservingAndesContextStore extends FailureObservingStore<And
         }
     }
 
-    @Override
-    public void clearHeartBeatData() throws AndesException {
-        try {
-            wrappedInstance.clearHeartBeatData();
-        } catch (AndesStoreUnavailableException exception) {
-            notifyFailures(exception);
-            throw exception;
-        }
-    }
-
     /**
      * {@inheritDoc}
      */
@@ -1025,19 +1015,6 @@ public class FailureObservingAndesContextStore extends FailureObservingStore<And
     public List<MembershipEvent> readMemberShipEvents(String nodeID) throws AndesException {
         try {
             return wrappedInstance.readMemberShipEvents(nodeID);
-        } catch (AndesStoreUnavailableException exception) {
-            notifyFailures(exception);
-            throw exception;
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void clearMembershipEvents() throws AndesException {
-        try {
-            wrappedInstance.clearMembershipEvents();
         } catch (AndesStoreUnavailableException exception) {
             notifyFailures(exception);
             throw exception;
@@ -1077,18 +1054,6 @@ public class FailureObservingAndesContextStore extends FailureObservingStore<And
     public List<ClusterNotification> readClusterNotifications(String nodeID) throws AndesException {
         try {
             return wrappedInstance.readClusterNotifications(nodeID);
-        } catch (AndesStoreUnavailableException exception) {
-            notifyFailures(exception);
-            throw exception;
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public void clearClusterNotifications() throws AndesException {
-        try {
-            wrappedInstance.clearClusterNotifications();
         } catch (AndesStoreUnavailableException exception) {
             notifyFailures(exception);
             throw exception;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingAndesContextStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingAndesContextStore.java
@@ -1037,6 +1037,7 @@ public class FailureObservingAndesContextStore extends FailureObservingStore<And
     /**
      * {@inheritDoc}
      */
+    @Override
     public void storeClusterNotification(List<String> clusterNodes, String originatedNode, String artifactType, String
             clusterNotificationType, String notification, String description) throws AndesException {
         try {
@@ -1051,6 +1052,7 @@ public class FailureObservingAndesContextStore extends FailureObservingStore<And
     /**
      * {@inheritDoc}.
      */
+    @Override
     public List<ClusterNotification> readClusterNotifications(String nodeID) throws AndesException {
         try {
             return wrappedInstance.readClusterNotifications(nodeID);
@@ -1063,6 +1065,7 @@ public class FailureObservingAndesContextStore extends FailureObservingStore<And
     /**
      * {@inheritDoc}
      */
+    @Override
     public void clearClusterNotifications(String nodeID) throws AndesException {
         try {
             wrappedInstance.clearClusterNotifications(nodeID);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSAndesContextStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSAndesContextStoreImpl.java
@@ -40,7 +40,6 @@ import org.wso2.carbon.metrics.manager.Level;
 import org.wso2.carbon.metrics.manager.MetricManager;
 import org.wso2.carbon.metrics.manager.Timer.Context;
 
-import javax.sql.DataSource;
 import java.net.InetSocketAddress;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -52,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import javax.sql.DataSource;
 
 /**
  * ANSI SQL based Andes Context Store implementation. This is used to persist information of
@@ -2582,56 +2582,6 @@ public class RDBMSAndesContextStoreImpl implements AndesContextStore {
      * {@inheritDoc}
      */
     @Override
-    public void clearMembershipEvents() throws AndesException {
-        Connection connection = null;
-        PreparedStatement clearMembershipEvents = null;
-        String task = "Clearing all membership events";
-        try {
-            connection = getConnection();
-            clearMembershipEvents = connection.prepareStatement(RDBMSConstants.PS_CLEAR_ALL_MEMBERSHIP_EVENTS);
-            clearMembershipEvents.executeUpdate();
-            connection.commit();
-        } catch (SQLException e) {
-            rollback(connection, task);
-            throw rdbmsStoreUtils.convertSQLException("Error occurred while " + task, e);
-        } finally {
-            close(clearMembershipEvents, task);
-            close(connection, task);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void clearHeartBeatData() throws AndesException {
-        Connection connection = null;
-        PreparedStatement clearNodeHeartbeatData = null;
-        PreparedStatement clearCoordinatorHeartbeatData = null;
-        String task = "Clearing all heartbeat data";
-        try {
-            connection = getConnection();
-            clearNodeHeartbeatData = connection.prepareStatement(RDBMSConstants.PS_CLEAR_NODE_HEARTBEATS);
-            clearNodeHeartbeatData.executeUpdate();
-
-            clearCoordinatorHeartbeatData = connection.prepareStatement(RDBMSConstants.PS_CLEAR_COORDINATOR_HEARTBEAT);
-            clearCoordinatorHeartbeatData.executeUpdate();
-
-            connection.commit();
-        } catch (SQLException e) {
-            rollback(connection, task);
-            throw rdbmsStoreUtils.convertSQLException("Error occurred while " + task, e);
-        } finally {
-            close(clearNodeHeartbeatData, task);
-            close(clearCoordinatorHeartbeatData, task);
-            close(connection, task);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public void clearMembershipEvents(String nodeID) throws AndesException {
         Connection connection = null;
         PreparedStatement clearMembershipEvents = null;
@@ -2728,28 +2678,6 @@ public class RDBMSAndesContextStoreImpl implements AndesContextStore {
         } finally {
             close(resultSet, task);
             close(preparedStatement, task);
-            close(clearMembershipEvents, task);
-            close(connection, task);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void clearClusterNotifications() throws AndesException {
-        Connection connection = null;
-        PreparedStatement clearMembershipEvents = null;
-        String task = "Clearing all cluster notifications";
-        try {
-            connection = getConnection();
-            clearMembershipEvents = connection.prepareStatement(RDBMSConstants.PS_CLEAR_ALL_CLUSTER_NOTIFICATIONS);
-            clearMembershipEvents.executeUpdate();
-            connection.commit();
-        } catch (SQLException e) {
-            rollback(connection, task);
-            throw rdbmsStoreUtils.convertSQLException("Error occurred while " + task, e);
-        } finally {
             close(clearMembershipEvents, task);
             close(connection, task);
         }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -429,12 +429,6 @@ public class RDBMSConstants {
             + " ORDER BY " + EVENT_ID;
 
     /**
-     * Prepared statement to clear all cluster notifications.
-     */
-    protected static final String PS_CLEAR_ALL_CLUSTER_NOTIFICATIONS =
-            "DELETE FROM " + CLUSTER_EVENT_TABLE;
-
-    /**
      * Prepared statement to clear cluster notifications destined to a particular member.
      */
     protected static final String PS_CLEAR_CLUSTER_NOTIFICATIONS_FOR_NODE =
@@ -884,12 +878,6 @@ public class RDBMSConstants {
             "DELETE FROM " + CLUSTER_NODE_HEARTBEAT_TABLE
                     + " WHERE " + NODE_ID + "=?";
 
-    protected static final String PS_CLEAR_NODE_HEARTBEATS =
-            "DELETE FROM " + CLUSTER_NODE_HEARTBEAT_TABLE;
-
-    protected static final String PS_CLEAR_COORDINATOR_HEARTBEAT =
-            "DELETE FROM " + CLUSTER_COORDINATOR_HEARTBEAT_TABLE;
-
     /**
      * Prepared statement to get slot message ids
      */
@@ -1053,12 +1041,6 @@ public class RDBMSConstants {
             + " FROM " + MEMBERSHIP_TABLE
             + " WHERE " + NODE_ID + "=?"
                     + " ORDER BY "  + EVENT_ID;
-
-    /**
-     * Prepared statement to clear the membership event table.
-     */
-    protected static final String PS_CLEAR_ALL_MEMBERSHIP_EVENTS =
-            "DELETE FROM " + MEMBERSHIP_TABLE;
 
     /**
      * Prepared statement to slear membership change events destined to a particular member.


### PR DESCRIPTION
This is to avoid cluster information (heartbeat data, cluster notifications, membership notifications) getting removed after initializing the coordination strategy. Only information destined to current node will be removed.