### PR TITLE
Remove redundant error logging from Andes client

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/AMQProtocolHandler.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/AMQProtocolHandler.java
@@ -716,9 +716,7 @@ public class AMQProtocolHandler implements ProtocolEngine
             }
             catch (AMQTimeoutException e)
             {
-                String error = "AMQP timed out when attempting to close the connection ";
-                _logger.error(error,e);
-                throw new AMQException(error,e);
+                throw new AMQException("AMQP timed out when attempting to close the connection ", e);
             }
             catch (FailoverException e)
             {


### PR DESCRIPTION
Remove redundant error logging done by Andes client. Error is thrown and logged at the same place.