### PR TITLE
Fix OSGI issue in andes-client with EI

### DIFF
--- a/modules/orbit/andes-client/pom.xml
+++ b/modules/orbit/andes-client/pom.xml
@@ -101,9 +101,9 @@
                         <Export-Package>
                             org.wso2.andes.*;-split-package:=merge-last;version="${project.version}",
                             org.apache.mina.*;-split-package:=merge-last,
-                            org.apache.commons.lang.*;-split-package:=merge-last
                         </Export-Package>
                         <Import-Package>
+                            org.apache.commons.lang.*;version="${commons-lang.imp.pkg.version}",
                             org.slf4j.*;version="1.6.1",
                             org.apache.commons.logging.*,
                             org.wso2.securevault.*,

--- a/pom.xml
+++ b/pom.xml
@@ -645,6 +645,7 @@
         <gs-collections-api.version>7.0.3</gs-collections-api.version>
         <gs-collections.version>7.0.3</gs-collections.version>
         <org.apache.commons.pool.version>2.4.2</org.apache.commons.pool.version>
+        <commons-lang.imp.pkg.version>[2.6, 3.0)</commons-lang.imp.pkg.version>
 
     </properties>
 


### PR DESCRIPTION
This change fix the issue https://github.com/wso2/product-ei/issues/453 in product-ei. It happens due to unnecessary export of org.apache.commons.lang.* package from andes-client. With the fix, it is added as import package and removed from export packages.