### PR TITLE
[MB-1920] fixed issue of messages not being deleted in fail-over

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
@@ -474,17 +474,26 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
         for (Map.Entry<UUID, ChannelInformation> channelInfoEntry : channelDeliveryInfo.entrySet()) {
             ChannelMessageStatus messageStatus = channelInfoEntry.getValue().getLatestMessageStatus();
 
-            //if channel is closed ignore it from considering
-            if (null != messageStatus && messageStatus.equals(ChannelMessageStatus.CLOSED)) {
-                continue;
-            }
-            //if message is rejected by client repeatedly ignore it from considering
-            if (null != messageStatus && messageStatus.equals(ChannelMessageStatus.CLIENT_REJECTED)) {
-                continue;
-            }
-            if (null == messageStatus || !messageStatus.equals(ChannelMessageStatus.ACKED)) {
+            if (null == messageStatus) {
                 isAcked = false;
                 break;
+            } else {
+                //if channel is closed ignore it from considering
+                if (messageStatus.equals(ChannelMessageStatus.CLOSED)) {
+                    continue;
+                }
+                //if message is rejected by client repeatedly ignore it from considering
+                if (messageStatus.equals(ChannelMessageStatus.CLIENT_REJECTED)) {
+                    continue;
+                }
+                //the message could be recovered by one client and acknowledged by another, hence needs to be ignored
+                if (messageStatus.equals(ChannelMessageStatus.RECOVERED)) {
+                    continue;
+                }
+                if (!messageStatus.equals(ChannelMessageStatus.ACKED)) {
+                    isAcked = false;
+                    break;
+                }
             }
         }
         if (channelDeliveryInfo.isEmpty()) {


### PR DESCRIPTION
Addresses the issue reported at https://wso2.org/jira/browse/MB-1920

A message which has 2 delivery statuses as RECOVERED and ACKED from 2 different channel will get deleted upon the ack.