### PR TITLE
Add LevelDB message store and dtx store.

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/file/FileDtxStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/file/FileDtxStoreImpl.java
@@ -1,0 +1,761 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*/
+
+package org.wso2.andes.store.file;
+
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBException;
+import org.iq80.leveldb.DBIterator;
+import org.iq80.leveldb.WriteBatch;
+import org.wso2.andes.dtx.XidImpl;
+import org.wso2.andes.kernel.Andes;
+import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.kernel.AndesMessage;
+import org.wso2.andes.kernel.AndesMessageMetadata;
+import org.wso2.andes.kernel.AndesMessagePart;
+import org.wso2.andes.kernel.DtxStore;
+import org.wso2.andes.kernel.dtx.AndesPreparedMessageMetadata;
+import org.wso2.andes.kernel.dtx.DtxBranch;
+import org.wso2.andes.server.ClusterResourceHolder;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.transaction.xa.Xid;
+
+import static org.iq80.leveldb.impl.Iq80DBFactory.asString;
+import static org.iq80.leveldb.impl.Iq80DBFactory.bytes;
+
+import static org.wso2.andes.store.file.FileStoreConstants.DELIMITER;
+import static org.wso2.andes.store.file.FileStoreConstants.DESTINATION_NAME;
+import static org.wso2.andes.store.file.FileStoreConstants.DLC;
+import static org.wso2.andes.store.file.FileStoreConstants.DLC_STATUS;
+import static org.wso2.andes.store.file.FileStoreConstants.DTX_ENTRY;
+import static org.wso2.andes.store.file.FileStoreConstants.DTX_ENQUEUE;
+import static org.wso2.andes.store.file.FileStoreConstants.DTX_DEQUEUE;
+import static org.wso2.andes.store.file.FileStoreConstants.DTX_XID;
+import static org.wso2.andes.store.file.FileStoreConstants.FORMAT_CODE;
+import static org.wso2.andes.store.file.FileStoreConstants.GLOBAL_ID;
+import static org.wso2.andes.store.file.FileStoreConstants.BRANCH_ID;
+import static org.wso2.andes.store.file.FileStoreConstants.MESSAGE;
+import static org.wso2.andes.store.file.FileStoreConstants.MESSAGE_CONTENT;
+import static org.wso2.andes.store.file.FileStoreConstants.MESSAGE_METADATA;
+import static org.wso2.andes.store.file.FileStoreConstants.START_OFFSET;
+import static org.wso2.andes.store.file.FileStoreConstants.XID_IDENTIFIER;
+
+/**
+ * Implementation of file based distributed transaction store. This supports LevelDB.
+ */
+public class FileDtxStoreImpl implements DtxStore {
+
+    private FileMessageStoreImpl fileMessageStore;
+
+    /**
+     * Generate unique IDs : temporary message ids and internal xids
+     */
+    private Andes uniqueIdGenerator;
+
+    FileDtxStoreImpl(FileMessageStoreImpl fileMessageStore) {
+        this.fileMessageStore = fileMessageStore;
+        uniqueIdGenerator = Andes.getInstance();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long storeDtxRecords(Xid xid, List<AndesMessage> enqueueRecords,
+                                List<? extends AndesMessageMetadata> dequeueRecords) throws AndesException {
+        DB brokerStore = fileMessageStore.getDB();
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+            long internalXid = prepareToStoreXid(xid, batch);
+            prepareToStoreEnqueuedRecords(enqueueRecords, internalXid, batch);
+
+            if (!dequeueRecords.isEmpty()) {
+                prepareToBackupDequeueRecords(dequeueRecords, internalXid, batch);
+                prepareToDeleteMessages(dequeueRecords, brokerStore, batch);
+            }
+            brokerStore.write(batch);
+            return internalXid;
+        } catch (AndesException e) {
+            throw e;
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while storing dtx records.", e);
+        } finally {
+            fileMessageStore.closeWriteBatch(batch);
+        }
+    }
+
+    /**
+     * Store the provided xid in the batch. Operations are not written to the database within the method. It is the
+     * responsibility of the caller to write the changes.
+     *
+     * @param xid   {@link Xid} object to be stored
+     * @param batch {@link DB} LevelDB write batch
+     * @return return the internal xid relating to the {@link Xid}
+     * @throws DBException throws {@link DBException} when there is an exception in LevelDB
+     */
+    private long prepareToStoreXid(Xid xid, WriteBatch batch) throws DBException {
+
+        String nodeId = ClusterResourceHolder.getInstance().getClusterManager().getMyNodeID();
+
+        String internalXid = Long.toString(uniqueIdGenerator.generateUniqueId());
+
+        String dtxFormatCodeIdentifier = fileMessageStore.generateKey(DTX_ENTRY, internalXid, nodeId, FORMAT_CODE);
+        String dtxGlobalIDIdentifier = fileMessageStore.generateKey(DTX_ENTRY, internalXid, nodeId, GLOBAL_ID);
+        String dtxBranchIDIdentifier = fileMessageStore.generateKey(DTX_ENTRY, internalXid, nodeId, BRANCH_ID);
+        String dtxXIDIdentifier = fileMessageStore.generateKey(DTX_XID, nodeId, Integer.toString(xid.getFormatId()),
+                asString(xid.getGlobalTransactionId()), asString(xid.getBranchQualifier()), XID_IDENTIFIER);
+
+        batch.put(bytes(dtxFormatCodeIdentifier), bytes(Integer.toString(xid.getFormatId())));
+        batch.put(bytes(dtxGlobalIDIdentifier), xid.getGlobalTransactionId());
+        batch.put(bytes(dtxBranchIDIdentifier), xid.getBranchQualifier());
+        batch.put(bytes(dtxXIDIdentifier), bytes(internalXid));
+
+        return Long.parseLong(internalXid);
+    }
+
+    /**
+     * Store enqueued messages in the batch. Operations are not written to the database within the method. It is the
+     * responsibility of the caller to write the changes.
+     *
+     * @param enqueueRecords {@link List} of {@link AndesMessage} to store
+     * @param internalXid    internal Xid of the transaction
+     * @param batch          {@link DB} LevelDB write batch
+     * @throws DBException throws {@link DBException} when there is an exception in LevelDB
+     */
+    private void prepareToStoreEnqueuedRecords(List<AndesMessage> enqueueRecords, long internalXid,
+                                               WriteBatch batch) throws DBException {
+
+        for (AndesMessage message : enqueueRecords) {
+            long temporaryMessageId = uniqueIdGenerator.generateUniqueId();
+
+            String dtxEnqueueMetadataIdentifier = fileMessageStore.generateKey(DTX_ENQUEUE,
+                    Long.toString(internalXid), MESSAGE_METADATA, Long.toString(temporaryMessageId));
+
+            batch.put(bytes(dtxEnqueueMetadataIdentifier), message.getMetadata().getBytes());
+
+            for (AndesMessagePart messagePart : message.getContentChunkList()) {
+                String dtxEnqueueContentIdentifier = fileMessageStore.generateKey(DTX_ENQUEUE,
+                        Long.toString(internalXid), MESSAGE_CONTENT, Long.toString(temporaryMessageId),
+                        Integer.toString(messagePart.getOffset()));
+
+                batch.put(bytes(dtxEnqueueContentIdentifier), messagePart.getData());
+            }
+        }
+    }
+
+    /**
+     * Prepare dequeued records in a batch. Operations are not written to the database within the method. It is the
+     * responsibility of the caller to write the changes.
+     *
+     * @param dequeueRecords {@link List} of acknowledged messages
+     * @param internalXid    internal {@link Xid}
+     * @param batch          {@link WriteBatch} LevelDB write batch
+     * @throws AndesException throws {@link AndesException} on database error
+     */
+    private void prepareToBackupDequeueRecords(List<? extends AndesMessageMetadata> dequeueRecords, long internalXid,
+                                               WriteBatch batch) throws AndesException {
+
+        for (AndesMessageMetadata messageMetadata : dequeueRecords) {
+
+            String dtxDequeueDestinationIdentifier = fileMessageStore.generateKey(DTX_DEQUEUE,
+                    Long.toString(internalXid), DESTINATION_NAME, Long.toString(messageMetadata.getMessageID()));
+            String dtxDequeueMetadataIdentifier = fileMessageStore.generateKey(DTX_DEQUEUE,
+                    Long.toString(internalXid), MESSAGE_METADATA, Long.toString(messageMetadata.getMessageID()));
+
+            batch.put(bytes(dtxDequeueDestinationIdentifier), bytes(messageMetadata.getStorageDestination()));
+            batch.put(bytes(dtxDequeueMetadataIdentifier), messageMetadata.getBytes());
+
+            DB brokerStore = fileMessageStore.getDB();
+            DBIterator keyIterator = brokerStore.iterator();
+            String head = fileMessageStore.generateKey(MESSAGE, Long.toString(messageMetadata.getMessageID()),
+                    START_OFFSET, MESSAGE_CONTENT);
+            keyIterator.seek(bytes(head));
+
+            try {
+                while (keyIterator.hasNext()) {
+                    //key arrangement : MESSAGE.$message_id.$offset.MESSAGE_CONTENT
+                    String key = asString(keyIterator.peekNext().getKey());
+                    String[] keySplit = key.split(DELIMITER);
+
+                    String messageID = keySplit[1];
+                    String offset = keySplit[2];
+
+                    String dtxDequeueContentIdentifier = fileMessageStore.generateKey(DTX_DEQUEUE,
+                            Long.toString(internalXid), MESSAGE_CONTENT, messageID, offset);
+
+                    batch.put(bytes(dtxDequeueContentIdentifier), keyIterator.peekNext().getValue());
+
+                    if (!keySplit[3].equals(MESSAGE_CONTENT)) {
+                        break;
+                    }
+
+                    keyIterator.next();
+                }
+            } catch (DBException e) {
+                throw new AndesException("Error occurred while retrieving content for dequeue records.", e);
+            } finally {
+                fileMessageStore.closeKeyIterator(keyIterator);
+            }
+        }
+    }
+
+    /**
+     * Delete the messages from message store using the provided batch. Operations are not written to the database
+     * within the method. It is the responsibility of the caller to write the changes.
+     *
+     * @param dequeueRecords {@link List} of dequeue records
+     * @param brokerStore    {@link DB} LevelDB store
+     * @param batch          {@link WriteBatch} LevelDB write batch
+     * @throws AndesException throws {@link AndesException} on database error
+     */
+    private void prepareToDeleteMessages(List<? extends AndesMessageMetadata> dequeueRecords,
+                                         DB brokerStore, WriteBatch batch) {
+        for (AndesMessageMetadata metadata : dequeueRecords) {
+            long messageID = metadata.getMessageID();
+            String storageQueueName = metadata.getStorageDestination();
+
+            fileMessageStore.deleteMessage(messageID, batch);
+            fileMessageStore.deleteMessageFromQueue(messageID, storageQueueName, batch);
+
+            // Delete message from DLC if it is in DLC
+            String messageDLCStatus = fileMessageStore.generateKey(MESSAGE, Long.toString(messageID),
+                    DLC_STATUS);
+
+            if (Long.parseLong(asString(brokerStore.get(bytes(messageDLCStatus)))) == 1) {
+                fileMessageStore.deleteMessageFromQueue(messageID, DLC, batch);
+            }
+        }
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void updateOnCommit(long internalXid, List<AndesMessage> enqueueRecords) throws AndesException {
+        DB brokerStore = fileMessageStore.getDB();
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+            if (!enqueueRecords.isEmpty()) {
+                prepareToStoreMessages(enqueueRecords, batch);
+            }
+            removePreparedRecords(internalXid, batch);
+            brokerStore.write(batch);
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while executing dtx commit event", e);
+        } finally {
+            fileMessageStore.closeWriteBatch(batch);
+        }
+    }
+
+    /**
+     * Store the messages in the message store using the provided batch. Operations are not written to the database
+     * within the method. It is the responsibility of the caller to write the changes.
+     *
+     * @param enqueueRecords {@link List} of enqueue records
+     * @param batch          {@link WriteBatch} LevelDB write batch
+     * @throws AndesException throws {@link AndesException} on database error
+     */
+    private void prepareToStoreMessages(List<AndesMessage> enqueueRecords, WriteBatch batch) throws AndesException {
+        for (AndesMessage message : enqueueRecords) {
+            AndesMessageMetadata metadata = message.getMetadata();
+
+            fileMessageStore.addMetadata(metadata, metadata.getStorageDestination(), batch);
+
+            if (metadata.getExpirationTime() > 0) {
+                fileMessageStore.addExpiryData(metadata, batch);
+            }
+
+            fileMessageStore.addContent(message.getContentChunkList(), batch);
+        }
+    }
+
+    /**
+     * Remove the prepared dtx records using the provided batch. Operations are not written to the database within the
+     * method. It is the responsibility of the caller to write the changes.
+     *
+     * @param internalXid internal {@link Xid}
+     * @param batch       {@link WriteBatch} LevelDB write batch
+     * @throws DBException throws {@link DBException} when there is an exception in LevelDB
+     */
+    private void removePreparedRecords(long internalXid, WriteBatch batch) throws DBException {
+
+        deleteDtxEntry(internalXid, batch);
+        deleteDtxEnqueueRecord(internalXid, batch);
+        deleteDtxDequeueRecord(internalXid, batch);
+    }
+
+    /**
+     * Remove the prepared dtx entry using the provided batch.
+     *
+     * @param internalXid internal {@link Xid}
+     * @param batch       {@link WriteBatch} LevelDB write batch
+     * @throws DBException throws {@link DBException} when there is an exception in LevelDB
+     */
+    private void deleteDtxEntry(long internalXid, WriteBatch batch) throws DBException {
+        String nodeId = ClusterResourceHolder.getInstance().getClusterManager().getMyNodeID();
+
+        DBIterator keyIterator = fileMessageStore.getDB().iterator();
+        String head = fileMessageStore.generateKey(DTX_ENTRY, Long.toString(internalXid), nodeId);
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+
+                String currentXID = keySplit[1];
+
+                if (!currentXID.equals(Long.toString(internalXid))) {
+                    break;
+                }
+
+                batch.delete(bytes(key));
+                keyIterator.next();
+            }
+
+            head = fileMessageStore.generateKey(DTX_XID);
+            keyIterator.seek(bytes(head));
+
+            while (keyIterator.hasNext()) {
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+
+                if (asString(keyIterator.peekNext().getValue()).equals(Long.toString(internalXid))) {
+                    batch.delete(bytes(key));
+                    break;
+                } else if (!keySplit[0].equals(DTX_XID)) {
+                    break;
+                }
+                keyIterator.next();
+            }
+        } finally {
+            fileMessageStore.closeKeyIterator(keyIterator);
+        }
+    }
+
+    /**
+     * Remove the prepared enqueue records using the provided batch.
+     *
+     * @param internalXid internal {@link Xid}
+     * @param batch       {@link WriteBatch} LevelDB write batch
+     * @throws DBException throws {@link DBException} when there is an exception in LevelDB
+     */
+    private void deleteDtxEnqueueRecord(long internalXid, WriteBatch batch) throws DBException {
+        DBIterator keyIterator = fileMessageStore.getDB().iterator();
+        String head = fileMessageStore.generateKey(DTX_ENQUEUE, Long.toString(internalXid));
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+
+                String xid = keySplit[1];
+
+                if (!xid.equals(Long.toString(internalXid))) {
+                    break;
+                }
+
+                batch.delete(bytes(key));
+                keyIterator.next();
+            }
+        } finally {
+            fileMessageStore.closeKeyIterator(keyIterator);
+        }
+    }
+
+    /**
+     * Remove the prepared dequeue records using the provided batch.
+     *
+     * @param internalXid internal {@link Xid}
+     * @param batch       {@link WriteBatch} LevelDB write batch
+     * @throws DBException throws {@link DBException} when there is an exception in LevelDB
+     */
+    private void deleteDtxDequeueRecord(long internalXid, WriteBatch batch) throws DBException {
+        DBIterator keyIterator = fileMessageStore.getDB().iterator();
+        String head = fileMessageStore.generateKey(DTX_DEQUEUE, Long.toString(internalXid));
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+
+                String xid = keySplit[1];
+
+                if (!xid.equals(Long.toString(internalXid))) {
+                    break;
+                }
+
+                batch.delete(bytes(key));
+                keyIterator.next();
+            }
+        } finally {
+            fileMessageStore.closeKeyIterator(keyIterator);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void updateOnOnePhaseCommit(List<AndesMessage> enqueueRecords, List<AndesPreparedMessageMetadata>
+            dequeueRecordsMetadata) throws AndesException {
+        DB brokerStore = fileMessageStore.getDB();
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+            if (!enqueueRecords.isEmpty()) {
+                prepareToStoreMessages(enqueueRecords, batch);
+            }
+
+            if (!dequeueRecordsMetadata.isEmpty()) {
+                prepareToDeleteMessages(dequeueRecordsMetadata, brokerStore, batch);
+            }
+
+            brokerStore.write(batch);
+
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while executing dtx commit event", e);
+        } finally {
+            fileMessageStore.closeWriteBatch(batch);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void updateOnRollback(long internalXid, List<AndesPreparedMessageMetadata> messagesToRestore)
+            throws AndesException {
+        DB brokerStore = fileMessageStore.getDB();
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+            restoreRolledBackAcknowledgedMessages(messagesToRestore, internalXid, batch);
+            removePreparedRecords(internalXid, batch);
+            brokerStore.write(batch);
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while executing dtx commit event", e);
+        } finally {
+            fileMessageStore.closeWriteBatch(batch);
+        }
+    }
+
+    /**
+     * Restore acknowledged but not committed messages back in the message store.
+     *
+     * @param messagesToRestore {@link List} of {@link AndesPreparedMessageMetadata}
+     * @param internalXid       internal Xid of the transaction
+     * @param batch             {@link WriteBatch} LevelDB write batch
+     * @throws DBException throws {@link DBException} when there is an exception in LevelDB
+     */
+    private void restoreRolledBackAcknowledgedMessages(List<AndesPreparedMessageMetadata> messagesToRestore,
+                                                       long internalXid, WriteBatch batch) throws DBException,
+            AndesException {
+
+        for (AndesPreparedMessageMetadata metadata : messagesToRestore) {
+
+            fileMessageStore.addMetadata(metadata, metadata.getStorageDestination(), batch);
+
+            if (metadata.getExpirationTime() > 0) {
+                fileMessageStore.addExpiryData(metadata, batch);
+            }
+
+            DB brokerStore = fileMessageStore.getDB();
+            DBIterator keyIterator = brokerStore.iterator();
+            String head = fileMessageStore.generateKey(DTX_DEQUEUE, Long.toString(internalXid),
+                    Long.toString(metadata.getOldMessageId()), START_OFFSET, MESSAGE_CONTENT);
+            keyIterator.seek(bytes(head));
+
+            try {
+                while (keyIterator.hasNext()) {
+                    //key arrangement : DTX_DEQUEUE:$xid:$message_id:$offset:MESSAGE_CONTENT
+                    String key = asString(keyIterator.peekNext().getKey());
+                    String[] keySplit = key.split(DELIMITER);
+
+                    String offset = keySplit[3];
+
+                    String messageContentIdentifier = fileMessageStore.generateKey(MESSAGE,
+                            Long.toString(metadata.getMessageID()), offset, MESSAGE_CONTENT);
+
+                    batch.put(bytes(messageContentIdentifier), keyIterator.peekNext().getValue());
+
+                    if (!keySplit[3].equals(MESSAGE_CONTENT)) {
+                        break;
+                    }
+
+                    keyIterator.next();
+                }
+            } catch (DBException e) {
+                throw new AndesException("Error occurred while retrieving content for dequeue records.", e);
+            } finally {
+                fileMessageStore.closeKeyIterator(keyIterator);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long recoverBranchData(DtxBranch branch, String nodeId) throws AndesException {
+        DB brokerStore = fileMessageStore.getDB();
+
+        try {
+            long internalXid = getInternalXid(branch.getXid(), nodeId, brokerStore);
+            if (internalXid == DtxBranch.NULL_XID) {
+                return DtxBranch.NULL_XID;
+            }
+            recoverEnqueueMessages(internalXid, branch, brokerStore);
+            recoverDequeueMessages(internalXid, branch, brokerStore);
+
+            return internalXid;
+        } catch (AndesException e) {
+            throw new AndesException("Error occurred while recovering DtxBranch ", e);
+        }
+    }
+
+    /**
+     * Retrieve the internal Xid from dtx store
+     *
+     * @param xid         {@link Xid} of the transaction
+     * @param nodeId      node id of the server
+     * @param brokerStore LevelDB object {@link DB}
+     * @return internal Xid
+     * @throws AndesException throws {@link AndesException} on database error
+     */
+    private long getInternalXid(Xid xid, String nodeId, DB brokerStore) throws AndesException {
+
+        try {
+            String dtxXIDIdentifier = fileMessageStore.generateKey(DTX_XID, nodeId, Integer.toString(xid.getFormatId()),
+                    asString(xid.getGlobalTransactionId()), asString(xid.getBranchQualifier()), XID_IDENTIFIER);
+
+            if (brokerStore.get(bytes(dtxXIDIdentifier)) != null) {
+                long internalXID = Long.parseLong(asString(brokerStore.get(bytes(dtxXIDIdentifier))));
+                return internalXID;
+            } else {
+                return DtxBranch.NULL_XID;
+            }
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while recovering DtxBranch internal Xid ", e);
+        }
+    }
+
+    /**
+     * Retrieve enqueued incoming messages that were not committed but prepared
+     *
+     * @param internalXid internal Xid of the transaction
+     * @param branch      {@link DtxBranch} of the transaction
+     * @param brokerStore LevelDB Object {@link DB}
+     * @throws AndesException throws {@link AndesException} on database error
+     */
+    private void recoverEnqueueMessages(long internalXid, DtxBranch branch, DB brokerStore)
+            throws AndesException {
+
+        Map<Long, AndesMessage> messageMap = new HashMap<>();
+
+        DBIterator keyIterator = brokerStore.iterator();
+        String head = fileMessageStore.generateKey(DTX_ENQUEUE, Long.toString(internalXid), MESSAGE_METADATA);
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                //key arrangement : DTX_ENQUEUE:$xid:MESSAGE_METADATA:$message_id
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+
+                if (!keySplit[2].equals(MESSAGE_METADATA)) {
+                    break;
+                }
+                long messageID = Long.parseLong(keySplit[3]);
+
+                AndesMessageMetadata metadata = new AndesMessageMetadata(keyIterator.peekNext().getValue());
+                AndesMessage andesMessage = new AndesMessage(metadata);
+
+                andesMessage.setChunkList(getDtxContent(internalXid, messageID, brokerStore));
+
+                messageMap.put(messageID, andesMessage);
+
+                keyIterator.next();
+            }
+
+            branch.setMessagesToStore(messageMap.values());
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while recovering enqueued messages for " + "internal xid " +
+                    internalXid, e);
+        } finally {
+            fileMessageStore.closeKeyIterator(keyIterator);
+        }
+    }
+
+    /**
+     * Return content chunk list for given xid and messageId from the dtxStore
+     *
+     * @param internalXid internal Xid of the transaction
+     * @param messageID   id of the message
+     * @param brokerStore LevelDB Object {@link DB}
+     * @throws AndesException throws {@link AndesException} on database error
+     */
+    private List<AndesMessagePart> getDtxContent(long internalXid, long messageID, DB brokerStore)
+            throws AndesException {
+        List<AndesMessagePart> contentChunkList = new ArrayList<>();
+
+        DBIterator keyIterator = brokerStore.iterator();
+        String head = fileMessageStore.generateKey(DTX_ENQUEUE, Long.toString(internalXid), MESSAGE_CONTENT,
+                Long.toString(messageID), START_OFFSET);
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                //key arrangement : DTX_ENQUEUE:$xid:MESSAGE_CONTENT:$message_id:$offset
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+                long currentMessageID = Long.parseLong(keySplit[3]);
+
+                if (currentMessageID != messageID) {
+                    break;
+                }
+                int offset = Integer.parseInt(keySplit[5]);
+
+                AndesMessagePart messagePart = new AndesMessagePart();
+                messagePart.setData(keyIterator.peekNext().getValue());
+                messagePart.setMessageID(messageID);
+                messagePart.setOffSet(offset);
+
+                contentChunkList.add(messagePart);
+
+                keyIterator.next();
+            }
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while retrieving content chunk list for message:" + messageID, e);
+        } finally {
+            fileMessageStore.closeKeyIterator(keyIterator);
+        }
+        return contentChunkList;
+    }
+
+    /**
+     * Retrieve the dequeued messages from the dtx store
+     *
+     * @param internalXid internal Xid of the transaction
+     * @param branch      {@link DtxBranch} of the transaction
+     * @param brokerStore LevelDB Object {@link DB}
+     * @throws AndesException throws {@link AndesException} related to database error
+     */
+    private void recoverDequeueMessages(long internalXid, DtxBranch branch, DB brokerStore) throws AndesException {
+        List<AndesPreparedMessageMetadata> dtxMetadataList = new ArrayList<>();
+
+        DBIterator keyIterator = brokerStore.iterator();
+        String head = fileMessageStore.generateKey(DTX_DEQUEUE, Long.toString(internalXid), MESSAGE_METADATA);
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                //key arrangement : DTX_DEQUEUE:$xid:MESSAGE_METADATA:$message_id
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+
+                if (!keySplit[2].equals(MESSAGE_METADATA)) {
+                    break;
+                }
+                String messageID = keySplit[3];
+                String dtxDestinationIdentifier = fileMessageStore.generateKey(DTX_DEQUEUE,
+                        Long.toString(internalXid), DESTINATION_NAME, messageID);
+                String destinationName = asString(brokerStore.get(bytes(dtxDestinationIdentifier)));
+
+                AndesMessageMetadata metadata = new AndesMessageMetadata(keyIterator.peekNext().getValue());
+                metadata.setStorageDestination(destinationName);
+
+                AndesPreparedMessageMetadata dtxMetadata = new AndesPreparedMessageMetadata(metadata);
+
+                dtxMetadataList.add(dtxMetadata);
+
+                keyIterator.next();
+            }
+            branch.setMessagesToRestore(dtxMetadataList);
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while recovering DtxBranch ", e);
+        } finally {
+            fileMessageStore.closeKeyIterator(keyIterator);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<XidImpl> getStoredXidSet(String nodeId) throws AndesException {
+        Set<XidImpl> xidSet = new HashSet<>();
+
+        DB brokerStore = fileMessageStore.getDB();
+        DBIterator keyIterator = brokerStore.iterator();
+        String head = fileMessageStore.generateKey(DTX_XID, nodeId);
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                //key arrangement : DTX_XID:$node_id:$format_code:$gloabal_id:$branch_id:XID_IDENTIFIER
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+                String currentNodeID = keySplit[1];
+
+                if (!currentNodeID.equals(nodeId)) {
+                    break;
+                }
+                String internalXid = asString(keyIterator.peekNext().getValue());
+
+                String dtxFormatCodeIdentifier = fileMessageStore.generateKey(DTX_ENTRY, internalXid, nodeId,
+                        FORMAT_CODE);
+                String dtxGlobalIDIdentifier = fileMessageStore.generateKey(DTX_ENTRY, internalXid, nodeId, GLOBAL_ID);
+                String dtxBranchIDIdentifier = fileMessageStore.generateKey(DTX_ENTRY, internalXid, nodeId, BRANCH_ID);
+
+                int formatCode = Integer.parseInt(asString(brokerStore.get(bytes(dtxFormatCodeIdentifier))));
+                byte[] branchID = brokerStore.get(bytes(dtxBranchIDIdentifier));
+                byte[] globalID = brokerStore.get(bytes(dtxGlobalIDIdentifier));
+
+                XidImpl xid = new XidImpl(branchID, formatCode, globalID);
+                xidSet.add(xid);
+
+                keyIterator.next();
+            }
+            return xidSet;
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while recovering DtxBranch ", e);
+        } finally {
+            fileMessageStore.closeKeyIterator(keyIterator);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isOperational(String testString, long testTime) {
+        return fileMessageStore.isOperational(testString, testTime);
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/file/FileMessageStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/file/FileMessageStoreImpl.java
@@ -1,0 +1,1351 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*/
+
+package org.wso2.andes.store.file;
+
+import com.gs.collections.api.iterator.MutableLongIterator;
+import com.gs.collections.api.list.primitive.MutableLongList;
+import com.gs.collections.impl.list.mutable.primitive.LongArrayList;
+import com.gs.collections.impl.map.mutable.primitive.LongObjectHashMap;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.log4j.Logger;
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBException;
+import org.iq80.leveldb.DBIterator;
+import org.iq80.leveldb.WriteBatch;
+import org.wso2.andes.configuration.util.ConfigurationProperties;
+import org.wso2.andes.kernel.AndesContextStore;
+import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.kernel.AndesMessage;
+import org.wso2.andes.kernel.AndesMessageMetadata;
+import org.wso2.andes.kernel.AndesMessagePart;
+import org.wso2.andes.kernel.DeliverableAndesMetadata;
+import org.wso2.andes.kernel.DtxStore;
+import org.wso2.andes.kernel.DurableStoreConnection;
+import org.wso2.andes.kernel.MessageStore;
+import org.wso2.andes.tools.utils.MessageTracer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.iq80.leveldb.impl.Iq80DBFactory.asString;
+import static org.iq80.leveldb.impl.Iq80DBFactory.bytes;
+
+import static org.wso2.andes.store.file.FileStoreConstants.DELIMITER;
+
+import static org.wso2.andes.store.file.FileStoreConstants.MESSAGE;
+import static org.wso2.andes.store.file.FileStoreConstants.MESSAGE_METADATA;
+import static org.wso2.andes.store.file.FileStoreConstants.MESSAGE_CONTENT;
+import static org.wso2.andes.store.file.FileStoreConstants.MESSAGE_EXPIRATION_TIME;
+import static org.wso2.andes.store.file.FileStoreConstants.INITIAL_MESSAGE_COUNT;
+import static org.wso2.andes.store.file.FileStoreConstants.START_OFFSET;
+
+import static org.wso2.andes.store.file.FileStoreConstants.DESTINATION;
+import static org.wso2.andes.store.file.FileStoreConstants.DESTINATION_NAME;
+import static org.wso2.andes.store.file.FileStoreConstants.MESSAGE_COUNT;
+
+import static org.wso2.andes.store.file.FileStoreConstants.DLC;
+import static org.wso2.andes.store.file.FileStoreConstants.DLC_STATUS;
+import static org.wso2.andes.store.file.FileStoreConstants.DEFAULT_DLC_STATUS;
+import static org.wso2.andes.store.file.FileStoreConstants.IN_DLC_STATUS;
+
+
+/**
+ * Implementation of LevelDB broker store. Message persistence related methods are implemented
+ * in this class.
+ */
+public class FileMessageStoreImpl implements MessageStore {
+
+    private static final Logger log = Logger.getLogger(FileMessageStoreImpl.class);
+
+    /**
+     * File store connection source object
+     */
+    private FileStoreConnection fileStoreConnection;
+
+    /**
+     * Contains utils methods related to connection tests
+     */
+    private FileStoreUtils fileStoreUtils;
+
+    /**
+     * All the database operations are preformed on this object. Refers to the LevelDB store.
+     */
+    private DB brokerStore;
+
+    /**
+     * Stores message counts of each destination as AtomicLong values.
+     */
+    private Map<String, AtomicLong> destinationMessageCount = new HashMap<>();
+
+    /**
+     * Store implementation to handle distributed transactions' store operations
+     */
+    private DtxStore dtxStore;
+
+    /**
+     * Initialize file store connection
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public DurableStoreConnection initializeMessageStore(AndesContextStore contextStore, ConfigurationProperties
+            connectionProperties) throws AndesException {
+        this.fileStoreUtils = new FileStoreUtils();
+        this.fileStoreConnection = new FileStoreConnection();
+        this.fileStoreConnection.initialize(connectionProperties);
+        this.brokerStore = (DB) fileStoreConnection.getConnection();
+        getInitialMessageCountsForAllDestinations();
+        dtxStore = new FileDtxStoreImpl(this);
+        return fileStoreConnection;
+    }
+
+    /**
+     * Load message counts for all destinations which are stored in the database and store them in
+     * destinationMessageCount map
+     */
+    private void getInitialMessageCountsForAllDestinations() throws AndesException {
+        DBIterator keyIterator = brokerStore.iterator();
+        String head = generateKey(DESTINATION, MESSAGE_COUNT);
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                //key arrangement : DESTINATION.MESSAGE_COUNT.$destination_name
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+                String identifier = keySplit[1];
+
+                if (!identifier.equals(MESSAGE_COUNT)) {
+                    break;
+                }
+                String destinationName = keySplit[2];
+                long messageCount = Long.parseLong(asString(keyIterator.peekNext().getValue()));
+                this.destinationMessageCount.put(destinationName, new AtomicLong(messageCount));
+
+                keyIterator.next();
+            }
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while loading message counts for destinations.", e);
+        } finally {
+            closeKeyIterator(keyIterator);
+        }
+    }
+
+    /**
+     * Check if data can be inserted, read and finally deleted from the database
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isOperational(String testString, long testTime) {
+        try {
+            return fileStoreUtils.testInsert(this.fileStoreConnection, testString, testTime) &&
+                    fileStoreUtils.testRead(this.fileStoreConnection, testString, testTime) &&
+                    fileStoreUtils.testDelete(this.fileStoreConnection, testString);
+        } catch (DBException e) {
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void storeMessages(List<AndesMessage> messageList) throws AndesException {
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+            for (AndesMessage message : messageList) {
+                storeMessage(message, batch);
+            }
+            brokerStore.write(batch);
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while storing message list.", e);
+        } finally {
+            closeWriteBatch(batch);
+        }
+    }
+
+    /**
+     * Add metadata, expire data and message content to the write batch.
+     *
+     * @param message message which needed to be stored
+     * @param batch   accumulates operations to apply atomically
+     * @throws AndesException throws {@link AndesException} on database error
+     */
+    private void storeMessage(AndesMessage message, WriteBatch batch) throws AndesException {
+        AndesMessageMetadata metadata = message.getMetadata();
+
+        addMetadata(metadata, metadata.getStorageDestination(), batch);
+
+        if (message.getMetadata().getExpirationTime() > 0) {
+            addExpiryData(metadata, batch);
+        }
+
+        addContent(message.getContentChunkList(), batch);
+    }
+
+    /**
+     * Add metadata to the write batch. Operations are not written to the database within the method. It is the
+     * responsibility of the caller to write the changes.
+     *
+     * Following keys will be created.
+     *
+     * MESSAGE.$message_id.DESTINATION_ID
+     * MESSAGE.$message_id.DLC_QUEUE_ID
+     * MESSAGE.$message_id.MESSAGE_METADATA
+     *
+     * @param metadata  message metadata which needed to be stored
+     * @param queueName queue/topic name where the message is needed to be stored
+     * @param batch     accumulates operations to apply atomically
+     * @throws AndesException throws {@link AndesException} on database error
+     */
+    public void addMetadata(AndesMessageMetadata metadata, final String queueName, WriteBatch batch)
+            throws AndesException {
+        String messageID = Long.toString(metadata.getMessageID());
+
+        String dlcStatusIdentifier = generateKey(MESSAGE, messageID, DLC_STATUS);
+        String messageDestinationIdentifier = generateKey(MESSAGE, messageID, DESTINATION_NAME);
+
+        batch.put(bytes(dlcStatusIdentifier), bytes(DEFAULT_DLC_STATUS));
+        batch.put(bytes(messageDestinationIdentifier), bytes(queueName));
+
+        createQueueMessageMapping(metadata, queueName, batch);
+    }
+
+    /**
+     * Add message expire data to the batch. Operations are not written to the database within the method. It is the
+     * responsibility of the caller to write the changes.
+     *
+     * Following keys will be created.
+     *
+     * DESTINATION.$destination_name.MESSAGE_EXPIRATION_TIME.$message_id
+     *
+     * @param metadata message metadata which contains required message expiration data
+     * @param batch    accumulates operations to apply atomically
+     */
+    public void addExpiryData(AndesMessageMetadata metadata, WriteBatch batch) {
+        String messageID = Long.toString(metadata.getMessageID());
+        String storageQueueName = metadata.getStorageDestination();
+        String expirationTime = Long.toString(metadata.getExpirationTime());
+
+        String queueMessageExpirationTimeIdentifier = generateKey(DESTINATION, storageQueueName,
+                MESSAGE_EXPIRATION_TIME, messageID);
+
+        batch.put(bytes(queueMessageExpirationTimeIdentifier), bytes(expirationTime));
+    }
+
+    /**
+     * Add message content to the batch. Operations are not written to the database within the method. It is the
+     * responsibility of the caller to write the changes.
+     *
+     * Following keys will be created.
+     *
+     * MESSAGE.$message_id.$offset.MESSAGE_CONTENT
+     *
+     * @param contentChunkList list which contains message content chunks which need to be stored
+     * @param batch            accumulates operations to apply atomically
+     */
+    public void addContent(List<AndesMessagePart> contentChunkList, WriteBatch batch) {
+
+        for (AndesMessagePart messagePart : contentChunkList) {
+            String messageContentIdentifier = generateKey(MESSAGE, Long.toString(messagePart.getMessageID()),
+                    Long.toString(messagePart.getOffset()), MESSAGE_CONTENT);
+
+            batch.put(bytes(messageContentIdentifier), messagePart.getData());
+        }
+    }
+
+    /**
+     * Create mapping between the destination and the message. Operations are not written to the database within the
+     * method. It is the responsibility of the caller to write the changes.
+     *
+     * Following keys will be created.
+     *
+     * DESTINATION.$destination_name.MESSAGE_METADATA.$message_id
+     * DESTINATION.MESSAGE_COUNT.$destination_name
+     *
+     * @param metadata message metadata which needs to be mapped
+     * @param batch    accumulates operations to apply atomically
+     * @throws AndesException throws {@link AndesException} on database error
+     */
+    public void createQueueMessageMapping(AndesMessageMetadata metadata, String queueName, WriteBatch batch)
+            throws AndesException {
+        addQueue(queueName);
+        String queueMessageMetaDataIdentifier = generateKey(DESTINATION, queueName, MESSAGE_METADATA,
+                Long.toString(metadata.getMessageID()));
+
+        batch.put(bytes(queueMessageMetaDataIdentifier), metadata.getBytes());
+        increaseMessageCount(queueName, batch);
+    }
+
+    /**
+     * Increment the message count value of destinationMessageCount map for a given destination and
+     * apply that value to the batch.
+     *
+     * @param storageQueueName message metadata which needs to be mapped
+     * @param batch            accumulates operations to apply atomically
+     */
+    private void increaseMessageCount(String storageQueueName, WriteBatch batch) {
+        String destinationMessageCountIdentifier = generateKey(DESTINATION, MESSAGE_COUNT, storageQueueName);
+
+        AtomicLong queueMessageCount = this.destinationMessageCount.get(storageQueueName);
+
+        batch.put(bytes(destinationMessageCountIdentifier),
+                bytes(Long.toString(queueMessageCount.incrementAndGet())));
+    }
+
+    /**
+     * Increment the message count value of destinationMessageCount map for a given destination and
+     * apply that value to the batch.
+     *
+     * @param storageQueueName message metadata which needs to be mapped
+     * @param batch            accumulates operations to apply atomically
+     */
+    private void decreaseMessageCount(String storageQueueName, WriteBatch batch) {
+        String destinationMessageCountIdentifier = generateKey(DESTINATION, MESSAGE_COUNT, storageQueueName);
+
+        AtomicLong queueMessageCount = this.destinationMessageCount.get(storageQueueName);
+
+        batch.put(bytes(destinationMessageCountIdentifier),
+                bytes(Long.toString(queueMessageCount.decrementAndGet())));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void storeMessagePart(List<AndesMessagePart> partList) throws AndesException {
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+            addContent(partList, batch);
+            brokerStore.write(batch);
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while storing message content list.", e);
+        } finally {
+            closeWriteBatch(batch);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AndesMessagePart getContent(long messageId, int offsetValue) throws AndesException {
+        try {
+            String messageContentIdentifier = generateKey(MESSAGE, Long.toString(messageId),
+                    Integer.toString(offsetValue), MESSAGE_CONTENT);
+
+            byte[] messageContent = brokerStore.get(bytes(messageContentIdentifier));
+
+            AndesMessagePart messagePart = new AndesMessagePart();
+            messagePart.setData(messageContent);
+            messagePart.setMessageID(messageId);
+            messagePart.setOffSet(offsetValue);
+
+            return messagePart;
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while retrieving content chunk for message: " + messageId, e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LongObjectHashMap<List<AndesMessagePart>> getContent(LongArrayList messageIDList) throws AndesException {
+        MutableLongIterator mutableLongIterator = messageIDList.longIterator();
+        LongObjectHashMap<List<AndesMessagePart>> messages = new LongObjectHashMap<>();
+
+        while (mutableLongIterator.hasNext()) {
+            long messageID = mutableLongIterator.next();
+            messages.put(messageID, getMessageContentChunkList(messageID));
+        }
+        return messages;
+    }
+
+    /**
+     * Get message content chunk list for a given message id.
+     *
+     * @param messageID id of the message which content chunk list should be retrieved
+     * @throws AndesException throws {@link AndesException} on database error
+     */
+    private List<AndesMessagePart> getMessageContentChunkList(long messageID) throws AndesException {
+        List<AndesMessagePart> messageContentList = new ArrayList<>();
+
+        DBIterator keyIterator = brokerStore.iterator();
+        String head = generateKey(MESSAGE, Long.toString(messageID), START_OFFSET, MESSAGE_CONTENT);
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                //key arrangement : MESSAGE.$message_id.$offset.MESSAGE_CONTENT
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+                String identifier = keySplit[keySplit.length - 1];
+
+                if (!identifier.equals(MESSAGE_CONTENT)) {
+                    break;
+                }
+                int offset = Integer.parseInt(keySplit[2]);
+
+                AndesMessagePart messagePart = new AndesMessagePart();
+                messagePart.setData(keyIterator.peekNext().getValue());
+                messagePart.setMessageID(messageID);
+                messagePart.setOffSet(offset);
+
+                messageContentList.add(messagePart);
+
+                keyIterator.next();
+            }
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while retrieving content chunk list for message:" + messageID, e);
+        } finally {
+            closeKeyIterator(keyIterator);
+        }
+        return messageContentList;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AndesMessageMetadata getMetadata(long messageId) throws AndesException {
+        try {
+            String messageID = Long.toString(messageId);
+            String messageDestinationIdentifier = generateKey(MESSAGE, messageID, DESTINATION_NAME);
+
+            String storageQueueName = asString(brokerStore.get(messageDestinationIdentifier.getBytes()));
+
+            String messageMetaDataIdentifier = generateKey(DESTINATION, storageQueueName, messageID, MESSAGE_METADATA);
+
+            byte[] byteMetaData = brokerStore.get(bytes(messageMetaDataIdentifier));
+            return new AndesMessageMetadata(byteMetaData);
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while retrieving metadata for message: " + messageId, e);
+        }
+    }
+
+    /**
+     * Read  a metadata list from store specifying a starting message id and a limit.
+     *
+     * @param storageQueueName name of the queue messages are stored
+     * @param firstMsgId       first id of the range
+     * @param limit            amount of messages which should be returned in the list
+     * @return list of metadata
+     * @throws AndesException throws {@link AndesException} on database error
+     */
+    @Override
+    public List<DeliverableAndesMetadata> getMetadataList(String storageQueueName, long firstMsgId, long limit)
+            throws AndesException {
+        List<DeliverableAndesMetadata> metadataList = new ArrayList<>();
+
+        DBIterator keyIterator = brokerStore.iterator();
+        String head = generateKey(DESTINATION, storageQueueName, MESSAGE_METADATA, Long.toString(firstMsgId));
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                //key arrangement : DESTINATION.$destination_name.MESSAGE_METADATA.$message_id
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(FileStoreConstants.DELIMITER);
+
+                if (!keySplit[1].equals(storageQueueName)) {
+                    break;
+                }
+
+                byte[] byteMetadata = keyIterator.peekNext().getValue();
+                DeliverableAndesMetadata metadata = new DeliverableAndesMetadata(byteMetadata);
+                metadataList.add(metadata);
+
+                //Tracing message
+                MessageTracer.trace(metadata, MessageTracer.METADATA_READ_FROM_DB);
+
+                if (metadataList.size() >= limit) {
+                    break;
+                }
+                keyIterator.next();
+            }
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while retrieving metadata from " + storageQueueName, e);
+        } finally {
+            closeKeyIterator(keyIterator);
+        }
+        return metadataList;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<AndesMessageMetadata> getMetadataList(String storageQueueName, long firstMsgId, int count)
+            throws AndesException {
+        return getMetadataList(storageQueueName, firstMsgId, count);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<AndesMessageMetadata> getNextNMessageMetadataForQueueFromDLC(
+            String storageQueueName, String dlcQueueName, long firstMsgId, int count) throws AndesException {
+        List<AndesMessageMetadata> metadataList = new ArrayList<>(count);
+
+        String head = generateKey(DESTINATION, dlcQueueName, MESSAGE_METADATA, Long.toString(firstMsgId));
+        DBIterator keyIterator = brokerStore.iterator();
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                // key arrangement : DESTINATION.$dlc_queue_name.MESSAGE_METADATA.$message_id
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+
+                if (!keySplit[2].equals(MESSAGE_METADATA) || !keySplit[1].equals(dlcQueueName)) {
+                    break;
+                }
+                String messageID = keySplit[3];
+
+                String messageDestinationIdentifier = generateKey(MESSAGE, messageID, DESTINATION_NAME);
+                String destination = asString(brokerStore.get(bytes(messageDestinationIdentifier)));
+
+                // Only if the message is stored in the given queue, it will be added to the metadataList
+                if (destination.equals(storageQueueName)) {
+                    byte[] byteMetadata = keyIterator.peekNext().getValue();
+                    AndesMessageMetadata metadata = new AndesMessageMetadata(byteMetadata);
+                    metadataList.add(metadata);
+                }
+
+                if (metadataList.size() >= count) {
+                    break;
+                }
+                keyIterator.next();
+            }
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while retrieving metadata from " + dlcQueueName, e);
+        } finally {
+            closeKeyIterator(keyIterator);
+        }
+        return metadataList;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<AndesMessageMetadata> getNextNMessageMetadataFromDLC(String dlcQueueName, long firstMsgId, int count)
+            throws AndesException {
+        return getMetadataList(dlcQueueName, firstMsgId, count);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addQueue(String storageQueueName) throws AndesException {
+        String destinationMessageCountIdentifier = generateKey(DESTINATION, MESSAGE_COUNT, storageQueueName);
+
+        if (brokerStore.get(bytes(destinationMessageCountIdentifier)) == null) {
+            try {
+                brokerStore.put(bytes(destinationMessageCountIdentifier), bytes(INITIAL_MESSAGE_COUNT));
+                getInitialMessageCountsForAllDestinations();
+            } catch (DBException e) {
+                throw new AndesException("Error occurred while adding destination: " + storageQueueName, e);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void moveMetadataToQueue(long messageId, String currentQueueName, String targetQueueName)
+            throws AndesException {
+        String messageID = Long.toString(messageId);
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+            // Update destination of the message
+            String messageDestinationIdentifier = generateKey(MESSAGE, Long.toString(messageId), DESTINATION_NAME);
+            batch.put(bytes(messageDestinationIdentifier), bytes(targetQueueName));
+
+            // Add message to the target queue
+            String messageMetaDataIdentifier = generateKey(DESTINATION, currentQueueName, MESSAGE_METADATA, messageID);
+            String messageExpirationTimeIdentifier = generateKey(DESTINATION, currentQueueName, MESSAGE_EXPIRATION_TIME,
+                    messageID);
+
+            byte[] byteMetaData = brokerStore.get(bytes(messageMetaDataIdentifier));
+            AndesMessageMetadata metadata = new AndesMessageMetadata(byteMetaData);
+            metadata.setMessageID(messageId);
+            metadata.setStorageDestination(targetQueueName);
+
+            createQueueMessageMapping(metadata, targetQueueName, batch);
+
+            if (brokerStore.get(bytes(messageExpirationTimeIdentifier)) != null) {
+                metadata.setExpirationTime(Long.parseLong(asString(brokerStore.
+                        get(bytes(messageExpirationTimeIdentifier)))));
+                addExpiryData(metadata, batch);
+            }
+
+            // Delete message from current queue
+            deleteMessageFromQueue(messageId, currentQueueName, batch);
+
+            brokerStore.write(batch);
+        } catch (DBException e) {
+            throw new AndesException(" Error occurred while moving message: " + messageId + " from " + currentQueueName
+                    + " to " + targetQueueName, e);
+        } finally {
+            closeWriteBatch(batch);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getMessageCountForQueueInRange(String storageQueueName, long firstMessageId, long lastMessageId)
+            throws AndesException {
+        String head = generateKey(DESTINATION, storageQueueName, MESSAGE_METADATA, Long.toString(firstMessageId));
+        DBIterator keyIterator = brokerStore.iterator();
+        keyIterator.seek(bytes(head));
+
+        long count = 0;
+
+        try {
+            while (keyIterator.hasNext()) {
+                //key arrangement : DESTINATION.$destination_name.MESSAGE_METADATA.$message_id
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+                count++;
+                long messageId = Long.parseLong(keySplit[3]);
+
+                if (messageId >= lastMessageId) {
+                    break;
+                }
+                keyIterator.next();
+            }
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while getting message count for " + storageQueueName);
+        } finally {
+            closeKeyIterator(keyIterator);
+        }
+        return count;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LongArrayList getMessageIDsAddressedToQueue(String storageQueueName, Long startMessageID)
+            throws AndesException {
+        LongArrayList messageIDs = new LongArrayList();
+
+        DBIterator keyIterator = brokerStore.iterator();
+        String head = generateKey(DESTINATION, storageQueueName, MESSAGE_METADATA, Long.toString(startMessageID));
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                //key arrangement : DESTINATION.$destination_name.MESSAGE_METADATA.$message_id
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+
+                if (!keySplit[1].equals(storageQueueName)) {
+                    break;
+                }
+                Long messageID = Long.parseLong(keySplit[3]);
+                messageIDs.add(messageID);
+
+                keyIterator.next();
+            }
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while retrieving message ids for " + storageQueueName);
+        } finally {
+            closeKeyIterator(keyIterator);
+        }
+        return messageIDs;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, Integer> getMessageCountForAllQueues(List<String> queueNames) throws AndesException {
+        Map<String, Integer> queueMessageCount = new HashMap<>();
+
+        try {
+            for (String queueName : queueNames) {
+                String destinationMessageCountIdentifier = generateKey(DESTINATION, MESSAGE_COUNT, queueName);
+                queueMessageCount.put(queueName,
+                        Integer.parseInt(asString(brokerStore.get(bytes(destinationMessageCountIdentifier)))));
+            }
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while getting message counts for all queues.", e);
+        }
+
+        return queueMessageCount;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getMessageCountForQueue(String storageQueueName) throws AndesException {
+        try {
+            String destinationMessageCountIdentifier = generateKey(DESTINATION, MESSAGE_COUNT, storageQueueName);
+            return Long.parseLong(asString(brokerStore.get(bytes(destinationMessageCountIdentifier))));
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while retrieving message count for " + storageQueueName, e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int deleteAllMessageMetadata(String storageQueueName) throws AndesException {
+        int count = 0;
+
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        DBIterator keyIterator = brokerStore.iterator();
+        String head = generateKey(DESTINATION, storageQueueName, MESSAGE_METADATA);
+        keyIterator.seek(bytes(head));
+
+        try {
+            try {
+                while (keyIterator.hasNext()) {
+                    //key arrangement : DESTINATION.$destination_name.MESSAGE_METADATA.$message_id
+                    String key = asString(keyIterator.peekNext().getKey());
+                    String[] keySplit = key.split(DELIMITER);
+
+                    if (!keySplit[1].equals(storageQueueName)) {
+                        break;
+                    }
+                    long messageID = Long.parseLong(keySplit[3]);
+
+                    deleteMessage(messageID, batch);
+                    deleteMessageFromQueue(messageID, storageQueueName, batch);
+
+                    count++;
+
+                    keyIterator.next();
+                }
+            } finally {
+                closeKeyIterator(keyIterator);
+            }
+            brokerStore.write(batch);
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while deleting message metadata from " + storageQueueName, e);
+        } finally {
+            closeWriteBatch(batch);
+        }
+        return count;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeQueue(String storageQueueName) throws AndesException {
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+            deleteAllMessagesFromQueue(storageQueueName, batch);
+            deleteDestinationData(storageQueueName, batch);
+
+            brokerStore.write(batch);
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while removing destination: " + storageQueueName, e);
+        } finally {
+            closeWriteBatch(batch);
+        }
+    }
+
+    private void deleteDestinationData(String storageQueueName, WriteBatch batch) {
+        String destinationMessageCountIdentifier = generateKey(DESTINATION, MESSAGE_COUNT, storageQueueName);
+        batch.delete(bytes(destinationMessageCountIdentifier));
+    }
+
+    /**
+     * Delete all messages stored in the destination. Operations are not written to the database within the method.
+     * It is the responsibility of the caller to write the changes.
+     *
+     * @param storageQueueName name of the destination
+     * @param batch            accumulates operations to apply atomically
+     */
+    private void deleteAllMessagesFromQueue(String storageQueueName, WriteBatch batch) {
+        DBIterator keyIterator = brokerStore.iterator();
+        String head = generateKey(DESTINATION, storageQueueName, MESSAGE_EXPIRATION_TIME);
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+
+                if (!keySplit[1].equals(storageQueueName)) {
+                    break;
+                }
+                long messageID = Long.parseLong(keySplit[3]);
+
+                deleteMessage(messageID, batch);
+                deleteMessageFromQueue(messageID, storageQueueName, batch);
+
+                keyIterator.next();
+            }
+        } finally {
+            closeKeyIterator(keyIterator);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void moveMetadataToDLC(long messageId, String dlcQueueName) throws AndesException {
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+
+            // Add message metadata to dlc
+            String messageDestinationIdentifier = generateKey(MESSAGE, Long.toString(messageId), DESTINATION_NAME);
+            String storageQueueName = asString(brokerStore.get(bytes(messageDestinationIdentifier)));
+
+            String messageMetaDataIdentifier = generateKey(DESTINATION, storageQueueName, MESSAGE_METADATA,
+                    Long.toString(messageId));
+            String messageExpireTimeIdentifier = generateKey(DESTINATION, storageQueueName, MESSAGE_EXPIRATION_TIME,
+                    Long.toString(messageId));
+
+            AndesMessageMetadata metadata = new AndesMessageMetadata(brokerStore.get(bytes(messageMetaDataIdentifier)));
+            metadata.setMessageID(messageId);
+
+            if (brokerStore.get(bytes(messageExpireTimeIdentifier)) != null) {
+                metadata.setExpirationTime(Long.parseLong(asString(
+                        brokerStore.get(bytes(messageExpireTimeIdentifier)))));
+            }
+            metadata.setStorageDestination(DLC);
+
+            createQueueMessageMapping(metadata, dlcQueueName, batch);
+
+            if (brokerStore.get(bytes(messageExpireTimeIdentifier)) != null) {
+                addExpiryData(metadata, batch);
+            }
+
+            // Update message dlc queue id
+            String messageDLCQueueIDIdentifier = generateKey(MESSAGE, Long.toString(messageId), DLC_STATUS);
+            batch.put(bytes(messageDLCQueueIDIdentifier), bytes(IN_DLC_STATUS));
+
+            // Delete metadata from current queue
+            deleteMessageFromQueue(messageId, storageQueueName, batch);
+
+            brokerStore.write(batch);
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while moving message:" + messageId + "to DLC.", e);
+        } finally {
+            closeWriteBatch(batch);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void moveMetadataToDLC(List<AndesMessageMetadata> messages, String dlcQueueName) throws AndesException {
+        for (AndesMessageMetadata message : messages) {
+            moveMetadataToDLC(message.getMessageID(), dlcQueueName);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Long> getMessageIdsInDLC(String dlcQueueName, long startMessageId, int messageLimit) throws
+            AndesException {
+        List<Long> messageIDList = new ArrayList<>();
+        MutableLongList messageIDs = getMessageIDsAddressedToQueue(dlcQueueName, startMessageId);
+
+        for (int i = 0; i < messageIDs.size(); i++) {
+            messageIDList.add(messageIDs.get(i));
+        }
+
+        return messageIDList.subList(0, messageLimit);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getMessageCountForDLCQueue(String dlcQueueName) throws AndesException {
+        return getMessageCountForQueue(dlcQueueName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Long> getMessageIdsInDLCForQueue(String sourceQueueName, String dlcQueueName, long startMessageId,
+                                                 int messageLimit) throws AndesException {
+        List<Long> messageIds = new ArrayList<>();
+
+        DBIterator keyIterator = brokerStore.iterator();
+        String head = generateKey(DESTINATION, dlcQueueName, MESSAGE_METADATA, Long.toString(startMessageId));
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                //key arrangement : DESTINATION.$destination_name.MESSAGE_METADATA.$message_id
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+
+                if (!keySplit[1].equals(dlcQueueName)) {
+                    break;
+                }
+                String messageID = keySplit[3];
+                String messageDestinationIdentifier = generateKey(MESSAGE, messageID, DESTINATION_NAME);
+                String storageQueueName = asString(brokerStore.get(bytes(messageDestinationIdentifier)));
+
+                if (storageQueueName.equals(sourceQueueName)) {
+                    messageIds.add(Long.parseLong(messageID));
+                }
+
+                if (messageIds.size() >= messageLimit) {
+                    break;
+                }
+                keyIterator.next();
+            }
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while retrieving message ids in" + sourceQueueName +
+                    "from" + dlcQueueName, e);
+        } finally {
+            closeKeyIterator(keyIterator);
+        }
+        return messageIds;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getMessageCountForQueueInDLC(String storageQueueName, String dlcQueueName) throws AndesException {
+        return getMessageIdsInDLCForQueue(storageQueueName, dlcQueueName, 0, Integer.MAX_VALUE).size();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int clearDLCQueue(String dlcQueueName) throws AndesException {
+        return deleteAllMessageMetadata(dlcQueueName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void updateMetadataInformation(String currentQueueName, List<AndesMessageMetadata> metadataList)
+            throws AndesException {
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+
+            for (AndesMessageMetadata metadata : metadataList) {
+
+                // Update metadata in the destination
+                updateMetadataInfoInDestination(metadata, currentQueueName, batch);
+            }
+            brokerStore.write(batch);
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while updating metadata in " + currentQueueName, e);
+        } finally {
+            closeWriteBatch(batch);
+        }
+    }
+
+    /**
+     * Update the destination of the message. Operations are not written to the database within the method. It is the
+     * responsibility of the caller to write the changes.
+     *
+     * @param metadata               updated message metadata
+     * @param currentDestinationName destination where the message is currently stored
+     * @param batch                  accumulates operations to apply atomically
+     * @throws AndesException throws {@link AndesException} on database error
+     */
+    private void updateMetadataInfoInDestination(AndesMessageMetadata metadata, String currentDestinationName,
+                                                 WriteBatch batch) throws AndesException {
+        Long messageId = metadata.getMessageID();
+        String targetQueueName = metadata.getStorageDestination();
+
+        // Delete message from current destination
+        deleteMessageFromQueue(messageId, currentDestinationName, batch);
+
+        // Add message to the target destination
+        createQueueMessageMapping(metadata, targetQueueName, batch);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void deleteMessageMetadataFromQueue(String storageQueueName, List<AndesMessageMetadata> messagesToRemove)
+            throws AndesException {
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+            for (AndesMessageMetadata metadata : messagesToRemove) {
+                long messageID = metadata.getMessageID();
+                deleteMessage(messageID, batch);
+                deleteMessageFromQueue(messageID, storageQueueName, batch);
+            }
+            brokerStore.write(batch);
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while deleting messages from " + storageQueueName, e);
+        } finally {
+            closeWriteBatch(batch);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void deleteMessages(Collection<? extends AndesMessageMetadata> messagesToRemove) throws AndesException {
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+            for (AndesMessageMetadata metadata : messagesToRemove) {
+                long messageID = metadata.getMessageID();
+                String storageQueueName = metadata.getStorageDestination();
+
+                deleteMessage(messageID, batch);
+                deleteMessageFromQueue(messageID, storageQueueName, batch);
+
+                // Delete message from DLC if it is in DLC
+                String messageDLCStatus = generateKey(MESSAGE, Long.toString(messageID), DLC_STATUS);
+
+                if (Long.parseLong(asString(brokerStore.get(bytes(messageDLCStatus)))) == 1) {
+                    deleteMessageFromQueue(messageID, DLC, batch);
+                }
+            }
+            brokerStore.write(batch);
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while deleting message list.", e);
+        } finally {
+            closeWriteBatch(batch);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void deleteMessages(List<Long> messagesToRemove) throws AndesException {
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+            for (Long messageID : messagesToRemove) {
+                //Delete message metadata and content
+                deleteMessage(messageID, batch);
+
+                // Delete message from destination
+                String messageQueueDestinationIdentifier = generateKey(MESSAGE, Long.toString(messageID),
+                        DESTINATION_NAME);
+                String storageQueueName = asString(brokerStore.get(bytes(messageQueueDestinationIdentifier)));
+                deleteMessageFromQueue(messageID, storageQueueName, batch);
+
+                // Delete message from DLC if it is in DLC
+                String messageDLCQueueIdIdentifier = generateKey(MESSAGE, Long.toString(messageID), DLC_STATUS);
+
+                if (Long.parseLong(asString(brokerStore.get(bytes(messageDLCQueueIdIdentifier)))) == 1) {
+                    deleteMessageFromQueue(messageID, DLC, batch);
+                }
+            }
+            brokerStore.write(batch);
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while deleting message list.", e);
+        } finally {
+            closeWriteBatch(batch);
+        }
+    }
+
+    /**
+     * Add message delete operations to the batch. Operations are not written to the database within the method. It is
+     * the responsibility of the caller to write the changes.
+     *
+     * Following keys will be removed.
+     *
+     * MESSAGE.$message_id.$offset.MESSAGE_CONTENT
+     * MESSAGE.$message_id.DESTINATION_NAME
+     * MESSAGE.$message_id.DLC_STATUS
+     *
+     * @param messageID id of the message which needed to be deleted
+     * @param batch     accumulates operations to apply atomically
+     */
+    public void deleteMessage(long messageID, WriteBatch batch) {
+        DBIterator keyIterator = brokerStore.iterator();
+        String head = generateKey(MESSAGE, Long.toString(messageID));
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                String key = asString(keyIterator.peekNext().getKey());
+                Long currentID = Long.parseLong(key.split(DELIMITER)[1]);
+
+                if (currentID != messageID) {
+                    break;
+                }
+                batch.delete(bytes(key));
+
+                keyIterator.next();
+            }
+        } finally {
+            closeKeyIterator(keyIterator);
+        }
+    }
+
+    /**
+     * Add message delete from destination operations to the batch. Operations are not written to the database within
+     * the method. It is the responsibility of the caller to write the changes.
+     *
+     * Following keys will be deleted.
+     *
+     * DESTINATION.$destination_name.MESSAGE_METADATA.$message_id
+     * DESTINATION.$destination_name.EXPIRATION_TIME.$message_id
+     *
+     * @param messageID id of the message which needed to be deleted
+     * @param batch     accumulates operations to apply atomically
+     */
+    public void deleteMessageFromQueue(long messageID, String queueName, WriteBatch batch) {
+        String queueMessageMetaDataIdentifier = generateKey(DESTINATION, queueName, MESSAGE_METADATA,
+                Long.toString(messageID));
+        String queueMessageExpireTimeIdentifier = generateKey(DESTINATION, queueName, MESSAGE_EXPIRATION_TIME,
+                Long.toString(messageID));
+
+        batch.delete(bytes(queueMessageMetaDataIdentifier));
+
+        if (brokerStore.get(bytes(queueMessageExpireTimeIdentifier)) != null) {
+            batch.delete(bytes(queueMessageExpireTimeIdentifier));
+        }
+        decreaseMessageCount(queueName, batch);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void deleteDLCMessages(List<AndesMessageMetadata> messagesToRemove) throws AndesException {
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+            for (AndesMessageMetadata metadata : messagesToRemove) {
+                long messageID = metadata.getMessageID();
+                deleteMessage(messageID, batch);
+                deleteMessageFromQueue(messageID, DLC, batch);
+            }
+            brokerStore.write(batch);
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while deleting message list from DLC.", e);
+        } finally {
+            closeWriteBatch(batch);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Long> getExpiredMessages(long lowerBoundMessageID, String queueName) throws AndesException {
+        List<Long> expiredMessageIDList = new ArrayList<>();
+        Long currentTime = System.currentTimeMillis();
+
+        DBIterator keyIterator = brokerStore.iterator();
+        String head = generateKey(DESTINATION, queueName, MESSAGE_EXPIRATION_TIME, Long.toString(lowerBoundMessageID));
+        keyIterator.seek(bytes(head));
+
+        try {
+            while (keyIterator.hasNext()) {
+                //key arrangement : DESTINATION.$destination_name.MESSAGE_EXPIRATION_TIME.$message_id
+                String key = asString(keyIterator.peekNext().getKey());
+                String[] keySplit = key.split(DELIMITER);
+
+                if (!keySplit[2].equals(MESSAGE_EXPIRATION_TIME)) {
+                    break;
+                }
+                Long messageID = Long.parseLong(keySplit[3]);
+                Long messageExpiredTime = Long.parseLong(asString(keyIterator.peekNext().getValue()));
+
+                if (messageExpiredTime < currentTime) {
+                    expiredMessageIDList.add(messageID);
+                }
+                keyIterator.next();
+            }
+        } catch (DBException e) {
+            throw new AndesException("Error occurred while retrieving expired messages from " + queueName, e);
+        } finally {
+            closeKeyIterator(keyIterator);
+        }
+        return expiredMessageIDList;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Long> getExpiredMessagesFromDLC(long messageCount) throws AndesException {
+        return getExpiredMessages(0, DLC).subList(0, (int) messageCount);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addMessageToExpiryQueue(Long messageId, Long expirationTime, boolean isMessageForTopic, String
+            destination) throws AndesException {
+        // Not implemented in RDBMS store
+        throw new AndesException(new NotImplementedException("Method is not implemented."));
+    }
+
+    @Override
+    public long getApproximateQueueMessageCount(String storageQueueName) throws AndesException {
+        return getMessageCountForQueue(storageQueueName);
+    }
+
+    @Override
+    public void resetMessageCounterForQueue(String storageQueueName) throws AndesException {
+        // Not implemented in RDBMS store
+        throw new AndesException(new NotImplementedException("Method is not implemented."));
+    }
+
+    @Override
+    public void removeLocalQueueData(String storageQueueName) {
+        // No cache is used
+        throw new NotImplementedException("Method is not implemented.");
+    }
+
+    @Override
+    public void incrementMessageCountForQueue(String storageQueueName, long incrementBy) throws AndesException {
+        // Not implemented in RDBMS store
+        throw new AndesException(new NotImplementedException("Method is not implemented."));
+    }
+
+    @Override
+    public void decrementMessageCountForQueue(String storageQueueName, long decrementBy) throws AndesException {
+        // Not implemented in RDBMS store
+        throw new AndesException(new NotImplementedException("Method is not implemented."));
+    }
+
+    // Retained store is not implemented as MB not supports MQTT
+    @Override
+    public void storeRetainedMessages(Map<String, AndesMessage> retainMap) throws AndesException {
+        throw new AndesException(new NotImplementedException("Method is not implemented."));
+    }
+
+    @Override
+    public List<String> getAllRetainedTopics() throws AndesException {
+        throw new AndesException(new NotImplementedException("Method is not implemented."));
+    }
+
+    @Override
+    public Map<Integer, AndesMessagePart> getRetainedContentParts(long messageID) throws AndesException {
+        throw new AndesException(new NotImplementedException("Method is not implemented."));
+    }
+
+    @Override
+    public DeliverableAndesMetadata getRetainedMetadata(String destination) throws AndesException {
+        throw new AndesException(new NotImplementedException("Method is not implemented."));
+    }
+
+    /**
+     * Close file based store connection.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        fileStoreConnection.close();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DtxStore getDtxStore() {
+        return this.dtxStore;
+    }
+
+    /**
+     * Close the given key iterator
+     *
+     * @param keyIterator key iterator which needs to be closed
+     */
+    public void closeKeyIterator(DBIterator keyIterator) {
+        try {
+            keyIterator.close();
+        } catch (IOException e) {
+            log.error("Error occurred while closing the key iterator.", e);
+        }
+    }
+
+    /**
+     * Close the given write batch
+     *
+     * @param batch write batch which needs to be closed
+     */
+    public void closeWriteBatch(WriteBatch batch) {
+        try {
+            batch.close();
+        } catch (IOException e) {
+            log.error("Error occurred while closing the write batch.", e);
+        }
+    }
+
+    /**
+     * Return LevelDB store object
+     *
+     * @return DB LevelDB store object
+     */
+    protected DB getDB() {
+        return this.brokerStore;
+    }
+
+    /**
+     * Create key name when identifiers are provided
+     *
+     * @param identifiers identifiers which are included in the key name
+     * @return key
+     */
+    public String generateKey(String... identifiers) {
+        String key = identifiers[0];
+
+        for (int i = 1; i <= identifiers.length - 2; i++) {
+            key = key + DELIMITER + identifiers[i];
+        }
+        return key + DELIMITER + identifiers[identifiers.length - 1];
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/file/FileStoreConnection.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/file/FileStoreConnection.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*/
+
+package org.wso2.andes.store.file;
+
+import org.apache.log4j.Logger;
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.Options;
+import org.wso2.andes.configuration.util.ConfigurationProperties;
+import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.kernel.DurableStoreConnection;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.iq80.leveldb.impl.Iq80DBFactory.factory;
+
+import static org.wso2.andes.store.file.FileStoreConstants.BLOCK_SIZE;
+import static org.wso2.andes.store.file.FileStoreConstants.CACHE_SIZE;
+import static org.wso2.andes.store.file.FileStoreConstants.MAX_OPEN_FILES;
+import static org.wso2.andes.store.file.FileStoreConstants.PATH;
+import static org.wso2.andes.store.file.FileStoreConstants.WRITE_BUFFER_SIZE;
+import static org.wso2.andes.store.file.FileStoreConstants.MB;
+
+/**
+ * File connection class. Initiate file based store.
+ */
+public class FileStoreConnection extends DurableStoreConnection {
+    private static final Logger logger = Logger.getLogger(FileStoreConnection.class);
+    private DB brokerStore;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void initialize(ConfigurationProperties connectionProperties) throws AndesException {
+        super.initialize(connectionProperties);
+
+        try {
+            Options options = new Options();
+
+            options.blockSize(Integer.parseInt(connectionProperties.getProperty(BLOCK_SIZE)));
+            options.cacheSize(Integer.parseInt(connectionProperties.getProperty(CACHE_SIZE)) * MB);
+            options.maxOpenFiles(Integer.parseInt(connectionProperties.getProperty(MAX_OPEN_FILES)) * MB);
+            options.writeBufferSize(Integer.parseInt(connectionProperties.getProperty(WRITE_BUFFER_SIZE))
+                    * MB);
+            options.createIfMissing(true);
+
+            this.brokerStore = factory.open(new File(connectionProperties.getProperty(PATH)), options);
+        } catch (IOException e) {
+            throw new AndesException("Error occurred while initializing LevelDB store in " +
+                    connectionProperties.getProperty(PATH), e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        try {
+            if (brokerStore != null) {
+                brokerStore.close();
+            }
+        } catch (IOException e) {
+            logger.error("Error occured while closing LevelDB store.", e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object getConnection() {
+        return this.brokerStore;
+    }
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/file/FileStoreConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/file/FileStoreConstants.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*/
+
+package org.wso2.andes.store.file;
+
+/**
+ * Holds the constant values related to the file store
+ */
+public class FileStoreConstants {
+
+    public static final String DELIMITER = "::";
+
+    // LevelDB store configuration
+    public static final String BLOCK_SIZE = "blockSize";
+    public static final String CACHE_SIZE = "cacheSize";
+    public static final String MAX_OPEN_FILES = "maxOpenFiles";
+    public static final String WRITE_BUFFER_SIZE = "writeBufferSize";
+    public static final String PATH = "path";
+    // Bytes per 1MB
+    public static final int MB = 1024 * 1024;
+
+    // Message related identifiers
+    public static final String MESSAGE = "MESSAGE";
+    public static final String MESSAGE_METADATA = "MESSAGE_METADATA";
+    public static final String MESSAGE_CONTENT = "MESSAGE_CONTENT";
+    public static final String MESSAGE_EXPIRATION_TIME = "MESSAGE_EXPIRATION_TIME";
+    public static final String INITIAL_MESSAGE_COUNT = "0";
+    public static final String START_OFFSET = "0";
+
+    // Destination related identifiers
+    public static final String DESTINATION = "DESTINATION";
+    public static final String DESTINATION_NAME = "DESTINATION_NAME";
+    public static final String LAST_DESTINATION_ID = "LAST_DESTINATION_ID";
+    public static final String MESSAGE_COUNT = "MESSAGE_COUNT";
+
+    // Dead letter channel related identifiers
+    public static final String DLC = "deadletterchannel";
+    public static final String DLC_STATUS = "DLC_STATUS";
+    public static final String DEFAULT_DLC_STATUS = "0";
+    public static final String IN_DLC_STATUS = "1";
+
+    // DTX Store related identifiers
+    public static final String DTX_ENTRY = "DTX_ENTRY";
+    public static final String DTX_ENQUEUE = "DTX_ENQUEUE";
+    public static final String DTX_DEQUEUE = "DTX_DEQUEUE";
+    public static final String FORMAT_CODE = "FORMAT_CODE";
+    public static final String GLOBAL_ID = "GLOBAL_ID";
+    public static final String BRANCH_ID = "BRANCH_ID";
+    public static final String DTX_XID = "DTX_XID";
+    public static final String XID_IDENTIFIER = "XID_IDENTIFIER";
+}

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/file/FileStoreUtils.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/file/FileStoreUtils.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*/
+
+package org.wso2.andes.store.file;
+
+import org.apache.log4j.Logger;
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBException;
+import org.iq80.leveldb.WriteBatch;
+import org.wso2.andes.kernel.DurableStoreConnection;
+
+import java.io.IOException;
+
+import static org.iq80.leveldb.impl.Iq80DBFactory.asString;
+import static org.iq80.leveldb.impl.Iq80DBFactory.bytes;
+
+/**
+ * Contains utilility methods required for  {@link FileMessageStoreImpl}
+ */
+
+public class FileStoreUtils {
+
+    private static final Logger log = Logger.getLogger(FileStoreUtils.class);
+
+    /**
+     * Inserts a test record
+     *
+     * @param testString a string value
+     * @param testTime   a time value
+     * @return true if the test was successful.
+     */
+    public boolean testInsert(DurableStoreConnection connection, String testString, long testTime) {
+        boolean canInsert;
+
+        DB brokerStore = (DB) connection.getConnection();
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+            batch.put(bytes(testString), bytes(Long.toString(testTime)));
+            brokerStore.write(batch);
+            canInsert = true;
+        } catch (DBException e) {
+            canInsert = false;
+        } finally {
+            closeWriteBatch(batch);
+        }
+
+        return canInsert;
+    }
+
+    /**
+     * Reads a test record
+     *
+     * @param testString a string value
+     * @param testTime   a time value
+     * @return true if the test was successful.
+     */
+    public boolean testRead(DurableStoreConnection connection, String testString, long testTime) {
+        boolean canRead = false;
+
+        DB brokerStore = (DB) connection.getConnection();
+
+        try {
+            if (testTime == Long.parseLong(asString(brokerStore.get(bytes(testString))))) {
+                canRead = true;
+            }
+        } catch (DBException e) {
+            canRead = false;
+        }
+
+        return canRead;
+    }
+
+    /**
+     * Delete a test record
+     *
+     * @param testString a string value
+     * @return true if the test was successful.
+     */
+    public boolean testDelete(DurableStoreConnection connection, String testString) {
+
+        boolean canDelete;
+
+        DB brokerStore = (DB) connection.getConnection();
+        WriteBatch batch = brokerStore.createWriteBatch();
+
+        try {
+            batch.delete(bytes(testString));
+            brokerStore.write(batch);
+            canDelete = true;
+        } catch (DBException e) {
+            canDelete = false;
+        } finally {
+            closeWriteBatch(batch);
+        }
+
+        return canDelete;
+    }
+
+    /**
+     * Close the given write batch
+     *
+     * @param batch write batch which needs to be closed
+     */
+    private void closeWriteBatch(WriteBatch batch) {
+        try {
+            batch.close();
+        } catch (IOException e) {
+            log.error("Write batch closing failed.", e);
+        }
+    }
+}

--- a/modules/andes-core/pom.xml
+++ b/modules/andes-core/pom.xml
@@ -343,6 +343,20 @@
             <groupId>commons-codec.wso2</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
+        <!-- File based database -->
+        <dependency>
+            <groupId>org.iq80.leveldb</groupId>
+            <artifactId>leveldb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.iq80.leveldb</groupId>
+            <artifactId>leveldb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.andes</groupId>
+            <artifactId>andes-common</artifactId>
+            <version>RELEASE</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/orbit/andes/pom.xml
+++ b/modules/orbit/andes/pom.xml
@@ -119,6 +119,15 @@
             <groupId>commons-jxpath</groupId>
             <artifactId>commons-jxpath</artifactId>
         </dependency>
+        <!-- Level DB Dependencies -->
+        <dependency>
+            <groupId>org.iq80.leveldb</groupId>
+            <artifactId>leveldb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.iq80.leveldb</groupId>
+            <artifactId>leveldb</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -171,6 +180,7 @@
             org.apache.derby.jdbc,
             org.apache.commons.configuration.*,
             org.apache.commons.jxpath.*,
+            org.iq80.leveldb.*;-split-package:=merge-last,
             org.wso2.andes.*;-split-package:=merge-last,
             org.apache.mina.*;-split-package:=merge-last,
             com.gs.collections.*;-split-package:=merge-last,

--- a/pom.xml
+++ b/pom.xml
@@ -466,6 +466,17 @@
                 <artifactId>org.wso2.carbon.config</artifactId>
                 <version>${carbon.config.version}</version>
             </dependency>
+            <!-- File based database-->
+            <dependency>
+                <groupId>org.iq80.leveldb</groupId>
+                <artifactId>leveldb-api</artifactId>
+                <version>${leveldb-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.iq80.leveldb</groupId>
+                <artifactId>leveldb</artifactId>
+                <version>${leveldb-version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -675,7 +686,8 @@
         <org.apache.commons.pool.version>2.4.2</org.apache.commons.pool.version>
         <commons-lang.imp.pkg.version>[2.6, 3.0)</commons-lang.imp.pkg.version>
         <carbon.config.version>2.0.5</carbon.config.version>
-
+        <leveldb-api-version>0.9</leveldb-api-version>
+        <leveldb-version>0.9</leveldb-version>
     </properties>
 
     <mailingLists>


### PR DESCRIPTION
## Purpose
> LevelDB store implementation for the message broker. The main purpose is improving data retrieving and storing performances of the broker.

## Goals
> Improve message broker store performances than the current RDBMS implementation.

## Approach
> Implemented message store related methods which are defined in MessageStore and DTXStore interface. Used org.iq80.leveldb API for the implementation.

## Documentation
> Google Doc : https://docs.google.com/document/d/1jYav0PTApusxR25Ozan9x3i2hLMt5d7U7z8VlqfqX_g/edit?usp=sharing