### PR TITLE
Fix EI-1644

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
@@ -668,7 +668,12 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
         try {
             //tell Andes Kernel to register a subscription
             queue.registerSubscription(subscription, exclusive);
-            QpidAndesBridge.createAMQPSubscription(subscription, queue);
+            try {
+                QpidAndesBridge.createAMQPSubscription(subscription, queue);
+            } catch (AMQException e) {
+                queue.unregisterSubscription(subscription);
+                throw e;
+            }
         } catch (AMQException e) {
             _tag2SubscriptionMap.remove(tag);
             throw e;


### PR DESCRIPTION
## Purpose
2nd node unable to create the durable subscription with the same subscription id after the first node disconnect.
Resolves https://github.com/wso2/product-ei/issues/1644

## Goals
2nd node should able to create the new durable subscription with the same subscription id after the first node disconnect.

## Release note
Creating a  durable subscription on the second node that was made with the same subscription id after disconnecting from the other node fail in a 2 node MB cluster. Ref: wso2/product-ei#1644