### PR TITLE
Fix cluster notification missing in the RDMBS coordination

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HazelcastBasedNotificationAgentImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/hazelcast/HazelcastBasedNotificationAgentImpl.java
@@ -82,7 +82,8 @@ public class HazelcastBasedNotificationAgentImpl implements ClusterNotificationA
                 localNodeID);
 
         if (log.isDebugEnabled()) {
-            log.debug("Sending GOSSIP: " + clusterNotification.getEncodedObjectAsString());
+            log.debug("Sending router change GOSSIP: " + changeType + " - "
+                    + clusterNotification.getEncodedObjectAsString());
         }
         try {
             clusterNotificationChannel.publish(clusterNotification);
@@ -113,7 +114,8 @@ public class HazelcastBasedNotificationAgentImpl implements ClusterNotificationA
                 localNodeID);
 
         if (log.isDebugEnabled()) {
-            log.debug("Sending GOSSIP: " + clusterNotification.getEncodedObjectAsString());
+            log.debug("Sending queue change GOSSIP: " + changeType + " - "
+                    + clusterNotification.getEncodedObjectAsString());
         }
         try {
             clusterNotificationChannel.publish(clusterNotification);
@@ -139,7 +141,8 @@ public class HazelcastBasedNotificationAgentImpl implements ClusterNotificationA
                 localNodeID);
 
         if (log.isDebugEnabled()) {
-            log.debug("GOSSIP: " + clusterNotification.getEncodedObjectAsString());
+            log.debug("Sending binding change GOSSIP: " + changeType + " - "
+                    + clusterNotification.getEncodedObjectAsString());
         }
         try {
             clusterNotificationChannel.publish(clusterNotification);
@@ -169,7 +172,8 @@ public class HazelcastBasedNotificationAgentImpl implements ClusterNotificationA
 
         //check hazelcast instance active because hazelcast bundle get deactivated before notification send
         if (log.isDebugEnabled()) {
-            log.debug("Sending GOSSIP: " + clusterNotification.getEncodedObjectAsString());
+            log.debug("Sending subscription change GOSSIP: " + changeType + " - "
+                    + clusterNotification.getEncodedObjectAsString());
         }
         try {
             clusterNotificationChannel.publish(clusterNotification);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/rdbms/RDBMSBasedNotificationAgentImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/coordination/rdbms/RDBMSBasedNotificationAgentImpl.java
@@ -77,7 +77,8 @@ public class RDBMSBasedNotificationAgentImpl implements ClusterNotificationAgent
                 localNodeID);
 
         if (log.isDebugEnabled()) {
-            log.debug("Sending GOSSIP: " + clusterNotification.getEncodedObjectAsString());
+            log.debug("Sending router change GOSSIP: " + changeType + " - "
+                    + clusterNotification.getEncodedObjectAsString());
         }
         publishNotificationToDB(clusterNotification);
     }
@@ -96,7 +97,8 @@ public class RDBMSBasedNotificationAgentImpl implements ClusterNotificationAgent
                 localNodeID);
 
         if (log.isDebugEnabled()) {
-            log.debug("Sending GOSSIP: " + clusterNotification.getEncodedObjectAsString());
+            log.debug("Sending queue change GOSSIP: " + changeType + " - "
+                    + clusterNotification.getEncodedObjectAsString());
         }
         publishNotificationToDB(clusterNotification);
     }
@@ -115,7 +117,8 @@ public class RDBMSBasedNotificationAgentImpl implements ClusterNotificationAgent
                 localNodeID);
 
         if (log.isDebugEnabled()) {
-            log.debug("GOSSIP: " + clusterNotification.getEncodedObjectAsString());
+            log.debug("Sending binding change GOSSIP: " + changeType + " - "
+                    + clusterNotification.getEncodedObjectAsString());
         }
         publishNotificationToDB(clusterNotification);
     }
@@ -134,7 +137,8 @@ public class RDBMSBasedNotificationAgentImpl implements ClusterNotificationAgent
                 localNodeID);
 
         if (log.isDebugEnabled()) {
-            log.debug("Sending GOSSIP: " + clusterNotification.getEncodedObjectAsString());
+            log.debug("Sending subscription change GOSSIP: " + changeType + " - "
+                    + clusterNotification.getEncodedObjectAsString());
         }
         publishNotificationToDB(clusterNotification);
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -422,8 +422,8 @@ public class RDBMSConstants {
      * Prepared statement to select cluster notification destined to a particular member.
      */
     protected static final String PS_SELECT_CLUSTER_NOTIFICATION_FOR_NODE =
-            "SELECT " + ORIGINATED_MEMBER_ID + ", " + EVENT_ARTIFACT + ","
-                    + EVENT_TYPE + ", " + EVENT_DETAILS + "," + EVENT_DESCRIPTION
+            "SELECT " + EVENT_ID + "," + ORIGINATED_MEMBER_ID + "," + EVENT_ARTIFACT + ","
+                    + EVENT_TYPE + "," + EVENT_DETAILS + "," + EVENT_DESCRIPTION
             + " FROM " + CLUSTER_EVENT_TABLE
             + " WHERE " + DESTINED_MEMBER_ID + "=?"
             + " ORDER BY " + EVENT_ID;
@@ -434,6 +434,10 @@ public class RDBMSConstants {
     protected static final String PS_CLEAR_CLUSTER_NOTIFICATIONS_FOR_NODE =
             "DELETE FROM " + CLUSTER_EVENT_TABLE
             + " WHERE " + DESTINED_MEMBER_ID + "=?";
+
+    protected static final String PS_CLEAR_CLUSTER_NOTIFICATIONS_FOR_EVENT_ID =
+            "DELETE FROM " + CLUSTER_EVENT_TABLE
+                    + " WHERE " + EVENT_ID + "=?";
 
     protected static final String PS_SELECT_ALL_NODE_INFO =
             "SELECT " + NODE_ID + "," + NODE_INFO
@@ -1037,7 +1041,7 @@ public class RDBMSConstants {
      * Prepared statement to select membership change event destined to a particular member.
      */
     protected static final String PS_SELECT_MEMBERSHIP_EVENT =
-            "SELECT " + MEMBERSHIP_CHANGE_TYPE + ", " + MEMBERSHIP_CHANGED_MEMBER_ID
+            "SELECT " + EVENT_ID + "," + MEMBERSHIP_CHANGE_TYPE + "," + MEMBERSHIP_CHANGED_MEMBER_ID
             + " FROM " + MEMBERSHIP_TABLE
             + " WHERE " + NODE_ID + "=?"
                     + " ORDER BY "  + EVENT_ID;
@@ -1048,6 +1052,10 @@ public class RDBMSConstants {
     protected static final String PS_CLEAN_MEMBERSHIP_EVENTS_FOR_NODE =
             "DELETE FROM " + MEMBERSHIP_TABLE
             + " WHERE " + NODE_ID + "=?";
+
+    protected static final String PS_CLEAN_MEMBERSHIP_EVENTS_FOR_EVENT_ID =
+            "DELETE FROM " + MEMBERSHIP_TABLE
+                    + " WHERE " + EVENT_ID + "=?";
 
     /*
      * =============== DTX related prepared statements


### PR DESCRIPTION
RDBMS coordination read notifications from MB_CLUSTER_EVENT and MB_MEMBERSHIP tables.
After selecting notifications, those are deleted by the destined node. This would
lead delete unread notifications in a high concurrent scenario. The fix is select
notifications with event id and then delete notifications by event id.
Additionally, DEBUG logs modified with more details in RDBMSBasedNotificationAgentImpl
and HazelcastBasedNotificationAgentImpl.

Public JIRAs - https://wso2.org/jira/browse/MB-1839, https://wso2.org/jira/browse/MB-1881