### PR TITLE
Recover ack duplication

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
@@ -643,4 +643,16 @@ public class QpidAndesBridge {
             }
         }
     }
+
+    /**
+     * notifies andes that a channel suspend/resume request has been received.
+     *
+     * @param channelId           the channel id from which the request was received
+     * @param active              whether the channel should be suspended/resumed. If set to true, channel will be
+     *                            resumed and vis versa
+     * @param channelFlowCallback the call back to be registered to send the response
+     */
+    public static void notifyChannelFlow(UUID channelId, boolean active, DisruptorEventCallback channelFlowCallback) {
+        Andes.getInstance().notifySubscriptionFlow(channelId, active, channelFlowCallback);
+    }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/Andes.java
@@ -27,6 +27,7 @@ import org.wso2.andes.configuration.enums.AndesConfiguration;
 import org.wso2.andes.kernel.disruptor.DisruptorEventCallback;
 import org.wso2.andes.kernel.disruptor.inbound.InboundAndesChannelEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundBindingEvent;
+import org.wso2.andes.kernel.disruptor.inbound.InboundChannelFlowEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundDeleteDLCMessagesEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundDeleteMessagesEvent;
 import org.wso2.andes.kernel.disruptor.inbound.InboundEventManager;
@@ -836,6 +837,21 @@ public class Andes {
     public List<Long> getNextNMessageIdsInDLC(final String dlcQueueName, long startMessageId, int messageLimit)
             throws AndesException {
         return MessagingEngine.getInstance().getNextNMessageIdsInDLC(dlcQueueName, startMessageId, messageLimit);
+    }
+
+    /**
+     * Publishes a channel suspend/resume event to the disruptor.
+     *
+     * @param channelId           the channel id from which the request was received
+     * @param active              whether the channel should be suspended/resumed. If set to true, channel will be
+     *                            resumed and vis versa
+     * @param channelFlowCallback the call back to be registered to send the response
+     */
+    public void notifySubscriptionFlow(UUID channelId, boolean active, DisruptorEventCallback channelFlowCallback) {
+
+        InboundChannelFlowEvent inboundChannelFlowEvent = new InboundChannelFlowEvent(channelId, active,
+                channelFlowCallback);
+        inboundEventManager.publishStateEvent(inboundChannelFlowEvent);
     }
 }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
@@ -482,6 +482,10 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
             if (null != messageStatus && messageStatus.equals(ChannelMessageStatus.CLIENT_REJECTED)) {
                 continue;
             }
+            //the message could be recovered by one client and acknowledged by another, hence needs to be ignored
+            if (null != messageStatus && messageStatus.equals(ChannelMessageStatus.RECOVERED)) {
+                continue;
+            }
             if (null == messageStatus || !messageStatus.equals(ChannelMessageStatus.ACKED)) {
                 isAcked = false;
                 break;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
@@ -50,13 +50,12 @@ public class FlowControlledQueueMessageDeliveryImpl implements MessageDeliverySt
         int sentMessageCount = 0;
         Iterator<DeliverableAndesMetadata> iterator = messages.iterator();
 
-        /**
-         * get all relevant type of subscriptions.
-         * For durable topic subscriptions this should return queue subscription
-         * bound to unique queue based on subscription id
+        /*
+          get all relevant types of subscriptions that are not suspended. For durable topic subscriptions
+          this should return queue subscription bound to unique queue based on subscription id.
          */
         List<org.wso2.andes.kernel.subscription.AndesSubscription> subscriptions4Queue =
-                storageQueue.getBoundSubscriptions();
+                storageQueue.getBoundUnSuspendedSubscriptions();
 
         List<org.wso2.andes.kernel.subscription.AndesSubscription> currentSubscriptions
                 = new ArrayList<>(subscriptions4Queue);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
@@ -50,13 +50,12 @@ public class NoLossBurstTopicMessageDeliveryImpl implements MessageDeliveryStrat
         Iterator<DeliverableAndesMetadata> iterator = messages.iterator();
         List<DeliverableAndesMetadata> droppedTopicMessagesList = new ArrayList<>();
 
-        /**
-         * get all relevant type of subscriptions. This call does NOT
-         * return hierarchical subscriptions for the destination. There
-         * are duplicated messages for each different subscribed destination.
+        /*
+          Get all relevant types of subscriptions that are not suspended. This call does NOT return hierarchical
+          subscriptions for the destination. There are duplicated messages for each different subscribed destination.
          */
         List<org.wso2.andes.kernel.subscription.AndesSubscription> subscriptions4Queue =
-                storageQueue.getBoundSubscriptions();
+                storageQueue.getBoundUnSuspendedSubscriptions();
 
         List<org.wso2.andes.kernel.subscription.AndesSubscription> currentSubscriptions =
                 Collections.unmodifiableList(subscriptions4Queue);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
@@ -49,13 +49,12 @@ public class SlowestSubscriberTopicMessageDeliveryImpl implements MessageDeliver
         Iterator<DeliverableAndesMetadata> iterator = messages.iterator();
         List<DeliverableAndesMetadata> droppedTopicMessagesList = new ArrayList<>();
 
-        /**
-         * get all relevant type of subscriptions. This call does NOT
-         * return hierarchical subscriptions for the destination. There
-         * are duplicated messages for each different subscribed destination.
+        /*
+          get all relevant type of subscriptions that are not suspended. This call does NOT return hierarchical
+          subscriptions for the destination. There are duplicated messages for each different subscribed destination.
          */
         List<org.wso2.andes.kernel.subscription.AndesSubscription> subscriptions4Queue =
-                storageQueue.getBoundSubscriptions();
+                storageQueue.getBoundUnSuspendedSubscriptions();
 
         List<org.wso2.andes.kernel.subscription.AndesSubscription> currentSubscriptions =
                 Collections.unmodifiableList(subscriptions4Queue);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundChannelFlowEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundChannelFlowEvent.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c)2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel.disruptor.inbound;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.AndesContext;
+import org.wso2.andes.kernel.disruptor.DisruptorEventCallback;
+
+import java.util.UUID;
+
+/**
+ * InboundChannelFlow event is used when a channel suspend/resume request is received. Once received, andes
+ * subscription manager is notified of the flow state to be updated.
+ */
+public class InboundChannelFlowEvent implements AndesInboundStateEvent {
+
+    private static Log log = LogFactory.getLog(InboundAndesChannelEvent.class);
+
+    /**
+     * Supported state events.
+     */
+    public enum EventType {
+
+        /**
+         * channel flow event signals the channel to be suspended/resumed.
+         */
+        CHANNEL_FLOW_EVENT
+    }
+
+    /**
+     * Channel event type handled by the event.
+     */
+    private EventType eventType;
+
+    /**
+     * Channel ID to which the flow information is related.
+     */
+    private UUID channelID;
+
+    /**
+     * Callback to send flow ok
+     */
+    private DisruptorEventCallback callback;
+
+    /**
+     * Whether the event suspends or resumes message delivery to the channel. If active is set to false, the channel
+     * will be suspended.
+     */
+    private boolean active;
+
+    /**
+     * Creates a disruptor event for channel event.
+     *
+     * @param channelID     Id of the channel
+     * @param active        the new state of the channel. If set to false, the channel is suspended.
+     * @param eventCallback Callback to send response
+     */
+    public InboundChannelFlowEvent(UUID channelID, boolean active, DisruptorEventCallback eventCallback) {
+        eventType = EventType.CHANNEL_FLOW_EVENT;
+        this.channelID = channelID;
+        this.active = active;
+        callback = eventCallback;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void updateState() {
+        switch (eventType) {
+            case CHANNEL_FLOW_EVENT:
+                AndesContext.getInstance().getAndesSubscriptionManager().notifySubscriptionFlow(channelID, active);
+                callback.execute();
+                break;
+            default:
+                log.error("Event type not set properly " + eventType);
+                break;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String eventInfo() {
+        return eventType.toString();
+    }
+
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscription.java
@@ -569,4 +569,18 @@ public class AndesSubscription {
                 + ",subscriberConnection=" + encodedConnectionInfo;
     }
 
+    /**
+     * Suspends message delivery for the subscription. Messages will no longer be buffered to the subscription until
+     * the subscription is resumed.
+     */
+    public void suspend() {
+        storageQueue.suspendSubscription(this);
+    }
+
+    /**
+     * Resume delivering messages for the subscription.
+     */
+    public void resume() {
+        storageQueue.resumeSubscription(this);
+    }
 }

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession.java
@@ -1829,9 +1829,7 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
         try
         {
 
-            boolean isSuspended = isSuspended();
-
-            if (!isSuspended)
+            if (!_suspended)
             {
                 suspendChannel(true);
             }
@@ -1855,7 +1853,7 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
             // Set inRecovery to false before you start message flow again again.            
             _inRecovery = false; 
             
-            if (!isSuspended)
+            if (_suspended)
             {
                 suspendChannel(false);
             }


### PR DESCRIPTION
Fixes the issues reported at:

1. https://wso2.org/jira/browse/MB-1919
2. https://wso2.org/jira/browse/MB-1920

Includes the following changes:

1. Added channel flow suspend/resume to broker
This is sent from andes slient prior to and after recovery respectively. Message will not be buffered to the susbscription that is associated with the channel id throughout the time that the channel is suspended.

2. A message which has to delivery statuses as RECOVERED and ACKED from 2 different channel will get deleted upon the ack.