### PR TITLE
Upgrade Carbon-Kernel to 5.2.0

### DIFF
--- a/modules/orbit/andes-client/pom.xml
+++ b/modules/orbit/andes-client/pom.xml
@@ -78,8 +78,8 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.securevault</groupId>
-            <artifactId>org.wso2.securevault</artifactId>
+            <groupId>org.wso2.carbon.secvault</groupId>
+            <artifactId>org.wso2.carbon.secvault</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -106,7 +106,7 @@
                             org.apache.commons.lang.*;version="${commons-lang.imp.pkg.version}",
                             org.slf4j.*;version="1.6.1",
                             org.apache.commons.logging.*,
-                            org.wso2.securevault.*,
+                            org.wso2.carbon.secvault.*,
                             org.ietf.jgss*,
                             javax.*,
                             com.google.common.base;version="19.0.0",

--- a/pom.xml
+++ b/pom.xml
@@ -433,8 +433,8 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.wso2.securevault</groupId>
-                <artifactId>org.wso2.securevault</artifactId>
+                <groupId>org.wso2.carbon.secvault</groupId>
+                <artifactId>org.wso2.carbon.secvault</artifactId>
                 <version>${securevault.version}</version>
             </dependency>
             <dependency>
@@ -665,14 +665,14 @@
         <hawtdb.version>1.6</hawtdb.version>
         <hawtbuf.version>1.9</hawtbuf.version>
         <hazelcast.version>3.5.0.wso2v1</hazelcast.version>
-        <org.wso2.carbon.metrics.manager.version>2.1.0</org.wso2.carbon.metrics.manager.version>
+        <org.wso2.carbon.metrics.manager.version>2.3.2</org.wso2.carbon.metrics.manager.version>
         <commons-codec.version>1.3.0.wso2v1</commons-codec.version>
         <h2.version>1.2.140</h2.version>
         <naming-factory.version>5.5.15</naming-factory.version>
         <naming-resources.version>5.5.15</naming-resources.version>
         <mysql-connector-java.version>5.1.31</mysql-connector-java.version>
         <gson.version>2.2.4</gson.version>
-        <securevault.version>1.0.0-wso2v2</securevault.version>
+        <securevault.version>5.0.8</securevault.version>
         <guava.version>19.0</guava.version>
         <cqengine.version>2.7.0</cqengine.version>
         <lz4.version>1.3.0</lz4.version>


### PR DESCRIPTION
## Purpose
Upgrade Carbon-Kernel and related dependencies to latest

## Approach
Following components are updated,

- Carbon-Kernel    5.2.0
- Carbon-Secvault 5.0.8
- Carbon-Metrics  2.3.2