### PR TITLE
Reset message cursor when last subscriber leaves

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageHandler.java
@@ -304,4 +304,12 @@ public class MessageHandler {
         }
         return messageCount;
     }
+
+    /**
+     * Reset the starting message Id to 0,
+     * so that messages can be read from the store from beginning.
+     */
+    public void resetLastBufferedMessageId() {
+        lastBufferedMessageId = 0;
+    }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/StorageQueue.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/StorageQueue.java
@@ -320,8 +320,10 @@ public class StorageQueue {
         if (boundedSubscriptions.isEmpty()) {
             if (isDurable) {
                 messageHandler.clearReadButUndeliveredMessages();
+                // In case of the last subscription being disconnected, we should reset the message Id cursor to read
+                // from the beginning.
+                messageHandler.resetLastBufferedMessageId();
             }
-
             messageHandler.stopMessageDelivery(this);
         } else {
             subscription.rebufferUnackedMessages();


### PR DESCRIPTION
We deliver messages for a given queue based on a cursor that moves forward while delegating every N messages to all active subscribers. However, if the last subscriber leaves abruptly, the next subscription will not receive the messages previously allocated. Thus, resetting the cursor.

Resolves github issue : https://github.com/wso2/product-ei/issues/689