### PR TITLE
[MB-1921] Add a scheduled close task to XAConnectionImpl

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/RDBMSCoordinationStrategy.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/cluster/RDBMSCoordinationStrategy.java
@@ -566,6 +566,7 @@ class RDBMSCoordinationStrategy implements CoordinationStrategy, RDBMSMembership
         private void cancelStateExpirationTask() {
             if (scheduledFuture != null) {
                 scheduledFuture.cancel(true);
+                scheduledFuture = null;
             }
         }
 

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionFactory.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionFactory.java
@@ -29,9 +29,6 @@ import org.wso2.andes.jms.ConnectionURL;
 import org.wso2.andes.url.AMQBindingURL;
 import org.wso2.andes.url.URLSyntaxException;
 
-import javax.jms.*;
-import javax.naming.*;
-import javax.naming.spi.ObjectFactory;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.InetAddress;
@@ -40,6 +37,8 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Hashtable;
 import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
 import javax.jms.JMSSecurityException;
@@ -80,6 +79,11 @@ public class AMQConnectionFactory implements ConnectionFactory, QueueConnectionF
 
     private ConnectionListener connectionListener = null;
     private ThreadLocal<Boolean> removeBURL = new ThreadLocal<Boolean>();
+
+    /**
+     * Scheduled executor share by the XAConnectionImpl objects
+     */
+    private ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
 
     private static final Logger log = LoggerFactory.getLogger(AMQConnectionFactory.class);
 
@@ -587,7 +591,7 @@ public class AMQConnectionFactory implements ConnectionFactory, QueueConnectionF
     {
         try
         {
-            return new XAConnectionImpl(_connectionDetails, _sslConfig);
+            return new XAConnectionImpl(_connectionDetails, _sslConfig, scheduledExecutor);
         }
         catch (Exception e)
         {

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/XAConnectionImpl.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/XAConnectionImpl.java
@@ -23,6 +23,9 @@ import org.wso2.andes.AMQException;
 import org.wso2.andes.jms.ConnectionURL;
 
 import java.util.ArrayList;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import javax.jms.IllegalStateException;
 import javax.jms.JMSException;
 import javax.jms.XAConnection;
@@ -43,21 +46,39 @@ public class XAConnectionImpl extends AMQConnection implements XAConnection, XAQ
     private static final Logger LOGGER = LoggerFactory.getLogger(XAConnectionImpl.class);
 
     /**
+     * After this delay(in seconds), the connection will be closed even if a commit or rollback is not received. This
+     * is done to avoid stale connections to broker.
+     */
+    private static final int CONNECTION_CLOSE_TIMEOUT = 60;
+
+    /**
      * Keep track of active XA sessions
      */
     private final ArrayList<XASession_9_1> xaSessions = new ArrayList<>();
+
+    /**
+     * Executor service used to schedule connection close task.
+     */
+    private final ScheduledExecutorService scheduledExecutor;
 
     /**
      * Indicate if the connection.close is called before
      */
     private boolean connectionCloseSignaled = false;
 
+    /**
+     * Hold the future object of the scheduled close task
+     */
+    private ScheduledFuture<?> connectionCloseFuture;
+
     //-- constructor
     /**
      * Create a XAConnection from a connectionURL
      */
-    XAConnectionImpl(ConnectionURL connectionURL, SSLConfiguration sslConfig) throws AMQException {
+    XAConnectionImpl(ConnectionURL connectionURL, SSLConfiguration sslConfig,
+            ScheduledExecutorService scheduledExecutor) throws AMQException {
         super(connectionURL, sslConfig);
+        this.scheduledExecutor = scheduledExecutor;
     }
 
     //-- interface XAConnection
@@ -65,7 +86,7 @@ public class XAConnectionImpl extends AMQConnection implements XAConnection, XAQ
      * Creates an XASession.
      *
      * @return A newly created XASession.
-     * @throws JMSException If the XAConnectiono fails to create an XASession due to
+     * @throws JMSException If the XAConnection fails to create an XASession due to
      *                      some internal error.
      */
     public synchronized XASession createXASession() throws JMSException {
@@ -124,10 +145,31 @@ public class XAConnectionImpl extends AMQConnection implements XAConnection, XAQ
                 super.close();
             } else {
                 LOGGER.error("XAConnection.close() was called before committing or rolling back");
+                connectionCloseFuture = scheduledExecutor.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            LOGGER.error("Closing XAConnection after waiting " + CONNECTION_CLOSE_TIMEOUT
+                                                 + " seconds for a commit or rollback");
+                            closePhysicalConnection();
+                        } catch (JMSException e) {
+                            LOGGER.error("Error occurred while closing the XAConnection after close timeout");
+                        }
+                    }
+                }, CONNECTION_CLOSE_TIMEOUT, TimeUnit.SECONDS);
             }
 
             connectionCloseSignaled = true;
         }
+    }
+
+    /**
+     * Close the underline socket connection
+     *
+     * @throws JMSException if failed to close the socket connection
+     */
+    private void closePhysicalConnection() throws JMSException {
+        super.close();
     }
 
     /**
@@ -145,9 +187,35 @@ public class XAConnectionImpl extends AMQConnection implements XAConnection, XAQ
      *
      * @throws JMSException if there was an error closing the physical connection
      */
-    synchronized void internalClose() throws JMSException {
+    void internalClose() throws JMSException {
+        boolean closeSuccessful = closeIfNoActiveSessions();
+        if (closeSuccessful) {
+            removeScheduledClose();
+        }
+    }
+
+    /**
+     * Closes the physical connection if there are no active sessions
+     *
+     * @return true if physical connection is closed, false otherwise
+     * @throws JMSException if there was an closing the connection
+     */
+    private synchronized boolean closeIfNoActiveSessions() throws JMSException {
         if (xaSessions.isEmpty()) {
-            super.close();
+            closePhysicalConnection();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Remove the scheduled connection close task
+     */
+    private synchronized void removeScheduledClose() {
+        if (connectionCloseFuture != null) {
+            connectionCloseFuture.cancel(true);
+            connectionCloseFuture = null;
         }
     }
 }

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/XAConnectionImpl.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/XAConnectionImpl.java
@@ -49,7 +49,7 @@ public class XAConnectionImpl extends AMQConnection implements XAConnection, XAQ
      * After this delay(in seconds), the connection will be closed even if a commit or rollback is not received. This
      * is done to avoid stale connections to broker.
      */
-    private static final int CONNECTION_CLOSE_TIMEOUT = 60;
+    private int connectionCloseTimeout = 60;
 
     /**
      * Keep track of active XA sessions
@@ -78,6 +78,7 @@ public class XAConnectionImpl extends AMQConnection implements XAConnection, XAQ
     XAConnectionImpl(ConnectionURL connectionURL, SSLConfiguration sslConfig,
             ScheduledExecutorService scheduledExecutor) throws AMQException {
         super(connectionURL, sslConfig);
+        this.connectionCloseTimeout = Integer.parseInt(System.getProperty("XaConnectionCloseWaitTimeOut", "60"));
         this.scheduledExecutor = scheduledExecutor;
     }
 
@@ -149,14 +150,14 @@ public class XAConnectionImpl extends AMQConnection implements XAConnection, XAQ
                     @Override
                     public void run() {
                         try {
-                            LOGGER.error("Closing XAConnection after waiting " + CONNECTION_CLOSE_TIMEOUT
+                            LOGGER.error("Closing XAConnection after waiting " + connectionCloseTimeout
                                                  + " seconds for a commit or rollback");
                             closePhysicalConnection();
                         } catch (JMSException e) {
                             LOGGER.error("Error occurred while closing the XAConnection after close timeout");
                         }
                     }
-                }, CONNECTION_CLOSE_TIMEOUT, TimeUnit.SECONDS);
+                }, connectionCloseTimeout, TimeUnit.SECONDS);
             }
 
             connectionCloseSignaled = true;


### PR DESCRIPTION
This to avoid stale connections when a commit or rollback get delayed for a long time.

https://wso2.org/jira/projects/MB/issues/MB-1921