### PR TITLE
Fix MB-1910

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/dtx/DtxBranch.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/dtx/DtxBranch.java
@@ -264,7 +264,7 @@ public class DtxBranch {
      * Enqueue a single message to the branch
      * @param andesMessage enqueue record
      */
-    public void enqueueMessage(AndesMessage andesMessage) {
+    public synchronized void enqueueMessage(AndesMessage andesMessage) {
         enqueueList.add(andesMessage);
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/dtx/DtxRegistry.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/dtx/DtxRegistry.java
@@ -334,7 +334,7 @@ public class DtxRegistry {
      *
      * @param sessionId sessionId of the closing transactional session
      */
-    public void close(UUID sessionId) {
+    public synchronized void close(UUID sessionId) {
 
         for (Iterator<Map.Entry<Xid, DtxBranch>> iterator = branches.entrySet().iterator();
              iterator.hasNext(); ) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSDtxStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSDtxStoreImpl.java
@@ -377,7 +377,6 @@ public class RDBMSDtxStoreImpl implements DtxStore {
                         true
                 );
                 AndesMessage andesMessage = new AndesMessage(metadata);
-                branch.enqueueMessage(andesMessage);
                 messageMap.put(metadata.getMessageID(), andesMessage);
             }
             retrieveContentPS.setLong(1, internalXid);


### PR DESCRIPTION
When multiple sessionis initiated with multiple connections work on
a single distributed transaction branch the ArrayList used to keep
enqueued records are accessed parallely. To avoid this behaviur the
enqueue method is synchronized.

https://wso2.org/jira/browse/MB-1910