### PR TITLE
[MB-1922] Fix : NPE when restoring empty messages from DLC queue

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
@@ -1136,9 +1136,11 @@ public class QueueManagementInformationMBean extends AMQManagedObject implements
 
             messagesToRemove.add(metadata);
             // Update Andes message with all the chunk details
-            List<AndesMessagePart> messageParts = messageContent.get(messageId);
-            for (AndesMessagePart messagePart : messageParts) {
-                andesMessage.addMessagePart(messagePart);
+            if(!messageContent.isEmpty()) {
+                List<AndesMessagePart> messageParts = messageContent.get(messageId);
+                for (AndesMessagePart messagePart : messageParts) {
+                    andesMessage.addMessagePart(messagePart);
+                }
             }
 
             // Handover message to Andes. This will generate a new message ID and store it


### PR DESCRIPTION
This PR contains the fix for the NPE thrown when restoring messages having empty content from the DLC queue.
Fix : https://wso2.org/jira/browse/MB-1922