### PR TITLE
Add YAML based configuration support.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/BrokerConfigurationService.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/BrokerConfigurationService.java
@@ -32,8 +32,17 @@ import java.nio.file.Paths;
 public class BrokerConfigurationService {
     private static Log log = LogFactory.getLog(BrokerConfigurationService.class);
 
+    /**
+     * Configuration directory name.
+     */
     private static String CONF_FOLDER = "conf";
+    /**
+     * Carbon runtime name.
+     */
     private static String RUNTIME = "broker";
+    /**
+     * Deployment descriptor name.
+     */
     private static String CONFIG_NAME = "deployment.yaml";
     private static BrokerConfigurationService brokerConfigurationService = new BrokerConfigurationService();
     private BrokerConfiguration brokerConfiguration;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/BrokerConfigurationService.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/BrokerConfigurationService.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.configuration.models.BrokerConfiguration;
+import org.wso2.carbon.config.ConfigProviderFactory;
+import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.config.provider.ConfigProvider;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Broker configuration provider.
+ */
+public class BrokerConfigurationService {
+    private static Log log = LogFactory.getLog(BrokerConfigurationService.class);
+
+    private static String CONF_FOLDER = "conf";
+    private static String RUNTIME = "broker";
+    private static String CONFIG_NAME = "deployment.yaml";
+    private static BrokerConfigurationService brokerConfigurationService = new BrokerConfigurationService();
+    private BrokerConfiguration brokerConfiguration;
+
+    // Get the config file location
+    Path deploymentConfigPath = Paths.get(System.getProperty(AndesConfigurationManager.CARBON_HOME), CONF_FOLDER, RUNTIME,
+            CONFIG_NAME);
+
+    private BrokerConfigurationService() {
+        // Get configuration
+        try {
+            ConfigProvider configProvider = ConfigProviderFactory.getConfigProvider(deploymentConfigPath);
+            brokerConfiguration = configProvider.getConfigurationObject(BrokerConfiguration.class);
+        } catch (ConfigurationException e) {
+            log.warn("Broker configuration could not be loaded. Using the default configurations.", e);
+            brokerConfiguration = new BrokerConfiguration();
+        }
+    }
+
+    /**
+     * Get the broker configuration service instance.
+     * @return BrokerConfigurationService
+     */
+    public static BrokerConfigurationService getInstance() {
+        return brokerConfigurationService;
+    }
+
+    /**
+     * Get the Broker Configuration instance.
+     * @return BrokerConfiguration
+     */
+    public BrokerConfiguration getBrokerConfiguration() {
+        return brokerConfiguration;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/AMQPConfigs.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/AMQPConfigs.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for AMQP transport.
+ */
+@Configuration(description = "AMQP transport related configurations. Refer qpid-config.xml for further AMQP-specific\n"
+        + "configurations.")
+public class AMQPConfigs {
+
+    @Element(description = "Enable MQTT transport")
+    private boolean enabled = true;
+
+    @Element(description = "MQTT bind address")
+    private String bindAddress = "0.0.0.0";
+
+    @Element(description = "Enable default connection")
+    private boolean defaultConnectionEnabled = true;
+
+    @Element(description = "Port for the default connection ")
+    private int defaultConnectionPort = 1883;
+
+    private SSLConnectionConfig sslConnection = new SSLConnectionConfig();
+
+    private int maximumRedeliveryAttempts = 10;
+
+    private boolean allowSharedTopicSubscriptions = false;
+
+    private boolean allowStrictNameValidation = true;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getBindAddress() {
+        return bindAddress;
+    }
+
+    public boolean isDefaultConnectionEnabled() {
+        return defaultConnectionEnabled;
+    }
+
+    public int getDefaultConnectionPort() {
+        return defaultConnectionPort;
+    }
+
+    public SSLConnectionConfig getSslConnection() {
+        return sslConnection;
+    }
+
+    public int getMaximumRedeliveryAttempts() {
+        return maximumRedeliveryAttempts;
+    }
+
+    public boolean isAllowSharedTopicSubscriptions() {
+        return allowSharedTopicSubscriptions;
+    }
+
+    public boolean isAllowStrictNameValidation() {
+        return allowStrictNameValidation;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/AckHandlingConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/AckHandlingConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for acknowledgment handling in performance tuning config.
+ */
+@Configuration(description = "Acknowledgment handling configuration.")
+public class AckHandlingConfig {
+
+    @Element(description = "Number of message acknowledgement handlers to process acknowledgements concurrently.\n"
+            + "            These acknowledgement handlers will batch and process acknowledgements.")
+    private int ackHandlerCount = 1;
+
+    @Element(description = "Maximum batch size of the acknowledgement handler. Andes process acknowledgements in\n"
+            + "            batches using Disruptor Increasing the batch size reduces the number of calls made to\n"
+            + "            database by MB. Depending on the database optimal batch size this value should be set.\n"
+            + "            Batches will be of the maximum batch size mostly in high throughput scenarios.\n"
+            + "            Underlying implementation use Disruptor for batching hence will batch message at a\n"
+            + "            lesser value than this in low throughput scenarios")
+    private int ackHandlerBatchSize = 100;
+
+    @Element(description = "Message delivery from server to the client will be paused temporarily if number of\n"
+            + "            delivered but unacknowledged message count reaches this size. Should be set considering\n"
+            + "            message consume rate. This is to avoid overwhelming slow subscribers.")
+    private int maxUnackedMessages = 100;
+
+    public int getAckHandlerCount() {
+        return ackHandlerCount;
+    }
+
+    public int getAckHandlerBatchSize() {
+        return ackHandlerBatchSize;
+    }
+
+    public int getMaxUnackedMessages() {
+        return maxUnackedMessages;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/BrokerConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/BrokerConfiguration.java
@@ -27,10 +27,41 @@ import org.wso2.carbon.config.annotation.Element;
                description = "Broker configuration parameters")
 public class BrokerConfiguration {
 
-    @Element(description = "Coordination related configuration")
-    private CoordinationConfiguration coordination = new CoordinationConfiguration();
+    @Element(description = "Coordination related configuration.")
+    private CoordinationConfig coordination = new CoordinationConfig();
 
-    public CoordinationConfiguration getCoordination() {
+    @Element(description = "Transport related configuration")
+    private TransportsConfig transports = new TransportsConfig();
+
+    @Element(description = "Depending on the database type selected in deployment.yaml, you must enable the\n"
+            + "relevant Data access classes here. Currently WSO2 MB Supports RDBMS(any RDBMS store).")
+    private PersistenceConfig persistance = new PersistenceConfig();
+
+    @Element(description = "Publisher transaction related configurations.")
+    private TransactionConfig transaction = new TransactionConfig();
+
+    @Element(description = "This section allows you to tweak memory and processor allocations used by WSO2 MB.\n"
+            + "Broken down by critical processes so you have a clear view of which parameters to change in\n"
+            + "different scenarios.")
+    private PerformanceTuningConfig performanceTuning = new PerformanceTuningConfig();
+
+    public CoordinationConfig getCoordination() {
         return coordination;
+    }
+
+    public TransportsConfig getTransports() {
+        return transports;
+    }
+
+    public PersistenceConfig getPersistance() {
+        return persistance;
+    }
+
+    public TransactionConfig getTransaction() {
+        return transaction;
+    }
+
+    public PerformanceTuningConfig getPerformanceTuning() {
+        return performanceTuning;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/BrokerConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/BrokerConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Root configuration model of the Broker.
+ * This class provide access to all the configuration object representations of the broker.
+ */
+@Configuration(namespace = "wso2.carbon.broker",
+               description = "Broker configuration parameters")
+public class BrokerConfiguration {
+
+    @Element(description = "Coordination related configuration")
+    private CoordinationConfiguration coordination = new CoordinationConfiguration();
+
+    public CoordinationConfiguration getCoordination() {
+        return coordination;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/BrokerConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/BrokerConfiguration.java
@@ -19,6 +19,8 @@ package org.wso2.andes.configuration.models;
 import org.wso2.carbon.config.annotation.Configuration;
 import org.wso2.carbon.config.annotation.Element;
 
+import javax.annotation.Resource;
+
 /**
  * Root configuration model of the Broker.
  * This class provide access to all the configuration object representations of the broker.
@@ -45,6 +47,28 @@ public class BrokerConfiguration {
             + "different scenarios.")
     private PerformanceTuningConfig performanceTuning = new PerformanceTuningConfig();
 
+    @Element(description = "Memory and resource exhaustion is something we should prevent and recover from.\n"
+            + "    This section allows you to specify the threshold at which to reduce/stop frequently intensive\n"
+            + "    operations within MB temporarily.")
+    private FlowControlConfig flowControl = new FlowControlConfig();
+
+    @Element(description = "Message broker keeps track of all messages it has received as groups. These groups are termed\n"
+            + "    'Slots' (To know more information about Slots and message broker install please refer to online wiki).\n"
+            + "    Size of a slot is loosely determined by the configuration <windowSize> (and the number of\n"
+            + "    parallel publishers for specific topic/queue). Message broker cluster (or in single node) keeps\n"
+            + "    track of slots which constitutes for a large part of operating state before the cluster went down.\n"
+            + "        When first message broker node of the cluster starts up, it will read the database to recreate\n"
+            + "    the internal state to previous state.")
+    private RecoveryConfig recovery = new RecoveryConfig();
+
+    @Element(description = "Specifies the deployment mode for the broker node (and cluster). Possible values {standalone, clustered}.\n"
+            + "\n"
+            + "        standalone - This is the simplest mode a broker can be started. The node will assume that message store is not\n"
+            + "                     shared with another node. Therefore it will not try to coordinate with other nodes (possibly\n"
+            + "                     non-existent) to provide HA.\n" + "\n"
+            + "        clustered - Broker node will run in HA mode (active/passive).")
+    private DeploymentConfig deployment = new DeploymentConfig();
+
     public CoordinationConfig getCoordination() {
         return coordination;
     }
@@ -63,5 +87,17 @@ public class BrokerConfiguration {
 
     public PerformanceTuningConfig getPerformanceTuning() {
         return performanceTuning;
+    }
+
+    public FlowControlConfig getFlowControl() {
+        return flowControl;
+    }
+
+    public RecoveryConfig getRecovery() {
+        return recovery;
+    }
+
+    public DeploymentConfig getDeployment() {
+        return deployment;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/CacheConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/CacheConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for cache in persistence config.
+ */
+@Configuration(description = "Message caching related configuration.")
+public class CacheConfig {
+    @Element(description = "Size of the messages cache in MBs. Setting '0' will disable the cache.")
+    private int size = 256;
+
+    @Element(description = "Expected concurrency for the cache (4 is guava default).")
+    private int concurrencyLevel = 4;
+
+    @Element(description = "Number of seconds cache will keep messages after they are added (unless they are consumed"
+            + " and deleted).")
+    private int expirySeconds = 2;
+
+    @Element(description = "Reference type used to hold messages in memory.\n"
+            + " weak   - Using java weak references ( - results higher cache misses)\n"
+            + " strong - ordinary references ( - higher cache hits, but not good if server\n"
+            + "          is going to run with limited heap size + under severe load).")
+    private String valueReferenceType = "strong";
+
+    @Element(description = "Prints cache statistics in 2 minute intervals\n"
+            + "in carbon log ( and console)")
+    private boolean printStats = false;
+
+    public int getSize() {
+        return size;
+    }
+
+    public int getConcurrencyLevel() {
+        return concurrencyLevel;
+    }
+
+    public int getExpirySeconds() {
+        return expirySeconds;
+    }
+
+    public String getValueReferenceType() {
+        return valueReferenceType;
+    }
+
+    public boolean isPrintStats() {
+        return printStats;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/ContentCacheConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/ContentCacheConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for Content caching.
+ */
+public class ContentCacheConfig {
+    @Element(description = "Specify the maximum number of entries the cache may contain.")
+    private int maximumSize = 100;
+
+    @Element(description = "Specify the time in seconds that each entry should be\n"
+            + "automatically removed from the cache after the entry's creation.")
+    private int expiryTime = 120;
+
+    public int getMaximumSize() {
+        return maximumSize;
+    }
+
+    public int getExpiryTime() {
+        return expiryTime;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/ContentHandlingConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/ContentHandlingConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for Content handling config in Performance tuning section.
+ */
+@Configuration(description = "Content handling configurations.")
+public class ContentHandlingConfig {
+
+    @Element(description = "Within Andes there are content chunk handlers which convert incoming large content\n"
+            + "            chunks into max content chunk size allowed by Andes core. These handlers run in parallel\n"
+            + "            converting large content chunks to smaller chunks.\n"
+            + "            If the protocol specific content chunk size is different from the max chunk size allowed\n"
+            + "            by Andes core and there are significant number of large messages published, then having\n"
+            + "            multiple handlers will increase performance.")
+    private int contentChunkHandlerCount = 3;
+
+    @Element(description = "Andes core will store message content chunks according to this chunk size. Different\n"
+            + "            database will have limits and performance gains by tuning this parameter.\n"
+            + "            For instance in MySQL the maximum table column size for content is less than 65534, which\n"
+            + "            is the default chunk size of AMQP. By changing this parameter to a lesser value we can\n"
+            + "            store large content chunks converted to smaller content chunks within the DB with this\n"
+            + "            parameter.")
+    private int maxContentChunkSize = 65500;
+
+    @Element(description = "This is the configuration to allow compression of message contents, before store messages\n"
+            + "            into the database.")
+    private boolean allowCompression = false;
+
+    @Element(description = "This is the configuration to change the value of the content compression threshold (in bytes).\n"
+            + "            Message contents less than this value will not compress, even compression is enabled. The recommended\n"
+            + "            message size of the smallest message before compression is 13bytes. Compress messages smaller than\n"
+            + "            13bytes will expand the message size by 0.4%")
+    private int contentCompressionThreshold = 1000;
+
+    public int getContentChunkHandlerCount() {
+        return contentChunkHandlerCount;
+    }
+
+    public int getMaxContentChunkSize() {
+        return maxContentChunkSize;
+    }
+
+    public boolean isAllowCompression() {
+        return allowCompression;
+    }
+
+    public int getContentCompressionThreshold() {
+        return contentCompressionThreshold;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/ContextStoreConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/ContextStoreConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration model for RDBMS MB StoreContext Config.
+ */
+@Configuration(description = "Configuration to persist and access other information relevant to messaging protocols.(\"contextStore\").")
+public class ContextStoreConfig {
+    private Map property = new HashMap();
+
+    private String _class = "org.wso2.andes.store.rdbms.RDBMSAndesContextStoreImpl";
+
+    public ContextStoreConfig () {
+        property.put("dataSource", "WSO2MBStoreDB");
+        property.put("storeUnavailableSQLStateClasses", 8);
+        property.put("integrityViolationSQLStateClasses", "23,27,44");
+        property.put("dataErrorSQLStateClasses", "21,22");
+        property.put("transactionRollbackSQLStateClasses", 40);
+    }
+
+    public Map getProperty() {
+        return property;
+    }
+
+    public String getClassConfig() {
+        return _class;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/CoordinationConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/CoordinationConfig.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for broker coordination.
+ */
+@Configuration(description = "Broker coordination config.")
+public class CoordinationConfig {
+
+    @Element(description = "The node ID of each member. If it is left as \"default\", the default node ID will be\n"
+            + "generated for it. (Using IP + UUID). The node ID of each member should ALWAYS be unique.")
+    private String nodeID = "default";
+
+    @Element(description = "Hostname of the thrift server used to maintain and sync slot (message groups) ranges "
+            + "nodes.")
+    private String thriftServerHost = "localhost";
+
+    @Element(description = "Port of the thrift server used to maintain and sync slot (message groups) ranges "
+            + "nodes.")
+    private int thriftServerPort = 7611;
+
+    @Element(description = "Thrify server SO timeout")
+    private int thriftSOTimeout = 0;
+
+    @Element(description = "Thrift server reconnect timeout. Value specified in seconds")
+    private int thriftServerReconnectTimeout = 5;
+
+    @Element(description = "Hazelcast reliable topics are used to share all notifications across the MB cluster (e.g. subscription\n"
+            + "changes), And this property defines the time-to-live for a notification since its creation. (in Seconds)")
+    private int clusterNotificationTimeout = 10;
+
+    @Element(description = "RDBMS based coordination algorithm related configs.")
+    private RDBMSBasedCoordinationConfig rdbmsBasedCoordination = new RDBMSBasedCoordinationConfig();
+
+    @Element(description = "RDBMS based cluster event synchronization configs.")
+    private RDBMSClusterEventSynchronizationConfig rdbmsBasedClusterEventSynchronization = new RDBMSClusterEventSynchronizationConfig();
+
+    public String getNodeID() {
+        return nodeID;
+    }
+
+    public String getThriftServerHost() {
+        return thriftServerHost;
+    }
+
+    public int getThriftServerPort() {
+        return thriftServerPort;
+    }
+
+    public int getThriftSOTimeout() {
+        return thriftSOTimeout;
+    }
+
+    public int getThriftServerReconnectTimeout() {
+        return thriftServerReconnectTimeout;
+    }
+
+    public int getClusterNotificationTimeout() {
+        return clusterNotificationTimeout;
+    }
+
+    public RDBMSBasedCoordinationConfig getRdbmsBasedCoordinationConfig() {
+        return rdbmsBasedCoordination;
+    }
+
+    public RDBMSClusterEventSynchronizationConfig getRdbmsBasedClusterEventSynchronizationConfig() {
+        return rdbmsBasedClusterEventSynchronization;
+    }
+
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/CoordinationConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/CoordinationConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for broker coordination.
+ */
+@Configuration(description = "Broker coordination config")
+public class CoordinationConfiguration {
+
+    @Element(description = "The node ID of each member")
+    private String nodeID = "default";
+
+    @Element(description = "Thrift is used to maintain and sync slot (message groups) ranges between MB nodes.")
+    private String thriftServerHost = "localhost";
+
+    public String getNodeID() {
+        return nodeID;
+    }
+
+    public String getThriftServerHost() {
+        return thriftServerHost;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/DeliveryConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/DeliveryConfig.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for delivery config in Performance Tuning config section.
+ */
+public class DeliveryConfig {
+    @Element(description = "Maximum number of undelivered messages that can have in memory. Increasing this\n"
+            + "value increase the possibility of out of memory scenario but performance will be\n"
+            + "improved")
+    private int maxNumberOfReadButUndeliveredMessages = 1000;
+
+    @Element(description = "This is the ring buffer size of the delivery disruptor. This value should be a\n"
+            + "power of 2 (E.g. 1024, 2048, 4096). Use a small ring size if you want to reduce the\n"
+            + "memory usage.")
+    private int ringBufferSize = 4096;
+
+    @Element(description = "Number of parallel readers used to used to read content from message store.\n"
+            + "Increasing this value will speed-up the message sending mechanism. But the load\n"
+            + "on the data store will increase.")
+    private int parallelContentReaders = 5;
+
+    @Element(description = "Number of parallel decompression handlers used to decompress messages before send to subscribers.\n"
+            + "Increasing this value will speed-up the message decompressing mechanism. But the system load\n"
+            + "will increase.")
+    private int parallelDecompressionHandlers = 5;
+
+    @Element(description = "Number of parallel delivery handlers used to send messages to subscribers.\n"
+            + "Increasing this value will speed-up the message sending mechanism. But the system load\n"
+            + "will increase.")
+    private int parallelDeliveryHandlers = 5;
+
+    @Element(description = "The size of the batch represents, at a given time the number of messages that could\n"
+            + "be retrieved from the database.")
+    private int contentReadBatchSize = 65000;
+
+    private ContentCacheConfig contentCache = new ContentCacheConfig();
+
+    private TopicMessageDeliveryStrategyConfig topicMessageDeliveryStrategy = new TopicMessageDeliveryStrategyConfig();
+
+    public int getMaxNumberOfReadButUndeliveredMessages() {
+        return maxNumberOfReadButUndeliveredMessages;
+    }
+
+    public int getRingBufferSize() {
+        return ringBufferSize;
+    }
+
+    public int getParallelContentReaders() {
+        return parallelContentReaders;
+    }
+
+    public int getParallelDecompressionHandlers() {
+        return parallelDecompressionHandlers;
+    }
+
+    public int getParallelDeliveryHandlers() {
+        return parallelDeliveryHandlers;
+    }
+
+    public int getContentReadBatchSize() {
+        return contentReadBatchSize;
+    }
+
+    public ContentCacheConfig getContentCache() {
+        return contentCache;
+    }
+
+    public TopicMessageDeliveryStrategyConfig getTopicMessageDeliveryStrategy() {
+        return topicMessageDeliveryStrategy;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/DeliveryConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/DeliveryConfig.java
@@ -16,11 +16,13 @@
  */
 package org.wso2.andes.configuration.models;
 
+import org.wso2.carbon.config.annotation.Configuration;
 import org.wso2.carbon.config.annotation.Element;
 
 /**
  * Configuration model for delivery config in Performance Tuning config section.
  */
+@Configuration(description = "Message delivery configurations.")
 public class DeliveryConfig {
     @Element(description = "Maximum number of undelivered messages that can have in memory. Increasing this\n"
             + "value increase the possibility of out of memory scenario but performance will be\n"

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/DeploymentConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/DeploymentConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+
+/**
+ * Configuration model for deployment mode config.
+ */
+@Configuration(description = "Specifies the deployment mode for the broker node (and cluster). Possible values {standalone, clustered}.\n"
+        + "        standalone - This is the simplest mode a broker can be started. The node will assume that message store is not\n"
+        + "                     shared with another node. Therefore it will not try to coordinate with other nodes (possibly\n"
+        + "                     non-existent) to provide HA.\n"
+        + "        clustered - Broker node will run in HA mode (active/passive).")
+public class DeploymentConfig {
+
+    /**
+     * Specifying the clustering mode to be used.
+     */
+    private String mode = "standalone";
+
+    public String getMode() {
+        return mode;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/FlowControlBufferBasedConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/FlowControlBufferBasedConfig.java
@@ -20,22 +20,24 @@ import org.wso2.carbon.config.annotation.Configuration;
 import org.wso2.carbon.config.annotation.Element;
 
 /**
- * Configuration model for Content caching.
+ * Configuration model for buffer based config in Flow control.
  */
-@Configuration(description = "Content caching configuration.")
-public class ContentCacheConfig {
-    @Element(description = "Specify the maximum number of entries the cache may contain.")
-    private int maximumSize = 100;
+@Configuration(description = "This is the channel specific buffer limits which enable/disable the flow control locally.")
+public class FlowControlBufferBasedConfig {
 
-    @Element(description = "Specify the time in seconds that each entry should be\n"
-            + "automatically removed from the cache after the entry's creation.")
-    private int expiryTime = 120;
+    @Element(description = "flow control is disabled (if enabled) when message chunk pending to be handled\n"
+            + "         by inbound disruptor reaches below this limit")
+    private int lowLimit = 100;
 
-    public int getMaximumSize() {
-        return maximumSize;
+    @Element(description = "flow control is enabled when message chunk pending to be handled by inbound\n"
+            + "         disruptor reaches above this limit")
+    private int highLimit = 1000;
+
+    public int getLowLimit() {
+        return lowLimit;
     }
 
-    public int getExpiryTime() {
-        return expiryTime;
+    public int getHighLimit() {
+        return highLimit;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/FlowControlConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/FlowControlConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model Flow control configs.
+ */
+@Configuration(description = "Memory and resource exhaustion is something we should prevent and recover from.\n"
+        + "    This section allows you to specify the threshold at which to reduce/stop frequently intensive\n"
+        + "    operations within MB temporarily.\n"
+        + "    highLimit - flow control is enabled when message chunk pending to be handled by inbound\n"
+        + "         disruptor reaches above this limit\n"
+        + "    lowLimit - flow control is disabled (if enabled) when message chunk pending to be handled\n"
+        + "         by inbound disruptor reaches below this limit")
+public class FlowControlConfig {
+
+    @Element(description = "This is the global buffer limits which enable/disable the flow control globally")
+    private FlowControlGlobalConfig  global = new FlowControlGlobalConfig();
+
+    @Element(description = "This is the channel specific buffer limits which enable/disable the flow control locally.")
+    private FlowControlBufferBasedConfig bufferBased = new FlowControlBufferBasedConfig();
+
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/FlowControlGlobalConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/FlowControlGlobalConfig.java
@@ -20,22 +20,24 @@ import org.wso2.carbon.config.annotation.Configuration;
 import org.wso2.carbon.config.annotation.Element;
 
 /**
- * Configuration model for Content caching.
+ * Configuration model for global config in Flow control section.
  */
-@Configuration(description = "Content caching configuration.")
-public class ContentCacheConfig {
-    @Element(description = "Specify the maximum number of entries the cache may contain.")
-    private int maximumSize = 100;
+@Configuration(description = "This is the global buffer limits which enable/disable the flow control globally")
+public class FlowControlGlobalConfig {
 
-    @Element(description = "Specify the time in seconds that each entry should be\n"
-            + "automatically removed from the cache after the entry's creation.")
-    private int expiryTime = 120;
+    @Element(description = "flow control is disabled (if enabled) when message chunk pending to be handled\n"
+            + "         by inbound disruptor reaches below this limit")
+    private int lowLimit = 800;
 
-    public int getMaximumSize() {
-        return maximumSize;
+    @Element(description = "flow control is enabled when message chunk pending to be handled by inbound\n"
+            + "         disruptor reaches above this limit")
+    private int highLimit = 8000;
+
+    public int getLowLimit() {
+        return lowLimit;
     }
 
-    public int getExpiryTime() {
-        return expiryTime;
+    public int getHighLimit() {
+        return highLimit;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/InboundEventsConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/InboundEventsConfig.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model class for Inbound event configs in Performance tuning section.
+ */
+@Configuration(description = "Inbound events config")
+public class InboundEventsConfig {
+
+    @Element(description = "Number of parallel writers used to write content to message store. Increasing this\n"
+            + "            value will speed-up the message receiving mechanism. But the load on the data store will\n"
+            + "            increase.")
+    private int parallelMessageWriters = 1;
+
+    @Element(description = "Size of the Disruptor ring buffer for inbound event handling. For publishing at\n"
+            + "            higher rates increasing the buffer size may give some advantage on keeping messages in\n"
+            + "            memory and write.\n"
+            + "            NOTE: Buffer size should be a value of power of two")
+    private int bufferSize = 65536;
+
+    @Element(description = "Maximum batch size of the batch write operation for inbound messages. MB internals\n"
+            + "            use Disruptor to batch events. Hence this batch size is set to avoid database requests\n"
+            + "            with high load (with big batch sizes) to write messages. This need to be configured in\n"
+            + "            high throughput messaging scenarios to regulate the hit on database from MB")
+    private int messageWriterBatchSize = 70;
+
+    @Element(description = "Timeout for waiting for a queue purge event to end to get the purged count. Doesn't\n"
+            + "            affect actual purging. If purge takes time, increasing the value will improve the\n"
+            + "            possibility of retrieving the correct purged count. Having a lower value doesn't stop\n"
+            + "            purge event. Getting the purged count is affected by this")
+    private int purgedCountTimeout = 180;
+
+    @Element(description = "Number of parallel writers used to write content to message store for transaction\n"
+            + "            based publishing. Increasing this value will speedup commit duration for a transaction.\n"
+            + "            But the load on the data store will increase.")
+    private int transactionMessageWriters = 1;
+
+    public int getParallelMessageWriters() {
+        return parallelMessageWriters;
+    }
+
+    public int getBufferSize() {
+        return bufferSize;
+    }
+
+    public int getMessageWriterBatchSize() {
+        return messageWriterBatchSize;
+    }
+
+    public int getPurgedCountTimeout() {
+        return purgedCountTimeout;
+    }
+
+    public int getTransactionMessageWriters() {
+        return transactionMessageWriters;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/KeyStoreConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/KeyStoreConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+
+/**
+ * Configuration model for SSL keystore configuration.
+ */
+@Configuration(description = "SSL keystore configuration")
+public class KeyStoreConfig {
+
+    private String location = "repository/resources/security/wso2carbon.jks";
+
+    private String password = "wso2carbon";
+
+    private String certType = "SunX509";
+
+    public String getLocation() {
+        return location;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getCertType() {
+        return certType;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/MessageExpirationConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/MessageExpirationConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for Message Expiration related configs in Performance tuning section.
+ */
+@Configuration(description = "Message expiration can be set for each messages which are published to Wso2 MB.\n"
+        + "         After the expiration time, the messages will not be delivered to the consumers. Eventually\n"
+        + "         they got deleted inside the MB.")
+public class MessageExpirationConfig {
+
+    @Element(description = "When messages delivered, in the delivery path messages were checked whether they are\n"
+            + "            already expired. If expired at that time add that message to a queue for a future batch\n"
+            + "            delete. This interval decides on the time gap between the batch deletes. Time interval\n"
+            + "            specified in seconds.")
+    private int preDeliveryExpiryDeletionInterval = 10;
+
+    @Element(description = "Periodically check the database for new expired messages which were not assigned to\n"
+            + "             any slot delivery worker so far and delete them. This interval decides on the time gap between\n"
+            + "             the periodic message deletion. Time interval specified in seconds.")
+    private int periodicMessageDeletionInterval = 900;
+
+    @Element(description = "When checking the database for expired messages, the messages which were handled by the slot\n"
+            + "            delivery worker should no be touched since that mess up the slot delivery worker functionality.\n"
+            + "            Those messages anyways get caught at the message delivery path. So there is a need to have a safe\n"
+            + "            buffer of slots which can be allocated to a slot delivery worker in the near future. The specified\n"
+            + "            number of slots from the last assigned should not be touched by the periodic deletion task.")
+    private int safetySlotCount = 3;
+
+    public int getPreDeliveryExpiryDeletionInterval() {
+        return preDeliveryExpiryDeletionInterval;
+    }
+
+    public int getPeriodicMessageDeletionInterval() {
+        return periodicMessageDeletionInterval;
+    }
+
+    public int getSafetySlotCount() {
+        return safetySlotCount;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/MessageStoreConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/MessageStoreConfig.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Configuration model for Message Store persistence configs
+ * Configuration model for Message Store persistence configs.
  */
 @Configuration(description = "RDBMS MB Store Configuration")
 public class MessageStoreConfig {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/MessageStoreConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/MessageStoreConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration model for Message Store persistence configs
+ */
+@Configuration(description = "RDBMS MB Store Configuration")
+public class MessageStoreConfig {
+    private Map property = new HashMap();
+
+    private String _class = "org.wso2.andes.store.rdbms.RDBMSMessageStoreImpl";
+
+    public MessageStoreConfig () {
+        property.put("dataSource", "WSO2MBStoreDB");
+        property.put("storeUnavailableSQLStateClasses", 8);
+        property.put("integrityViolationSQLStateClasses", "23,27,44");
+        property.put("dataErrorSQLStateClasses", "21,22");
+        property.put("transactionRollbackSQLStateClasses", 40);
+    }
+
+    public Map getProperty() {
+        return property;
+    }
+
+    public String getClassConfig() {
+        return _class;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/NetworkPartitionsDetectionConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/NetworkPartitionsDetectionConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for Network partitions detection config in recovery section.
+ */
+@Configuration(description = "Enables network partition detection ( and surrounding functionality, such\n"
+        + "         as disconnecting subscriptions, enabling error based flow control if the\n"
+        + "         minimal node count becomes less than configured value.")
+public class NetworkPartitionsDetectionConfig {
+
+    @Element(description = "Enable network partition detection.")
+    private boolean enabled = false;
+
+    @Element(description = "The minimum node count the cluster should maintain for this node to\n"
+            + "                operate. if cluster size becomes less that configured value\n"
+            + "                This node will not accept any incoming traffic ( and disconnect\n"
+            + "                subscriptions) etc.")
+    private int minimumClusterSize = 1;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public int getMinimumClusterSize() {
+        return minimumClusterSize;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/PerformanceTuningConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/PerformanceTuningConfig.java
@@ -28,4 +28,36 @@ public class PerformanceTuningConfig {
     private SlotsConfig slots = new SlotsConfig();
 
     private DeliveryConfig delivery = new DeliveryConfig();
+
+    private AckHandlingConfig ackHandling = new AckHandlingConfig();
+
+    private ContentHandlingConfig contentHandling = new ContentHandlingConfig();
+
+    private InboundEventsConfig inboundEvents = new InboundEventsConfig();
+
+    private MessageExpirationConfig messageExpiration = new MessageExpirationConfig();
+
+    public SlotsConfig getSlots() {
+        return slots;
+    }
+
+    public DeliveryConfig getDelivery() {
+        return delivery;
+    }
+
+    public AckHandlingConfig getAckHandling() {
+        return ackHandling;
+    }
+
+    public ContentHandlingConfig getContentHandling() {
+        return contentHandling;
+    }
+
+    public InboundEventsConfig getInboundEvents() {
+        return inboundEvents;
+    }
+
+    public MessageExpirationConfig getMessageExpiration() {
+        return messageExpiration;
+    }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/PerformanceTuningConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/PerformanceTuningConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+
+/**
+ * Configuration model for performance tuning parameters.
+ */
+@Configuration(description = "This section allows you to tweak memory and processor allocations used by WSO2 MB.\n"
+        + "Broken down by critical processes so you have a clear view of which parameters to change in\n"
+        + "different scenarios.")
+public class PerformanceTuningConfig {
+    private SlotsConfig slots = new SlotsConfig();
+
+    private DeliveryConfig delivery = new DeliveryConfig();
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/PersistenceConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/PersistenceConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for data access classes (persistance)
+ */
+@Configuration(description = "Depending on the database type selected in deployment.yaml, you must enable the\n"
+        + "relevant Data access classes here. Currently WSO2 MB Supports RDBMS(any RDBMS store).")
+public class PersistenceConfig {
+    @Element(description = "RDBMS MB Store Configuration.")
+    private MessageStoreConfig messageStore = new MessageStoreConfig();
+
+    @Element(description = "RDBMS MB ContextStore Configuration.")
+    private ContextStoreConfig contextStore = new ContextStoreConfig();
+
+    @Element(description = "Message caching related configuration.")
+    private CacheConfig cache = new CacheConfig();
+
+    @Element(description = "This class decides how unique IDs are generated for the MB node. This id generator is\n"
+            + "expected to be thread safe and a implementation of interface\n"
+            + "org.wso2.andes.server.cluster.coordination.MessageIdGenerator\n"
+            + "NOTE: This is NOT used in MB to generate message IDs.")
+    private String idGenerator = "org.wso2.andes.server.cluster.coordination.TimeStampBasedMessageIdGenerator";
+
+    @Element(description = "This is the Task interval (in SECONDS) to check whether communication\n"
+            + "is healthy between message store (/Database) and this server instance.")
+    private int storeHealthCheckInterval = 10;
+
+    public MessageStoreConfig getMessageStore() {
+        return messageStore;
+    }
+
+    public ContextStoreConfig getContextStore() {
+        return contextStore;
+    }
+
+    public CacheConfig getCache() {
+        return cache;
+    }
+
+    public String getIdGenerator() {
+        return idGenerator;
+    }
+
+    public int getStoreHealthCheckInterval() {
+        return storeHealthCheckInterval;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/RDBMSBasedCoordinationConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/RDBMSBasedCoordinationConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for RDBMS based coordination algorithm.
+ */
+@Configuration(description = "Configurations related to RDBMS based coordination algorithm.")
+public class RDBMSBasedCoordinationConfig {
+
+    @Element(description = "Enable RDBMS based coordination algorithm.")
+    private boolean enabled = true;
+
+    @Element(description = "Heartbeat interval used in the RDBMS base coordination algorithm in milliseconds.")
+    private int heartbeatInterval = 5000;
+
+    @Element(description = "Time to wait before informing others about coordinator change in milliseconds. This value should be\n"
+            + "larger than a database read time including network latency and should be less than heartbeatInterval")
+    private int coordinatorEntryCreationWaitTime = 3000;
+
+    @Element(description = "Time interval used to poll database for membership related events in milliseconds.")
+    private int eventPollingInterval = 4000;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public int getHeartbeatInterval() {
+        return heartbeatInterval;
+    }
+
+    public int getCoordinatorEntryCreationWaitTime() {
+        return coordinatorEntryCreationWaitTime;
+    }
+
+    public int getEventPollingInterval() {
+        return eventPollingInterval;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/RDBMSClusterEventSynchronizationConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/RDBMSClusterEventSynchronizationConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for RDBMS based cluster event synchronization.
+ */
+@Configuration(description = "RDBMS based cluster event synchronization configs")
+public class RDBMSClusterEventSynchronizationConfig {
+
+    @Element(description = "Enabling this will make the cluster notifications such as Queue changes(additions and deletions),\n"
+            + "Subscription changes, etc. sent within the cluster be synchronized using RDBMS. If set to false, Hazelcast\n"
+            + "will be used for this purpose.")
+    private boolean enabled = true;
+
+    @Element(description = "Specifies the interval at which, the cluster events will be read from the database. Needs to be\n"
+            + "declared in milliseconds. Setting this to a very low value could downgrade the performance where as\n"
+            + "setting this to a large value could increase the time taken for a cluster event to be synchronized in\n"
+            + "all the nodes in a cluster.")
+    private int eventSyncInterval = 1000;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public int getEventSyncInterval() {
+        return eventSyncInterval;
+    }
+
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/RecoveryConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/RecoveryConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+@Configuration(description = "Message broker keeps track of all messages it has received as groups. These groups are termed\n"
+        + "    'Slots' (To know more information about Slots and message broker install please refer to online wiki).\n"
+        + "    Size of a slot is loosely determined by the configuration <windowSize> (and the number of\n"
+        + "    parallel publishers for specific topic/queue). Message broker cluster (or in single node) keeps\n"
+        + "    track of slots which constitutes for a large part of operating state before the cluster went down.\n"
+        + "        When first message broker node of the cluster starts up, it will read the database to recreate\n"
+        + "    the internal state to previous state.")
+public class RecoveryConfig {
+
+    @Element(description = " There could be multiple storage queues worked before entire cluster (or single node) went down.\n"
+            + "        We need to recover all remaining messages of each storage queue when first node startup and we can\n"
+            + "        read remaining message concurrently of each storage queue. Default value to set here to 5. You can\n"
+            + "        increase this value based on number of storage queues exist. Please use optimal value based on\n"
+            + "        number of storage queues to speed up warm startup.")
+    private int concurrentStorageQueueReads = 5;
+
+    @Element(description = "Virtual host sync interval seconds in for the Virtual host syncing Task which will\n"
+            + "            sync the Virtual host details across the cluster")
+    private int vHostSyncTaskInterval = 900;
+
+    @Element(description = "Enables network partition detection ( and surrounding functionality, such\n"
+            + "         as disconnecting subscriptions, enabling error based flow control if the\n"
+            + "         minimal node count becomes less than configured value.")
+    private NetworkPartitionsDetectionConfig networkPartitionsDetection = new NetworkPartitionsDetectionConfig();
+
+    public int getConcurrentStorageQueueReads() {
+        return concurrentStorageQueueReads;
+    }
+
+    public int getvHostSyncTaskInterval() {
+        return vHostSyncTaskInterval;
+    }
+
+    public NetworkPartitionsDetectionConfig getNetworkPartitionsDetection() {
+        return networkPartitionsDetection;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/SSLConnectionConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/SSLConnectionConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+
+/**
+ * Configuration for SSL configs.
+ */
+@Configuration(description = "SSL related configuration")
+public class SSLConnectionConfig {
+
+    private boolean enabled = true;
+
+    private int port = 8883;
+
+    private KeyStoreConfig keyStore = new KeyStoreConfig();
+
+    private TrustStoreConfig trustStore = new TrustStoreConfig();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public KeyStoreConfig getKeyStore() {
+        return keyStore;
+    }
+
+    public TrustStoreConfig getTrustStore() {
+        return trustStore;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/SlotsConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/SlotsConfig.java
@@ -16,11 +16,13 @@
  */
 package org.wso2.andes.configuration.models;
 
+import org.wso2.carbon.config.annotation.Configuration;
 import org.wso2.carbon.config.annotation.Element;
 
 /**
  * Configuration model for slots config in performance tuning section.
  */
+@Configuration(description = "Slots related configurations.")
 public class SlotsConfig {
 
     @Element(description = "Rough estimate for size of a slot. What is meant by size is the number of messages\n"

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/SlotsConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/SlotsConfig.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for slots config in performance tuning section.
+ */
+public class SlotsConfig {
+
+    @Element(description = "Rough estimate for size of a slot. What is meant by size is the number of messages\n"
+            + "contained within bounties of a slot.")
+    private int windowSize = 1000;
+
+    @Element(description = "If message publishers are slow, time taken to fill the slot (up to <windowSize>) will be longer.\n"
+            + "This will add an latency to messages. Therefore broker will mark the slot as\n"
+            + "ready to deliver before even the slot is entirely filled after specified time.\n"
+            + "NOTE: specified in milliseconds.")
+    private int messageAccumulationTimeout = 2000;
+
+    @Element(description = "Time interval which broker check for slots that can be marked as 'ready to deliver'\n"
+            + "(- slots which have a aged more than 'messageAccumulationTimeout')\n"
+            + "NOTE: specified in milliseconds.")
+    private int maxSubmitDelay = 1000;
+
+    @Element(description = "Number of MessageDeliveryWorker threads that should be started")
+    private int deliveryThreadCount = 5;
+
+    @Element(description = "Number of parallel threads to execute slot deletion task. Increasing this value will remove slots\n"
+            + "whose messages are read/delivered to consumers/acknowledged faster reducing heap memory used by\n"
+            + "server.")
+    private int deleteThreadCount = 5;
+
+    @Element(description = "Max number of pending message count to delete per Slot Deleting Task. This config is used to raise\n"
+            + "a WARN when pending scheduled number of slots exceeds this limit (indicate of an  issue that can lead to\n"
+            + "message accumulation on server.")
+    private int slotDeleteQueueDepthWarningThreshold = 1000;
+
+    @Element(description = "Maximum number of thrift client connections that should be created in the thrift connection pool")
+    private int thriftClientPoolSize = 10;
+
+    public int getWindowSize() {
+        return windowSize;
+    }
+
+    public int getMessageAccumulationTimeout() {
+        return messageAccumulationTimeout;
+    }
+
+    public int getMaxSubmitDelay() {
+        return maxSubmitDelay;
+    }
+
+    public int getDeliveryThreadCount() {
+        return deliveryThreadCount;
+    }
+
+    public int getDeleteThreadCount() {
+        return deleteThreadCount;
+    }
+
+    public int getSlotDeleteQueueDepthWarningThreshold() {
+        return slotDeleteQueueDepthWarningThreshold;
+    }
+
+    public int getThriftClientPoolSize() {
+        return thriftClientPoolSize;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/TopicMessageDeliveryStrategyConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/TopicMessageDeliveryStrategyConfig.java
@@ -23,10 +23,10 @@ import org.wso2.carbon.config.annotation.Element;
  * Configuration model for Topic delivery strategy config.
  */
 @Configuration(description = "When delivering topic messages to multiple topic\n"
-        + "subscribers one of following stratigies can be choosen.\n" + "\n"
+        + "subscribers one of following stratigies can be choosen.\n"
         + "               1. DISCARD_NONE     - Broker do not loose any message to any subscriber.\n"
         + "                                     When there are slow subscribers this can cause broker\n"
-        + "                                     go Out of Memory.\n" + "\n"
+        + "                                     go Out of Memory.\n"
         + "               2. SLOWEST_SUB_RATE - Broker deliver to the speed of the slowest\n"
         + "                                     topic subscriber. This can cause fast subscribers\n"
         + "                                     to starve. But eliminate Out of Memory issue.\n" + "\n"

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/TopicMessageDeliveryStrategyConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/TopicMessageDeliveryStrategyConfig.java
@@ -29,7 +29,7 @@ import org.wso2.carbon.config.annotation.Element;
         + "                                     go Out of Memory.\n"
         + "               2. SLOWEST_SUB_RATE - Broker deliver to the speed of the slowest\n"
         + "                                     topic subscriber. This can cause fast subscribers\n"
-        + "                                     to starve. But eliminate Out of Memory issue.\n" + "\n"
+        + "                                     to starve. But eliminate Out of Memory issue.\n"
         + "               3. DISCARD_ALLOWED  - Broker will try best to deliver. To eliminate Out\n"
         + "                                     of Memory threat broker limits sent but not acked message\n"
         + "                                     count to <maxUnackedMessages>.\n"

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/TopicMessageDeliveryStrategyConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/TopicMessageDeliveryStrategyConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for Topic delivery strategy config.
+ */
+@Configuration(description = "When delivering topic messages to multiple topic\n"
+        + "subscribers one of following stratigies can be choosen.\n" + "\n"
+        + "               1. DISCARD_NONE     - Broker do not loose any message to any subscriber.\n"
+        + "                                     When there are slow subscribers this can cause broker\n"
+        + "                                     go Out of Memory.\n" + "\n"
+        + "               2. SLOWEST_SUB_RATE - Broker deliver to the speed of the slowest\n"
+        + "                                     topic subscriber. This can cause fast subscribers\n"
+        + "                                     to starve. But eliminate Out of Memory issue.\n" + "\n"
+        + "               3. DISCARD_ALLOWED  - Broker will try best to deliver. To eliminate Out\n"
+        + "                                     of Memory threat broker limits sent but not acked message\n"
+        + "                                     count to <maxUnackedMessages>.\n"
+        + "                                     If it is breached, and <deliveryTimeout> is also\n"
+        + "                                     breached message can either be lost or actually\n"
+        + "                                     sent but ack is not honoured.")
+public class TopicMessageDeliveryStrategyConfig {
+    private String strategyName = "DISCARD_NONE";
+
+    @Element(description = "If you choose DISCARD_ALLOWED topic message delivery strategy,\n"
+            + "broker keep messages in memory until ack is done until this timeout.\n"
+            + "If an ack is not received under this timeout, ack will be simulated\n"
+            + "internally and real acknowledgement is discarded.\n"
+            + "deliveryTimeout is in seconds")
+    private int deliveryTimeout = 60;
+
+    public String getStrategyName() {
+        return strategyName;
+    }
+
+    public int getDeliveryTimeout() {
+        return deliveryTimeout;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/TransactionConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/TransactionConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+import org.wso2.carbon.config.annotation.Element;
+
+/**
+ * Configuration model for publisher transactions.
+ */
+@Configuration(description = "Publisher transaction related configurations.")
+public class TransactionConfig {
+
+    @Element(description = "Maximum batch size (Messages) in kilobytes for a transaction. Exceeding this limit will\n"
+            + "result in a failure in the subsequent commit (or prepare) request. Default is set to 1MB.\n"
+            + "Limit is calculated considering the payload of messages.")
+    private int maxBatchSizeInKB = 10240;
+
+    @Element(description = "Maximum number of parallel dtx enabled channel count. Distributed transaction\n"
+            + "requests exceeding this limit will fail.")
+    private int maxParallelDtxChannels = 20;
+
+    public int getMaxBatchSizeInKB() {
+        return maxBatchSizeInKB;
+    }
+
+    public int getMaxParallelDtxChannels() {
+        return maxParallelDtxChannels;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/TransportsConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/TransportsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License, 
  * Version 2.0 (the "License"); you may not use this file except 
@@ -17,25 +17,18 @@
 package org.wso2.andes.configuration.models;
 
 import org.wso2.carbon.config.annotation.Configuration;
-import org.wso2.carbon.config.annotation.Element;
 
 /**
- * Configuration model for broker coordination.
+ * Configuration model for transports related configs.
  */
-@Configuration(description = "Broker coordination config")
-public class CoordinationConfiguration {
+@Configuration(description = "You can enable/disable specific messaging transports in this section. By default all\n"
+        + "transports are enabled. This section also allows you to customize the messaging flows used\n"
+        + "within WSO2 MB. NOT performance related, but logic related.")
+public class TransportsConfig {
 
-    @Element(description = "The node ID of each member")
-    private String nodeID = "default";
+    private AMQPConfigs amqp = new AMQPConfigs();
 
-    @Element(description = "Thrift is used to maintain and sync slot (message groups) ranges between MB nodes.")
-    private String thriftServerHost = "localhost";
-
-    public String getNodeID() {
-        return nodeID;
-    }
-
-    public String getThriftServerHost() {
-        return thriftServerHost;
+    public AMQPConfigs getAmqp() {
+        return amqp;
     }
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/TrustStoreConfig.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/models/TrustStoreConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.andes.configuration.models;
+
+import org.wso2.carbon.config.annotation.Configuration;
+
+/**
+ * Trust store configuration model.
+ */
+@Configuration(description = "Trust store configuration")
+public class TrustStoreConfig {
+
+    private String location = "repository/resources/security/client-truststore.jks";
+
+    private String password = "wso2carbon";
+
+    private String certType = "SunX509";git add
+
+    public String getLocation() {
+        return location;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getCertType() {
+        return certType;
+    }
+}

--- a/modules/orbit/andes/pom.xml
+++ b/modules/orbit/andes/pom.xml
@@ -131,6 +131,31 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.carbon.config</groupId>
+                <artifactId>org.wso2.carbon.config.maven.plugin</artifactId>
+                <version>${carbon.config.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>create-doc</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <configclasses>
+                        <configclass>
+                            org.wso2.andes.configuration.models.BrokerConfiguration
+                        </configclass>
+                    </configclasses>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <properties>
         <bundle.name>${project.artifactId}</bundle.name>
         <private.package>
@@ -145,6 +170,7 @@
             com.google.common.base;version="19.0.0",
             com.google.common.util.concurrent;version="19.0.0",
             com.google.common.cache;version="19.0.0",
+            org.wso2.carbon.config.*,
             *;resolution:=optional
         </import.package>
         <export.package>

--- a/pom.xml
+++ b/pom.xml
@@ -407,6 +407,11 @@
                 <artifactId>org.wso2.carbon.utils</artifactId>
                 <version>${carbon.utils.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.config</groupId>
+                <artifactId>org.wso2.carbon.config</artifactId>
+                <version>${carbon.config.version}</version>
+            </dependency>
             <!--Carbon Metrics-->
             <dependency>
                 <groupId>org.wso2.carbon.metrics</groupId>
@@ -680,6 +685,7 @@
         <gs-collections.version>7.0.3</gs-collections.version>
         <org.apache.commons.pool.version>2.4.2</org.apache.commons.pool.version>
         <commons-lang.imp.pkg.version>[2.6, 3.0)</commons-lang.imp.pkg.version>
+        <carbon.config.version>2.0.5</carbon.config.version>
 
     </properties>
 


### PR DESCRIPTION
Add carbon-config dependancy and the plugin for config doc generation.
Add Configuration service singleton to fetch the root config instance.
Add model classes for the configurations in broker.xml
Use BrokerConfigurationService.getInstance().getBrokerConfiguration() to
fetch a config value.
NOTE : This commit only add support for yaml based configs, conversion
of broker.xml to deployment.yaml is not done.