### PR TITLE
Fix NPE when subscriber closed and Thrift server thread hang and Thrift server hangs in socket read

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/delivery/DeliveryEventHandler.java
@@ -112,7 +112,6 @@ public class DeliveryEventHandler implements EventHandler<DeliveryEventData> {
                     } else {
                         onSendError(message, subscription);
                         onSubscriptionAlreadyClosed(message, subscription);
-                        reQueueMessageIfDurable(message, subscription);
                     }
                 } else {
                     // Stale only happens when last subscription is closed and slot is returned. No need to re-queue

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/SubscriptionImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/subscription/SubscriptionImpl.java
@@ -20,7 +20,10 @@ package org.wso2.andes.server.subscription;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.Logger;
+import org.wso2.andes.AMQChannelClosedException;
+import org.wso2.andes.AMQConnectionClosedException;
 import org.wso2.andes.AMQException;
+import org.wso2.andes.AMQSubscriptionClosedException;
 import org.wso2.andes.common.AMQPFilterTypes;
 import org.wso2.andes.common.ClientProperties;
 import org.wso2.andes.configuration.qpid.ConfigStore;
@@ -285,8 +288,9 @@ public abstract class SubscriptionImpl implements Subscription, FlowCreditManage
                                 + entry.getMessage().getMessageNumber());
 
                     }
-                    throw new SubscriptionAlreadyClosedException("Channel " + getChannel().getId() + " is already"
-                            + " closed. Delivery failed message id = " + entry.getMessage().getMessageNumber());
+                    throw new AMQSubscriptionClosedException("Channel " + getChannel().getId() + " is already"
+                                                             + " closed. Delivery failed message id = "
+                                                             + entry.getMessage().getMessageNumber());
                 }
 
                 if (log.isDebugEnabled()) {
@@ -305,7 +309,9 @@ public abstract class SubscriptionImpl implements Subscription, FlowCreditManage
                  in a loaded environment
                  */
                 entry.dispose();
-
+            } catch (AMQSubscriptionClosedException | AMQChannelClosedException | AMQConnectionClosedException e) {
+                throw new AMQSubscriptionClosedException("SEND FAILED >> Exception occurred while sending message "
+                                                         + "out", e);
             } catch (Exception e) {
 
                 // Try and shed more light about the exact context of the error (only in debug mode)

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/thrift/MBThriftServer.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/thrift/MBThriftServer.java
@@ -26,6 +26,8 @@ import org.apache.thrift.server.TServer;
 import org.apache.thrift.server.TThreadPoolServer;
 import org.apache.thrift.transport.TServerSocket;
 import org.apache.thrift.transport.TTransportException;
+import org.wso2.andes.configuration.AndesConfigurationManager;
+import org.wso2.andes.configuration.enums.AndesConfiguration;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.thrift.slot.gen.SlotManagementService;
 
@@ -78,7 +80,8 @@ public class MBThriftServer {
             throw new AndesException("Invalid thrift server host 0.0.0.0");
         }
         try {
-            TServerSocket socket = new TServerSocket(new InetSocketAddress(hostName, port));
+            int socketTimeout = AndesConfigurationManager.readValue(AndesConfiguration.COORDINATION_THRIFT_SO_TIMEOUT);
+            TServerSocket socket = new TServerSocket(new InetSocketAddress(hostName, port), socketTimeout);
             SlotManagementService.Processor<SlotManagementServiceImpl> processor =
                     new SlotManagementService.Processor<SlotManagementServiceImpl>(slotManagementServerHandler);
             TProtocolFactory protocolFactory = new TBinaryProtocol.Factory();

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/AMQSubscriptionClosedException.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/AMQSubscriptionClosedException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes;
+
+/**
+ * AMQSubscriptionClosedException indicate that a subscriber is already closed. This is thrown if the AMQ channel
+ * representing subscription is closed while delivering messages.
+ */
+public class AMQSubscriptionClosedException extends AMQException {
+
+    public AMQSubscriptionClosedException(String message, Throwable cause) {
+        super(null, message, cause);
+    }
+
+    public AMQSubscriptionClosedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Purpose
To fix https://github.com/wso2/product-ei/issues/1619 and https://github.com/wso2/product-ei/issues/1613. 

## Goals
Fixes the NPE that occurs when a subscription connection is abruptly removed. The issue was caused by a message duplication. Messages that are failed during delivery were requeued where all the messages that are bound to the subscription are also requeued from another path. As the resolution, avoided requeueing messages when the delivery is failed due to the subscriber being not available.

This fix provided by @sdkottegoda .