### PR TITLE
 Improve selectors using multiple cursors

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
@@ -119,7 +119,6 @@ public class FlowControlledQueueMessageDeliveryImpl implements MessageDeliverySt
 
                         //for queue messages and durable topic messages (as they are now queue messages)
                         // we only send to one selected subscriber if it is a queue message
-                        localSubscription.setCursor(currentCursor);
                         minCursor = Long.min(currentCursor, minCursor);
                         if (numOfCurrentMsgDeliverySchedules == 1) {
                             if (log.isDebugEnabled()) {
@@ -132,6 +131,7 @@ public class FlowControlledQueueMessageDeliveryImpl implements MessageDeliverySt
                         }
                         break;
                     }
+                    localSubscription.setCursor(currentCursor);
                 }
             }
             if (isRemoved) {
@@ -152,11 +152,12 @@ public class FlowControlledQueueMessageDeliveryImpl implements MessageDeliverySt
         }
         return sentMessageCount;
     }
+
     /**
      * Check if the message is unacked in at least one of the subscriptions.
      *
      * @param subscriptions The subscriptions to check in.
-     * @param messageId The message id of the message to see if it is unacked.
+     * @param messageId     The message id of the message to see if it is unacked.
      */
     private boolean checkIfUnacked(List<AndesSubscription> subscriptions, long messageId) {
         for (AndesSubscription subscription : subscriptions) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageHandler.java
@@ -15,14 +15,11 @@
 
 package org.wso2.andes.kernel;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import java.util.Collection;
+
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.configuration.AndesConfigurationManager;
@@ -200,8 +197,8 @@ public class MessageHandler {
      *
      * @return Collection with DeliverableAndesMetadata
      */
-    public Collection<DeliverableAndesMetadata> getReadButUndeliveredMessages() {
-        return readButUndeliveredMessages.values();
+    public Map<Long, DeliverableAndesMetadata> getReadButUndeliveredMessages() {
+        return readButUndeliveredMessages;
     }
 
     /**
@@ -303,5 +300,14 @@ public class MessageHandler {
             messageCount = messageStore.getMessageCountForDLCQueue(storageQueueName);
         }
         return messageCount;
+    }
+
+    /**
+     * set the lastBufferedMessageId. This enable having a separate circular buffer.
+     *
+     * @param lastBufferedMessageId last buffered message id.
+     */
+    public void setLastBufferedMessageId(long lastBufferedMessageId) {
+        this.lastBufferedMessageId = lastBufferedMessageId;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
@@ -45,7 +45,7 @@ public class NoLossBurstTopicMessageDeliveryImpl implements MessageDeliveryStrat
     public int deliverMessageToSubscriptions(StorageQueue storageQueue) throws
             AndesException {
 
-        Collection<DeliverableAndesMetadata> messages = storageQueue.getMessagesForDelivery();
+        Collection<DeliverableAndesMetadata> messages = storageQueue.getMessagesForDelivery().values();
         int sentMessageCount = 0;
         Iterator<DeliverableAndesMetadata> iterator = messages.iterator();
         List<DeliverableAndesMetadata> droppedTopicMessagesList = new ArrayList<>();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
@@ -44,7 +44,7 @@ public class SlowestSubscriberTopicMessageDeliveryImpl implements MessageDeliver
     public int deliverMessageToSubscriptions(StorageQueue storageQueue) throws
             AndesException {
 
-        Collection<DeliverableAndesMetadata> messages = storageQueue.getMessagesForDelivery();
+        Collection<DeliverableAndesMetadata> messages = storageQueue.getMessagesForDelivery().values();
         int sentMessageCount = 0;
         Iterator<DeliverableAndesMetadata> iterator = messages.iterator();
         List<DeliverableAndesMetadata> droppedTopicMessagesList = new ArrayList<>();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscription.java
@@ -301,7 +301,7 @@ public class AndesSubscription {
                     unAckedMessage.rollbackDelivery(subscriberConnection.getProtocolChannelID());
                     storageQueue.bufferMessageForDelivery(unAckedMessage);
                     unAckedMessageIterator.remove();
-                    resetCursors();
+                    resetCursors();//TODO:make sure order is maintained for all delivery
                 }
             } else {    //reschedule messages back to subscriber
                 for (DeliverableAndesMetadata unAckedMessage : unAckedMessages) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionManager.java
@@ -177,6 +177,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
         //binding contains some validations. Thus register should happen after binding subscriber to queue
         storageQueue.bindSubscription(subscription, subscriptionRequest.getRoutingKey());
         registerSubscription(subscription);
+        storageQueue.setLastBufferedMessageId(0);
         //Store the subscription
         try {
             andesContextStore.storeDurableSubscription(subscription);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/OutBoundMessageTracker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/OutBoundMessageTracker.java
@@ -114,6 +114,15 @@ public class OutBoundMessageTracker {
     }
 
     /**
+     * Check if the message referenced by the messageId is unacked
+     *
+     * @param messageId ID of the message
+     * @return true if message referenced by messageId is unacked and false if it is not
+     */
+    public boolean isUnacked(long messageId) {
+        return messageSendingTracker.containsKey(messageId);
+    }
+    /**
      * Clear tracked sent but un-acknowledged messages. Return the messages in the same view.
      * While this operation is performed, no new message will be added to the list.
      *

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/StorageQueue.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/StorageQueue.java
@@ -19,6 +19,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -395,9 +398,9 @@ public class StorageQueue {
      * Get messages for delivery. This call returns the messages that are buffered
      * for delivery (read by slots - loadMessagesForDelivery())
      *
-     * @return Collection of messages
+     * @return Map of messages
      */
-    public Collection<DeliverableAndesMetadata> getMessagesForDelivery() {
+    public Map<Long, DeliverableAndesMetadata> getMessagesForDelivery() {
         return messageHandler.getReadButUndeliveredMessages();
     }
 
@@ -453,6 +456,15 @@ public class StorageQueue {
      */
     public long getMessageCount() throws AndesException {
         return messageHandler.getMessageCountForQueue();
+    }
+
+    /**
+     * Set the lastBufferedMessageId in the {@link MessageHandler}. This enable having a separate circular buffer.
+     *
+     * @param lastBufferedMessageId last buffered message id in {@link MessageHandler}.
+     */
+    public void setLastBufferedMessageId(long lastBufferedMessageId) {
+        messageHandler.setLastBufferedMessageId(lastBufferedMessageId);
     }
 
     public boolean equals(Object o) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/SubscriberConnection.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/SubscriberConnection.java
@@ -318,6 +318,16 @@ public class SubscriberConnection {
     }
 
     /**
+     * Check if the message referenced by the messageId is unacked
+     *
+     * @param messageId ID of the message
+     * @return true if message referenced by messageId is unacked and false if it is not
+     */
+    public boolean isUnacked(long messageId) {
+        return outBoundMessageTracker.isUnacked(messageId);
+    }
+
+    /**
      * Get all sent but not acknowledged messages to connection
      *
      * @return list of messages


### PR DESCRIPTION
Changes have been made to let AndesSubscription have a cursor and this cursor is used when filtering selectors for the messages. Also a sliding buffer has been used.