### PR TITLE
Change deployment configurations

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -738,16 +738,13 @@ public enum AndesConfiguration implements ConfigurationProperty {
             "1", Integer.class),
 
     /**
-     * Specifies the deployment mode for the broker node (and cluster). Possible values {default, standalone}.
+     * Specifies the deployment mode for the broker node (and cluster). Possible values {standalone, clustered}.
      *
-     * default - Broker node will decide to run HA (master/slave) or fully distributed mode. Decision is taken based
-     * on the node has a clustering mechanism enabled or not. If the node is not configured to join a cluster it
-     * will run in HA mode (refer to axis2.xml for more information). If the node can join a cluster it will
-     * start in fully clustered mode.
+     * standalone - This is the simplest mode a broker can be started. The node will assume that message store is not
+     * shared with another node. Therefore it will not try to coordinate with other nodes (possibly non-existent) to
+     * provide HA.
      *
-     * standalone - This is the simplest mode a broker can be started. Node will assume datastore is not shared with
-     * another node. Therefore it will not try to coordinate with other nodes (possibly non-existent) to
-     * provide HA or clustering.
+     * clustered - Broker node will run in HA mode (active/passive).
      */
     DEPLOYMENT_MODE("deployment/mode","standalone", String.class);
 


### PR DESCRIPTION
We now have two options for "deployment/mode". They are,

- **standalone** - This is the simplest mode a broker can be started. The node will assume that message store is not shared with another node. Therefore it will not try to coordinate with other nodes (possibly non-existent) to provide HA. This is the default configuration used.
- **clustered** - Broker node will run in HA mode (active/passive).