### PR TITLE
Fix wso2/product-ei#737

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DtxStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DtxStore.java
@@ -53,6 +53,16 @@ public interface DtxStore extends HealthAwareStore {
     void updateOnCommit(long internalXid, List<AndesMessage> enqueueRecords) throws AndesException;
 
     /**
+     * Update the store on a dtx.commit(one-phase) request with a set of enqueued and dequeued records.
+     * This is done in a database transaction operation.
+     *
+     * @param enqueueRecords {@link AndesMessage} list to be stored
+     * @param dequeueRecordsMetadata {@link AndesPreparedMessageMetadata} list to be removed
+     * @throws AndesException Throws exception on database related errors
+     */
+    void updateOnOnePhaseCommit(List<AndesMessage> enqueueRecords, List<AndesPreparedMessageMetadata> dequeueRecordsMetadata)
+            throws AndesException;
+    /**
      * Update the data store on rollback. Move acknowledged but not committed messages to message store
      *
      * @param internalXid internalXid of the dtx transaction

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -252,7 +252,7 @@ public class MessagingEngine {
         return storageSeparatedMessages;
     }
 
-    public List<AndesPreparedMessageMetadata> acknowledgeOnDtxPrepare(List<AndesAckData> ackDataList)
+    public List<AndesPreparedMessageMetadata> acknowledgeAndRetrieveDequeueRecords(List<AndesAckData> ackDataList)
             throws AndesException {
 
         List<AndesPreparedMessageMetadata> messagesToRemove = new ArrayList<>(ackDataList.size());

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/ContentChunkHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/ContentChunkHandler.java
@@ -71,7 +71,8 @@ public class ContentChunkHandler implements EventHandler<InboundEventContainer> 
             case TRANSACTION_ENQUEUE_EVENT:
                 handleTransaction(event, sequence);
                 break;
-            case DTX_COMMIT_EVENT:
+            case DTX_ONE_PHASE_COMMIT_EVENT:
+            case DTX_TWO_PHASE_COMMIT_EVENT:
                 handleDtxEvent(event, sequence);
                 break;
             default:

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/DtxDbWriter.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/DtxDbWriter.java
@@ -66,8 +66,10 @@ public class DtxDbWriter extends InboundEventHandler {
                 log.debug("Sequence [ " + sequence + " ] Event " + event.getEventType());
 
             }
-            if (InboundEventContainer.Type.DTX_COMMIT_EVENT == event.getEventType()) {
+            if (InboundEventContainer.Type.DTX_TWO_PHASE_COMMIT_EVENT == event.getEventType()) {
                 event.getDtxBranch().writeToDbOnCommit();
+            } else if (InboundEventContainer.Type.DTX_ONE_PHASE_COMMIT_EVENT == event.getEventType()) {
+                event.getDtxBranch().writeToDbOnOnePhaseCommit();
             } else if (InboundEventContainer.Type.DTX_ROLLBACK_EVENT == event.getEventType()) {
                 event.getDtxBranch().writeToDbOnRollback();
             } else if (InboundEventContainer.Type.DTX_PREPARE_EVENT == event.getEventType()) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundEventContainer.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundEventContainer.java
@@ -195,9 +195,14 @@ public class InboundEventContainer {
         DTX_PREPARE_EVENT,
 
         /**
-         * Distributed transaction commit event
+         * Distributed transaction two-phase commit event
          */
-        DTX_COMMIT_EVENT,
+        DTX_TWO_PHASE_COMMIT_EVENT,
+
+        /**
+         * Distributed transaction one-phase commit event
+         */
+        DTX_ONE_PHASE_COMMIT_EVENT,
 
         /**
          * Distributed transaction rollback event
@@ -238,7 +243,8 @@ public class InboundEventContainer {
                 getTransactionEvent().updateState();
                 break;
             case DTX_PREPARE_EVENT:
-            case DTX_COMMIT_EVENT:
+            case DTX_TWO_PHASE_COMMIT_EVENT:
+            case DTX_ONE_PHASE_COMMIT_EVENT:
             case DTX_ROLLBACK_EVENT:
                 getDtxBranch().updateState(this);
                 break;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/MessagePreProcessor.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/MessagePreProcessor.java
@@ -73,7 +73,8 @@ public class MessagePreProcessor implements EventHandler<InboundEventContainer> 
             case TRANSACTION_COMMIT_EVENT:
                 preProcessTransaction(inboundEvent, sequence);
                 break;
-            case DTX_COMMIT_EVENT:
+            case DTX_ONE_PHASE_COMMIT_EVENT:
+            case DTX_TWO_PHASE_COMMIT_EVENT:
                 preProcessDtxCommit(inboundEvent);
                 break;
             case DTX_ROLLBACK_EVENT:

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/dtx/DtxBranch.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/dtx/DtxBranch.java
@@ -399,7 +399,8 @@ public class DtxBranch {
      * @param channel  corresponding channel object
      * @throws AndesException if an internal error occured
      */
-    public void commit(DisruptorEventCallback callback, AndesChannel channel) throws AndesException {
+    public void commit(DisruptorEventCallback callback, AndesChannel channel, boolean isOnePhaseCommit) throws
+            AndesException {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Performing commit for DtxBranch " + xid);
         }
@@ -408,7 +409,11 @@ public class DtxBranch {
 
         this.callback = callback;
         updateSlotCommand = new DtxCommitCommand();
-        eventManager.requestDtxEvent(this, channel, InboundEventContainer.Type.DTX_COMMIT_EVENT);
+        if (isOnePhaseCommit) {
+            eventManager.requestDtxEvent(this, channel, InboundEventContainer.Type.DTX_ONE_PHASE_COMMIT_EVENT);
+        } else {
+            eventManager.requestDtxEvent(this, channel, InboundEventContainer.Type.DTX_TWO_PHASE_COMMIT_EVENT);
+        }
     }
 
     /**
@@ -443,6 +448,16 @@ public class DtxBranch {
     public void writeToDbOnCommit() throws AndesException {
         dtxRegistry.getStore().updateOnCommit(internalXid, enqueueList);
         traceMessageList(enqueueList, MessageTracer.DTX_MESSAGE_WRITTEN_TO_DB);
+    }
+
+    /**
+     * Write committed messages to the database.
+     *
+     * @throws AndesException throws AndesException on database error
+     */
+    public void writeToDbOnOnePhaseCommit() throws AndesException {
+        dtxRegistry.getStore().updateOnOnePhaseCommit(enqueueList, dtxRegistry.acknowledgeAndRetrieveDequeueRecords
+                (this));
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingDtxStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingDtxStore.java
@@ -75,6 +75,17 @@ public class FailureObservingDtxStore extends FailureObservingStore<DtxStore> im
     }
 
     @Override
+    public void updateOnOnePhaseCommit(List<AndesMessage> enqueueRecords,
+            List<AndesPreparedMessageMetadata> dequeueRecordsMetadata) throws AndesException {
+        try {
+            wrappedInstance.updateOnOnePhaseCommit(enqueueRecords, dequeueRecordsMetadata);
+        } catch (AndesStoreUnavailableException e) {
+            notifyFailures(e);
+            throw new AndesException(e);
+        }
+    }
+
+    @Override
     public void updateOnRollback(long internalXid, List<AndesPreparedMessageMetadata> messagesToRestore) throws AndesException {
         try {
             wrappedInstance.updateOnRollback(internalXid, messagesToRestore);


### PR DESCRIPTION
Issue: wso2/product-ei#737

During prepare step, the messages to be dequeued are deleted from MB_METADATA table and moved into MB_DTX_DEQUEUE_RECORD and also acknowledged. The messages to be enqueued are inserted to MB_DTX_ENQUEUE_RECORD.

During the commit step, the in-memory enqueue list of the dtx branch is inserted to the MB_METADATA table. And the dequeue records in the MB_DTX_DEQUEUE_RECORD are removed.

During a one phase commit scenario, prepare step is not executed and commit step is directly executed. In that case, in-memory enqueue list will get inserted to the MB_METADATA table just as before. But, the dequeue list will still remain in MB_METADATA unacknowledged. So to fix this we need to directly acknowledge and remove dequeue list from MB_METADATA table if it is a one-phase commit.

So what this fix does is, introducing a new event type "DTX_ONE_PHASE_COMMIT_EVENT" and when it occurs follow the same path as in "DTX_COMMIT_EVENT" with the addition of the step of acknowledgement and direct removal of dequeue list instead of the removal of the records in MB_DTX_DEQUEUE_RECORD table(records are not available in this table anyway since prepare step wasn't executed)