### PR TITLE
Add Qpid independant Andes metadata implementation

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesAckEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesAckEvent.java
@@ -126,7 +126,7 @@ public class AndesAckEvent {
      */
     private void addTraceLog() {
         //Tracing Message
-        MessageTracer.trace(metadataReference.messageID,
+        MessageTracer.trace(metadataReference.getMessageID(),
                 metadataReference.getDestination(), MessageTracer.ACK_MESSAGE_REFERENCE_SET_BY_DISRUPTOR);
 
         //Adding metrics meter for ack rate

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesEncodingUtil.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesEncodingUtil.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.kernel;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * <p>
+ * Utility class to encode/decode values to/from a {@link ByteBuffer}
+ * </p>
+ */
+public class AndesEncodingUtil {
+
+    /**
+     * Encode a long variable
+     *
+     * @param buffer {@link ByteBuffer}
+     * @param value  long value to be encoded
+     */
+    public static void putLong(ByteBuffer buffer, long value) {
+        buffer.putLong(value);
+    }
+
+    /**
+     * Encode an integer variable
+     *
+     * @param buffer {@link ByteBuffer}
+     * @param value  integer value to be encoded
+     */
+    public static void putInt(ByteBuffer buffer, int value) {
+        buffer.putInt(value);
+    }
+
+    /**
+     * Encode a boolean value.
+     *
+     * @param buffer {@link ByteBuffer}
+     * @param value  value to be encoded
+     */
+    public static void putBoolean(ByteBuffer buffer, boolean value) {
+        buffer.put(value ? (byte) 1 : (byte) 0);
+    }
+
+    /**
+     * Encode a string value
+     *
+     * @param buffer {@link ByteBuffer}
+     * @param value  string value to be encoded
+     */
+    public static void putString(ByteBuffer buffer, String value) {
+        byte[] byteArray = value.getBytes(StandardCharsets.UTF_8);
+        buffer.putInt(byteArray.length);
+        buffer.put(byteArray);
+    }
+
+    /**
+     * Retrieve an encoded String
+     *
+     * @param buffer {@link ByteBuffer}
+     * @return decoded String
+     */
+    public static String getString(ByteBuffer buffer) {
+        int length = buffer.getInt();
+        byte[] byteArray = new byte[length];
+        buffer.get(byteArray);
+        return new String(byteArray);
+    }
+
+    /**
+     * Retrieve the value of an encoded boolean
+     *
+     * @param buffer {@link ByteBuffer}
+     * @return decoded boolean value
+     */
+    public static boolean getBoolean(ByteBuffer buffer) {
+        return buffer.get() == (byte) 1;
+    }
+
+    /**
+     * Retrieve encoded integer
+     *
+     * @param buffer {@link ByteBuffer}
+     * @return decoded integer value
+     */
+    public static int getEncodedInt(ByteBuffer buffer) {
+        return buffer.getInt();
+    }
+
+    /**
+     * Retrieve encoded long value
+     *
+     * @param buffer {@link ByteBuffer}
+     * @return decoded long value
+     */
+    public static long getEncodedLong(ByteBuffer buffer) {
+        return buffer.getLong();
+    }
+
+    /**
+     * The number of bytes used to represent a {@code long} value in two's
+     * complement binary form.
+     *
+     * @return encoded long in bytes
+     */
+    public static int getEncodedLongLength() {
+        return Long.BYTES;
+    }
+
+    /**
+     * The number of bytes used to represent a {@code int} value in two's
+     * complement binary form.
+     *
+     * @return encoded integer in bytes
+     */
+    public static int getEncodedIntLength() {
+        return Integer.BYTES;
+    }
+
+    /**
+     * Length of encoded boolean
+     *
+     * @return encoded boolean in bytes
+     */
+    public static int getEncodedBooleanLength() {
+        return Byte.BYTES;
+    }
+
+    /**
+     * The number of bytes used to represent a {@code byte} value in two's
+     * complement binary form.
+     *
+     * @return length in bytes
+     */
+    public static int getEncodedByteLength() {
+        return Byte.BYTES;
+    }
+
+    /**
+     * This method call is slow. This calls string#getBytes() which is slower.
+     *
+     * @param value String that we need to get the encoded length
+     * @return length in bytes
+     */
+    public static int getEncodedStringLength(String value) {
+        return Integer.BYTES + value.getBytes(StandardCharsets.UTF_8).length;
+    }
+
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
@@ -66,8 +66,8 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
 
     private static Log log = LogFactory.getLog(DeliverableAndesMetadata.class);
 
-    public DeliverableAndesMetadata(long messageID, byte[] metadata, boolean parse) {
-        super(messageID, metadata, parse);
+    public DeliverableAndesMetadata(byte[] metadata) {
+        super(metadata);
         this.timeMessageIsRead = System.currentTimeMillis();
         this.channelDeliveryInfo = new ConcurrentHashMap<>();
         this.messageStatus = Collections.synchronizedList(new ArrayList<MessageStatus>());
@@ -91,9 +91,9 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
      * @return check expire result
      */
     public boolean isExpired() {
-        if (expirationTime != 0L) {
+        if (getExpirationTime() != 0L) {
             long now = System.currentTimeMillis();
-            if (now > expirationTime) {
+            if (now > getExpirationTime()) {
                 addMessageStatus(MessageStatus.EXPIRED);
                 return true;
             } else {
@@ -515,7 +515,7 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
                 messageStatus.add(state);
             } else {
                 log.warn(
-                        "Invalid message state transition suggested: " + state + " Message ID: " + messageID);
+                        "Invalid message state transition suggested: " + state + " Message ID: " + getMessageID());
             }
         } else {
             isValidTransition = messageStatus.get(messageStatus.size() - 1).isValidNextTransition(state);
@@ -523,7 +523,7 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
                 messageStatus.add(state);
             } else {
                 log.warn("Invalid message state transition from " + messageStatus.get(messageStatus.size() - 1)
-                        + " suggested: " + state + " Message ID: " + messageID
+                        + " suggested: " + state + " Message ID: " + getMessageID()
                         + " Message Status History >> " + messageStatus);
             }
         }
@@ -551,7 +551,7 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
         StringBuilder information = new StringBuilder();
 
         information.append("Message ID ");
-        information.append(Long.toString(messageID));
+        information.append(Long.toString(getMessageID()));
         information.append(',');
         information.append("Message Header ");
         information.append("null");
@@ -566,7 +566,7 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
         information.append(Long.toString(timeMessageIsRead));
         information.append(',');
         information.append("Expiration time ");
-        information.append(Long.toString(expirationTime));
+        information.append(Long.toString(getExpirationTime()));
         information.append(',');
         information.append("Channels sent ");
         StringBuilder deliveries = new StringBuilder();
@@ -619,7 +619,7 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
                 } else {
                     log.warn(
                             "Invalid channel message state transition suggested: " + state +
-                                    " Message ID: " + messageID + " Message Status History >> " + messageStatus);
+                                    " Message ID: " + getMessageID() + " Message Status History >> " + messageStatus);
                 }
             } else {
                 isValidTransition = messageStatusesForChannel.
@@ -630,7 +630,7 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
                 } else {
                     log.warn("Invalid channel message state transition from " + messageStatusesForChannel
                             .get(messageStatusesForChannel.size() - 1) + " suggested: " + state + " Message ID: "
-                            + messageID + " Channel Status History >> " + messageStatusesForChannel);
+                            + getMessageID() + " Channel Status History >> " + messageStatusesForChannel);
                 }
             }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageHandler.java
@@ -179,7 +179,7 @@ public class MessageHandler {
 
         if (!messagesRead.isEmpty()) {
             DeliverableAndesMetadata metadata = messagesRead.get(messagesRead.size()-1);
-            lastBufferedMessageId = metadata.messageID;
+            lastBufferedMessageId = metadata.getMessageID();
         }
 
         if (log.isDebugEnabled()) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessagingEngine.java
@@ -214,7 +214,7 @@ public class MessagingEngine {
             //mark messages as deleted
             message.markAsPreparedToDelete();
             if(log.isDebugEnabled()) {
-                log.debug("Scheduled to delete message id= " + message.messageID);
+                log.debug("Scheduled to delete message id= " + message.getMessageID());
             }
         }
     }
@@ -230,7 +230,7 @@ public class MessagingEngine {
             //mark messages as deleted
             message.markAsDeletedMessage();
             if(log.isDebugEnabled()) {
-                log.debug("Deleted message id= " + message.messageID);
+                log.debug("Deleted message id= " + message.getMessageID());
             }
         }
     }
@@ -242,12 +242,12 @@ public class MessagingEngine {
 
         for (DeliverableAndesMetadata message : messagesToRemove) {
             List<AndesMessageMetadata> messagesOfStorageQueue = storageSeparatedMessages
-                    .get(message.getStorageQueueName());
+                    .get(message.getStorageDestination());
             if (null == messagesOfStorageQueue) {
                 messagesOfStorageQueue = new ArrayList<>();
             }
             messagesOfStorageQueue.add(message);
-            storageSeparatedMessages.put(message.getStorageQueueName(), messagesOfStorageQueue);
+            storageSeparatedMessages.put(message.getStorageDestination(), messagesOfStorageQueue);
         }
         return storageSeparatedMessages;
     }
@@ -308,12 +308,12 @@ public class MessagingEngine {
 
         for (AndesMessageMetadata message : messagesToMove) {
             List<AndesMessageMetadata> messagesOfStorageQueue = storageSeparatedMessages
-                    .get(message.getStorageQueueName());
+                    .get(message.getStorageDestination());
             if (null == messagesOfStorageQueue) {
                 messagesOfStorageQueue = new ArrayList<>();
             }
             messagesOfStorageQueue.add(message);
-            storageSeparatedMessages.put(message.getStorageQueueName(), messagesOfStorageQueue);
+            storageSeparatedMessages.put(message.getStorageDestination(), messagesOfStorageQueue);
         }
         for (Map.Entry<String, List<AndesMessageMetadata>> entry : storageSeparatedMessages.entrySet()) {
             //move messages to dead letter channel

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/LZ4ContentCompressionStrategy.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/LZ4ContentCompressionStrategy.java
@@ -63,10 +63,11 @@ public class LZ4ContentCompressionStrategy implements ContentCompressionStrategy
 
         if (originalContentLength > lz4CompressionHelper.getContentCompressionThreshold()) {
             // Compress message
-            AndesMessagePart compressedMessagePart = lz4CompressionHelper.getCompressedMessage(partList, originalContentLength);
+            AndesMessagePart compressedMessagePart =
+                    lz4CompressionHelper.getCompressedMessage(partList, originalContentLength);
 
             // Update metadata to indicate the message is a compressed one
-            metadata.updateMetadata(true);
+            metadata.setCompressed(true);
             message.setMetadata(metadata);
 
             contentLength = compressedMessagePart.getDataLength();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/MessagePreProcessor.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/MessagePreProcessor.java
@@ -197,7 +197,7 @@ public class MessagePreProcessor implements EventHandler<InboundEventContainer> 
         for (StorageQueue matchingQueue : matchingQueues) {
 
             if (!originalMessageConsumed) {
-                message.getMetadata().setStorageQueueName(matchingQueue.getName());
+                message.getMetadata().setStorageDestination(matchingQueue.getName());
 
                 // add the topic wise cloned message to the events list. Message writers will pick that and
                 // write it.
@@ -210,16 +210,11 @@ public class MessagePreProcessor implements EventHandler<InboundEventContainer> 
                 //Message should be written to storage queue name. This is
                 //determined by destination of the message. So should be
                 //updated (but internal metadata will have topic name as usual)
-                clonedMessage.getMetadata().setStorageQueueName(matchingQueue.getName());
-
-                // Update cloned message metadata if isCompressed set true.
-                if (clonedMessage.getMetadata().isCompressed()) {
-                    clonedMessage.getMetadata().updateMetadata(true);
-                }
+                clonedMessage.getMetadata().setStorageDestination(matchingQueue.getName());
 
                 if (MessageTracer.isEnabled()) {
                     MessageTracer.trace(message, MessageTracer.MESSAGE_CLONED + clonedMessage.getMetadata()
-                            .getMessageID() + " for " + clonedMessage.getMetadata().getStorageQueueName());
+                            .getMessageID() + " for " + clonedMessage.getMetadata().getStorageDestination());
                 }
 
                 // add the topic wise cloned message to the events list. Message writers will pick that and

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/dtx/AndesPreparedMessageMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/dtx/AndesPreparedMessageMetadata.java
@@ -18,6 +18,7 @@
 
 package org.wso2.andes.kernel.dtx;
 
+import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.AndesMessageMetadata;
 
 /**
@@ -32,9 +33,9 @@ public class AndesPreparedMessageMetadata extends AndesMessageMetadata {
     private long oldMessageId;
 
     public AndesPreparedMessageMetadata(AndesMessageMetadata messageMetadata) {
-        super(messageMetadata.getMessageID(), messageMetadata.getMetadata(), true);
+        super(messageMetadata.getBytes());
         oldMessageId = getMessageID();
-        setStorageQueueName(messageMetadata.getStorageQueueName());
+        setStorageDestination(messageMetadata.getStorageDestination());
         setExpirationTime(messageMetadata.getExpirationTime());
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscription.java
@@ -345,7 +345,7 @@ public class AndesSubscription {
                             + subscriberConnection.getProtocolChannelID());
                 }
 
-                MessageTracer.trace(unAckedMessage.getMessageID(), unAckedMessage.getStorageQueueName(),
+                MessageTracer.trace(unAckedMessage.getMessageID(), unAckedMessage.getStorageDestination(),
                         "rebuffering message due to subscription left");
 
                 UUID protocolChannelID = getSubscriberConnection().getProtocolChannelID();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
@@ -364,16 +364,19 @@ public class QueueManagementInformationMBean extends AMQManagedObject implements
      * @param destinationQueueName The Dead Letter Queue Name for the tenant
      */
     @Override
-    public void deleteMessagesFromDeadLetterQueue(@MBeanOperationParameter(name = "andesMetadataIDs",
-                                                                           description = "ID of the Messages to Be DELETED") long[] andesMetadataIDs,
+    public void deleteMessagesFromDeadLetterQueue(
+            @MBeanOperationParameter(name = "andesMetadataIDs",
+                                     description = "ID of the Messages to Be DELETED") long[] andesMetadataIDs,
             @MBeanOperationParameter(name = "destinationQueueName",
-                                     description = "The Dead Letter Queue Name for the selected tenant") String destinationQueueName) {
+                                     description = "The Dead Letter Queue Name for the selected tenant")
+                                     String destinationQueueName) {
 
         List<AndesMessageMetadata> messageMetadataList = new ArrayList<>(andesMetadataIDs.length);
 
         for (long andesMetadataID : andesMetadataIDs) {
-            AndesMessageMetadata messageToRemove = new AndesMessageMetadata(andesMetadataID, null, false);
-            messageToRemove.setStorageQueueName(destinationQueueName);
+            AndesMessageMetadata messageToRemove =
+                    new AndesMessageMetadata(andesMetadataID, destinationQueueName, ProtocolType.AMQP);
+            messageToRemove.setStorageDestination(destinationQueueName);
             messageToRemove.setDestination(destinationQueueName);
             messageMetadataList.add(messageToRemove);
         }
@@ -1111,9 +1114,9 @@ public class QueueManagementInformationMBean extends AMQManagedObject implements
 
                 // Set the new destination queue
                 metadata.setDestination(targetQueue);
-                metadata.setStorageQueueName(targetQueue);
-                metadata.setMessageRouterName(newStorageQueue.getMessageRouter().getName());
-                metadata.updateMetadata(targetQueue, newStorageQueue.getMessageRouter().getName());
+                metadata.setStorageDestination(targetQueue);
+//                metadata.setMessageRouterName(newStorageQueue.getMessageRouter().getName());
+//                metadata.updateMetadata(targetQueue, newStorageQueue.getMessageRouter().getName());
             }
 
             AndesMessageMetadata clonedMetadata = metadata.shallowCopy(metadata.getMessageID());

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/message/AMQMessage.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/message/AMQMessage.java
@@ -247,7 +247,7 @@ public class AMQMessage implements ServerMessage
 
     }
 
-    public MessagePublishInfo getMessagePublishInfo() throws AMQException
+    public MessagePublishInfo getMessagePublishInfo()
     {
         return getMessageMetaData().getMessagePublishInfo();
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/message/MessageMetaData.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/message/MessageMetaData.java
@@ -23,6 +23,7 @@ import org.wso2.andes.framing.EncodingUtils;
 import org.wso2.andes.framing.AMQShortString;
 import org.wso2.andes.framing.FieldTable;
 import org.wso2.andes.framing.abstraction.MessagePublishInfo;
+import org.wso2.andes.kernel.AndesMessageMetadata;
 import org.wso2.andes.server.store.StorableMessageMetaData;
 import org.wso2.andes.server.store.MessageMetaDataType;
 import org.wso2.andes.AMQException;
@@ -237,11 +238,12 @@ public class MessageMetaData implements StorableMessageMetaData
     {
 
 
-        public MessageMetaData createMetaData(ByteBuffer buf)
+        public MessageMetaData createMetaData(AndesMessageMetadata messageMetadata)
         {
             try
             {
-                org.apache.mina.common.ByteBuffer minaSrc = org.apache.mina.common.ByteBuffer.wrap(buf);
+                byte[] metadata = messageMetadata.getProtocolMetadata();
+                org.apache.mina.common.ByteBuffer minaSrc = org.apache.mina.common.ByteBuffer.wrap(metadata);
                 int size = EncodingUtils.readInteger(minaSrc);
                 ContentHeaderBody chb = ContentHeaderBody.createFromBuffer(minaSrc, size);
                 final AMQShortString exchange = EncodingUtils.readAMQShortString(minaSrc);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/message/MessageMetaData_0_10.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/message/MessageMetaData_0_10.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.andes.server.message;
 
+import org.wso2.andes.kernel.AndesMessageMetadata;
 import org.wso2.andes.server.store.StorableMessageMetaData;
 import org.wso2.andes.server.store.MessageMetaDataType;
 import org.wso2.andes.transport.MessageTransfer;
@@ -214,10 +215,10 @@ public class MessageMetaData_0_10 implements StorableMessageMetaData
 
     private static class MetaDataFactory implements MessageMetaDataType.Factory<MessageMetaData_0_10>
     {
-        public MessageMetaData_0_10 createMetaData(ByteBuffer buf)
+        public MessageMetaData_0_10 createMetaData(AndesMessageMetadata metadata)
         {
             BBDecoder decoder = new BBDecoder();
-            decoder.init(buf);
+            decoder.init(ByteBuffer.wrap(metadata.getProtocolMetadata()));
 
             long arrivalTime = decoder.readInt64();
             int bodySize = decoder.readInt32();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/DLCQueueUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/queue/DLCQueueUtils.java
@@ -175,7 +175,7 @@ public class DLCQueueUtils {
         Long messageID = amqMessage.getMessageNumber();
         String storageQueue = amqMessage.getRoutingKey();
         AndesMessageMetadata messageToMove = AMQPUtils.convertAMQMessageToAndesMetadata(amqMessage);
-        messageToMove.setStorageQueueName(storageQueue);
+        messageToMove.setStorageDestination(storageQueue);
 
         List<AndesMessageMetadata> messageToMoveToDLC = new ArrayList<>();
         messageToMoveToDLC.add(messageToMove);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/store/MessageMetaDataType.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/store/MessageMetaDataType.java
@@ -17,19 +17,19 @@
  */
 package org.wso2.andes.server.store;
 
+import org.wso2.andes.kernel.AndesMessageMetadata;
 import org.wso2.andes.server.message.MessageMetaData;
 import org.wso2.andes.server.message.MessageMetaData_0_10;
-
-import java.nio.ByteBuffer;
 
 public enum MessageMetaDataType
 {
     META_DATA_0_8  {   public Factory<MessageMetaData> getFactory() { return MessageMetaData.FACTORY; } },
     META_DATA_0_10 {   public Factory<MessageMetaData_0_10> getFactory() { return MessageMetaData_0_10.FACTORY; } };
 
+
     public static interface Factory<M extends StorableMessageMetaData>
     {
-        M createMetaData(ByteBuffer buf);
+        M createMetaData(AndesMessageMetadata messageMetadata);
     }
 
     abstract public Factory<? extends StorableMessageMetaData> getFactory();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingMessageStore.java
@@ -290,7 +290,7 @@ public class FailureObservingMessageStore extends FailureObservingStore<MessageS
             if (MessageTracer.isEnabled()) {
                 for (AndesMessageMetadata message : messagesToRemove) {
                     MessageTracer.trace(message.getMessageID(),
-                                        message.getStorageQueueName(), MessageTracer.MESSAGE_DELETED);
+                                        message.getStorageDestination(), MessageTracer.MESSAGE_DELETED);
                 }
             }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -268,7 +268,7 @@ public class RDBMSConstants {
 
     // TODO: MySQL syntax. Updated RDBMS queries optimized for each database
     protected static final String PS_SELECT_METADATA_RANGE_FROM_QUEUE =
-            "SELECT " + MESSAGE_ID + "," + METADATA
+            "SELECT " + METADATA
             + " FROM " + METADATA_TABLE
             + " WHERE " + QUEUE_ID + "=?"
             + " AND " + DLC_QUEUE_ID + "=-1"
@@ -285,7 +285,7 @@ public class RDBMSConstants {
             + " ORDER BY " + MESSAGE_ID;
 
     protected static final String PS_SELECT_METADATA_FROM_QUEUE =
-            "SELECT " + MESSAGE_ID + "," + METADATA
+            "SELECT " + METADATA
             + " FROM " + METADATA_TABLE
             + " WHERE " + MESSAGE_ID + ">?"
             + " AND " + QUEUE_ID + "=?"
@@ -302,7 +302,7 @@ public class RDBMSConstants {
             + " ORDER BY " + MESSAGE_ID;
 
     protected static final String PS_SELECT_METADATA_IN_DLC_FOR_QUEUE =
-            "SELECT " + MESSAGE_ID + "," + METADATA
+            "SELECT " + METADATA
             + " FROM " + METADATA_TABLE
             + " WHERE " + MESSAGE_ID + ">?"
             + " AND " + QUEUE_ID + "=?"
@@ -310,7 +310,7 @@ public class RDBMSConstants {
             + " ORDER BY " + MESSAGE_ID;
 
     protected static final String PS_SELECT_METADATA_IN_DLC =
-            "SELECT " + MESSAGE_ID + "," + METADATA
+            "SELECT " + METADATA
             + " FROM " + METADATA_TABLE
             + " WHERE " + MESSAGE_ID + ">?"
             + " AND " + DLC_QUEUE_ID + "=?"
@@ -841,7 +841,7 @@ public class RDBMSConstants {
      * Prepared statement to select retained message metadata for a given topic id
      */
     protected static final String PS_SELECT_RETAINED_METADATA =
-            "SELECT " + MESSAGE_ID + ", " + METADATA
+            "SELECT " + METADATA
             + " FROM " + RETAINED_METADATA_TABLE
             + " WHERE " + TOPIC_ID + "=?";
 
@@ -964,7 +964,7 @@ public class RDBMSConstants {
                     + " FROM " + DTX_ENTRY_TABLE;
 
     public static final String PS_SELECT_DTX_DEQUEUE_METADATA =
-            "SELECT " + MESSAGE_ID + "," + QUEUE_NAME + "," + METADATA
+            "SELECT " + METADATA
                     + " FROM " + DTX_DEQUEUE_RECORD_TABLE
                     + " WHERE " + INTERNAL_XID + "=?";
 
@@ -994,7 +994,7 @@ public class RDBMSConstants {
                     + " FROM " + DTX_CONTENT_DEQUEUE_TABLE + " WHERE " + MESSAGE_ID + "=?";
 
     static final String PS_SELECT_DTX_ENQUEUED_METADATA =
-            "SELECT " + MESSAGE_ID + "," + METADATA
+            "SELECT " + METADATA
                     + " FROM " + DTX_ENQUEUE_RECORD_TABLE
                     + " WHERE " + INTERNAL_XID + "=?";
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSDtxStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSDtxStoreImpl.java
@@ -122,8 +122,8 @@ public class RDBMSDtxStoreImpl implements DtxStore {
 
                 storeDequeueRecordMetadataPS.setLong(1, internalXid);
                 storeDequeueRecordMetadataPS.setLong(2, messageMetadata.getMessageID());
-                storeDequeueRecordMetadataPS.setString(3, messageMetadata.getStorageQueueName());
-                storeDequeueRecordMetadataPS.setBytes(4, messageMetadata.getMetadata());
+                storeDequeueRecordMetadataPS.setString(3, messageMetadata.getStorageDestination());
+                storeDequeueRecordMetadataPS.setBytes(4, messageMetadata.getBytes());
                 storeDequeueRecordMetadataPS.addBatch();
 
                 backupDequeueMessagesPS.setLong(1, internalXid);
@@ -163,7 +163,7 @@ public class RDBMSDtxStoreImpl implements DtxStore {
                 AndesMessageMetadata metadata = message.getMetadata();
                 storeMetadataPS.setLong(1, internalXid);
                 storeMetadataPS.setLong(2, temporaryMessageId);
-                storeMetadataPS.setBytes(3, metadata.getMetadata());
+                storeMetadataPS.setBytes(3, metadata.getBytes());
                 storeMetadataPS.addBatch();
 
                 for (AndesMessagePart messagePart : message.getContentChunkList()) {
@@ -360,12 +360,7 @@ public class RDBMSDtxStoreImpl implements DtxStore {
 
             List<AndesPreparedMessageMetadata> dtxMetadataList = new ArrayList<>();
             while (resultSet.next()) {
-                AndesMessageMetadata metadata = new AndesMessageMetadata(
-                        resultSet.getLong(RDBMSConstants.MESSAGE_ID),
-                        resultSet.getBytes(RDBMSConstants.METADATA),
-                        true
-                        );
-                metadata.setStorageQueueName(resultSet.getString(RDBMSConstants.QUEUE_NAME));
+                AndesMessageMetadata metadata = new AndesMessageMetadata(resultSet.getBytes(RDBMSConstants.METADATA));
                 AndesPreparedMessageMetadata dtxMetadata = new AndesPreparedMessageMetadata(metadata);
                 dtxMetadataList.add(dtxMetadata);
             }
@@ -399,11 +394,8 @@ public class RDBMSDtxStoreImpl implements DtxStore {
             metadataResultSet = retrieveMetadataPS.executeQuery();
             Map<Long, AndesMessage> messageMap = new HashMap<>();
             while (metadataResultSet.next()) {
-                AndesMessageMetadata metadata = new AndesMessageMetadata(
-                        metadataResultSet.getLong(RDBMSConstants.MESSAGE_ID),
-                        metadataResultSet.getBytes(RDBMSConstants.METADATA),
-                        true
-                );
+                AndesMessageMetadata metadata =
+                        new AndesMessageMetadata(metadataResultSet.getBytes(RDBMSConstants.METADATA));
                 AndesMessage andesMessage = new AndesMessage(metadata);
                 messageMap.put(metadata.getMessageID(), andesMessage);
             }
@@ -492,8 +484,8 @@ public class RDBMSDtxStoreImpl implements DtxStore {
             for (AndesPreparedMessageMetadata metadata : messagesToRestore) {
                 storeMetadataPS.setLong(1, metadata.getMessageID());
                 storeMetadataPS.setLong(2,
-                                        rdbmsMessageStore.getCachedQueueID( metadata.getStorageQueueName()));
-                storeMetadataPS.setBytes(3, metadata.getMetadata());
+                                        rdbmsMessageStore.getCachedQueueID( metadata.getStorageDestination()));
+                storeMetadataPS.setBytes(3, metadata.getBytes());
                 storeMetadataPS.addBatch();
 
                 restoreContentPS.setLong(1, metadata.getMessageID());

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/tools/messagestore/commands/Show.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/tools/messagestore/commands/Show.java
@@ -409,17 +409,9 @@ public class Show extends AbstractCommand
                 userid.add(useridSS == null ? "null" : useridSS.toString());
 
                 MessagePublishInfo info = null;
-                try
-                {
-                    if(msg instanceof AMQMessage)
-                    {
-                        info = ((AMQMessage)msg).getMessagePublishInfo();
-                    }
 
-                }
-                catch (AMQException e)
-                {
-                    //ignore
+                if (msg instanceof AMQMessage) {
+                    info = ((AMQMessage) msg).getMessagePublishInfo();
                 }
 
                 if (info != null)

--- a/modules/andes-core/broker/src/test/java/org/wso2/andes/server/exchange/AbstractHeadersExchangeTestBase.java
+++ b/modules/andes-core/broker/src/test/java/org/wso2/andes/server/exchange/AbstractHeadersExchangeTestBase.java
@@ -622,17 +622,8 @@ public class AbstractHeadersExchangeTestBase extends InternalBrokerBaseCase
             return getKey().toString();
         }
 
-        private Object getKey()
-        {
-            try
-            {
-                return getMessagePublishInfo().getRoutingKey();
-            }
-            catch (AMQException e)
-            {
-                _log.error("Error getting routing key: " + e, e);
-                return null;
-            }
+        private Object getKey() {
+            return getMessagePublishInfo().getRoutingKey();
         }
     }
 }


### PR DESCRIPTION
## Purpose
> Implement a new Andes message metadata implementation to make broker core independant from the existing Qpid code.

## Goals
> Created a new AndesMessageMetadata implementation that doesn't depend on Qpid

## Release note
> Implement Qpid independent message metadata format for the broker

## Migrations (if applicable)
> This metadata implementation is not compatible with older metadata format. Hence DB data migration is required when moving from 3.xx versions to 4.xx
