### PR TITLE
Avoid connection credentials in console logs

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQBrokerDetails.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQBrokerDetails.java
@@ -78,7 +78,8 @@ public class AMQBrokerDetails implements BrokerDetails
                 }
                 else if (url.indexOf("//") == -1)
                 {
-                    throw new URLSyntaxException(url, "Missing '//' after the transport In broker URL",transport.length()+1,1);
+                    throw URLHelper.parseError(transport.length()+1, 1, "Missing '//' after the transport In broker " +
+                            "URL", url);
                 }
             }
             else

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/url/URLHelper.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/url/URLHelper.java
@@ -21,6 +21,8 @@
 package org.wso2.andes.url;
 
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class URLHelper
 {
@@ -136,8 +138,10 @@ public class URLHelper
 
     public static URLSyntaxException parseError(int index, int length, String error, String url)
     {
-        return new URLSyntaxException(url, error, index, length);
+        return new URLSyntaxException(maskURLPassword(url), error, index, length);
     }
+
+
 
     public static String printOptions(Map<String, String> options)
     {
@@ -165,5 +169,25 @@ public class URLHelper
 
             return sb.toString();
         }
+    }
+
+    /**
+     * Mask the password of the connection url with ***
+     * @param url the actual url
+     * @return the masked url
+     */
+    private static String maskURLPassword(String url) {
+
+        Pattern urlPattern = Pattern.compile("[a-z]+://.*");
+        Pattern passwordPattern = Pattern.compile(":(?:[^/]+)@");
+
+        final Matcher urlMatcher = urlPattern.matcher(url);
+        String maskUrl;
+        if (urlMatcher.find()) {
+            final Matcher pwdMatcher = passwordPattern.matcher(url);
+            maskUrl = pwdMatcher.replaceFirst(":***@");
+            return maskUrl;
+        }
+        return url;
     }
 }


### PR DESCRIPTION
If the connection url specified in the jndi context fails to parse, the andes client includes the full url into the exception message. Since this url can contain passwords, this commit avoids adding the such sensitive data into the exception object.

Public Jira : https://wso2.org/jira/browse/APIMANAGER-5915