### PR TITLE
Fix NullPointerException during messaging

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventCleanupHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventCleanupHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel.disruptor.delivery;
+
+import com.lmax.disruptor.EventHandler;
+
+/**
+ * Disruptor handler used to clear events.
+ */
+public class DeliveryEventCleanupHandler implements EventHandler<DeliveryEventData> {
+
+    @Override
+    public void onEvent(DeliveryEventData deliveryEventData, long l, boolean b) throws Exception {
+        deliveryEventData.clearData();
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventData.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventData.java
@@ -76,6 +76,8 @@ public class DeliveryEventData {
      * Clear state data for current instance. This should be called by the last event handler for the ring-buffer
      */
     public void clearData() {
+        localSubscription = null;
+        metadata = null;
         errorOccurred = false;
         andesContent = null;
         freshContent.set(true);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
@@ -149,9 +149,6 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
                 onDeliveryException(message, subscription);
                 reQueueMessageIfDurable(message, subscription);
 
-            } finally {
-                deliveryEventData.clearData();
-
             }
         }
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DisruptorBasedFlusher.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DisruptorBasedFlusher.java
@@ -119,8 +119,11 @@ public class DisruptorBasedFlusher {
             deliveryEventHandlers[i] = new DeliveryEventHandler(i, parallelDeliveryHandlers);
         }
 
+        // Initialize handler for delivery event cleanup
+        DeliveryEventCleanupHandler deliveryEventCleanupHandler = new DeliveryEventCleanupHandler();
+
         disruptor.handleEventsWith(contentReadTaskBatchProcessor).then(decompressionEventHandlers)
-                .then(deliveryEventHandlers);
+                .then(deliveryEventHandlers).then(deliveryEventCleanupHandler);
 
         disruptor.start();
         ringBuffer = disruptor.getRingBuffer();


### PR DESCRIPTION
## Purpose
Resolves wso2/product-ei#1113

## Goals
Clears references for objects within Disruptor after usage.

## Approach
Last event handler of the Disruptor clears all the object reference from the Disruptor event container objects. In the outbound disruptor, we have missed clearing some newly introduced objects, With this fix, we have added a new handler for clearing those objects as well from the Disruptor buffer.

## User stories
N/A, this is a bug fix to prevent the server from going OOM.

## Release note
Clear references for objects within Disruptor after usage.

## Documentation
N/A, this is a bug fix

## Training
N/A, this is a bug fix

## Certification
N/A, this is a bug fix

## Marketing
N/A, this is a bug fix

## Automation tests
N/A, Need to manually test a heap dump to identify this. Since this is a probable OOM scenario.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A, this is a bug fix

## Related PRs
N/A, this is a bug fix

## Migrations (if applicable)
N/A, this is a bug fix

## Test environment
This can be reproduced with any JDK, OS and DB
 
## Learning
This issue can be identified by taking a heap dump after publishing and consuming the message from the broker and checking for references of ProtocolMessage, AndesChannel, LocalSubscription objects from Disruptor.