### PR TITLE
Remove redundant error logs from Andes client code

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnection.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnection.java
@@ -1354,7 +1354,7 @@ public class AMQConnection extends Closeable implements Connection, QueueConnect
         if (_exceptionListener != null) {
             _exceptionListener.onException(je);
         } else {
-            _logger.error("Throwable Received but no listener set: " + cause);
+            _logger.warn("Throwable Received but no listener set: " + cause);
         }
 
         // if we are closing the connection, close sessions first

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionFactory.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionFactory.java
@@ -346,7 +346,6 @@ public class AMQConnectionFactory implements ConnectionFactory, QueueConnectionF
             JMSException jmse = new JMSException("Error creating connection: " + e.getMessage());
             jmse.setLinkedException(e);
             jmse.initCause(e);
-            log.error("Error while creating connection", e);
             throw jmse;
         }
 

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/state/AMQStateManager.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/state/AMQStateManager.java
@@ -154,12 +154,12 @@ public class AMQStateManager implements AMQMethodListener
 
         if (_waiters.size() == 0)
         {
-            _logger.error("No Waiters for error saving as last error:" + error.getMessage());
+            _logger.warn("No Waiters for error saving as last error:" + error.getMessage());
             _lastException = error;
         }
         for (StateWaiter waiter : _waiters)
         {
-            _logger.error("Notifying Waiters(" + _waiters + ") for error:" + error.getMessage());
+            _logger.info("Notifying Waiters(" + _waiters + ") for error:" + error.getMessage());
             waiter.error(error);
         }
     }


### PR DESCRIPTION
## Purpose

Remove redundant error logging from the client code on connection failures 