### PR TITLE
Fix for ei#1113

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventData.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventData.java
@@ -76,6 +76,8 @@ public class DeliveryEventData {
      * Clear state data for current instance. This should be called by the last event handler for the ring-buffer
      */
     public void clearData() {
+        localSubscription = null;
+        metadata = null;
         errorOccurred = false;
         andesContent = null;
         freshContent.set(true);


### PR DESCRIPTION
## Purpose
References to Objects in Disruptor are not cleared properly after using. This fix clears the references after usage within Disruptor

## Issue 
> https://github.com/wso2/product-ei/issues/1113

## Goals
> Clear references for objects within Disruptor after usage. 

## Approach
> Last event handler of the Disruptor clears all the object reference from the Disruptor event container objects. In outbound and inbound disruptor we have missed clearing some newly introduced objects, With this fix, we are clearing those objects as well from the Disruptor buffer with the last event handler.

## User stories
> User publishes and consumes message from the broker. Once the messages get consumed references to delivered messages and already closed channels should be GC'ed

## Release note
> Clear references for objects within Disruptor after usage. 

## Documentation
> No documentation change needed

## Training
> No training document change needed

## Certification
> N/A - Functionality of the broker is not affected

## Marketing
> Not a feature, Fix for a bug

## Automation tests
 - Unit tests 
   > Not added
 - Integration tests
   > Need to manually test a heap dump to identify this. Since this is a probable OOM scenario.
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> None

## Migrations (if applicable)
> N/A

## Test environment
> This can be reproduced with any JDK, OS and DB
 
## Learning
> This issue can be identified by taking a heap dump after publishing and consuming the message from the broker and checking for references of ProtocolMessage, AndesChannel, LocalSubscription objects from Disruptor.