### PR TITLE
Fix wso2/product-ei/issues/1845

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/FlowControlledQueueMessageDeliveryImpl.java
@@ -85,7 +85,8 @@ public class FlowControlledQueueMessageDeliveryImpl implements MessageDeliverySt
                         suspendedSubFound = true;
                         continue;
                     }
-                    if (localSubscription.getSubscriberConnection().hasRoomToAcceptMessages()) {
+                    if (localSubscription.getSubscriberConnection().hasRoomToAcceptMessages()
+                            & localSubscription.getSubscriberConnection().isReadyToDeliver()) {
 
                         if (!localSubscription.getSubscriberConnection().
                                 isMessageAcceptedByConnectionSelector(message)) {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/NoLossBurstTopicMessageDeliveryImpl.java
@@ -99,7 +99,8 @@ public class NoLossBurstTopicMessageDeliveryImpl implements MessageDeliveryStrat
 
                 boolean allTopicSubscriptionsSaturated = true;
                 for (AndesSubscription subscription : subscriptionsToDeliver) {
-                    if (subscription.getSubscriberConnection().hasRoomToAcceptMessages()) {
+                    if (subscription.getSubscriberConnection().hasRoomToAcceptMessages()
+                            & subscription.getSubscriberConnection().isReadyToDeliver()) {
                         allTopicSubscriptionsSaturated = false;
                         break;
                     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/SlowestSubscriberTopicMessageDeliveryImpl.java
@@ -108,8 +108,9 @@ public class SlowestSubscriberTopicMessageDeliveryImpl implements MessageDeliver
                  */
                 boolean allTopicSubscriptionsHasRoom = true;
                 for (AndesSubscription subscription : subscriptionsToDeliver) {
-                    if (!subscription.getSubscriberConnection().hasRoomToAcceptMessages()
-                        || subscription.getSubscriberConnection().isSuspended()) {
+                    if ((!subscription.getSubscriberConnection().hasRoomToAcceptMessages()
+                            & !subscription.getSubscriberConnection().isReadyToDeliver())
+                            || subscription.getSubscriberConnection().isSuspended()) {
                         allTopicSubscriptionsHasRoom = false;
                         break;
                     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundSubscriptionEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundSubscriptionEvent.java
@@ -32,6 +32,15 @@ import java.util.concurrent.ExecutionException;
  */
 public class InboundSubscriptionEvent implements AndesInboundStateEvent {
 
+    /**
+     * A thread to send consume-ok frame after opening the subscription.
+     */
+    private Runnable postOpenSubscriptionAction;
+
+    public Runnable getPostOpenSubscriptionAction() {
+        return postOpenSubscriptionAction;
+    }
+
     private static Log log = LogFactory.getLog(InboundSubscriptionEvent.class);
 
     /**
@@ -82,6 +91,19 @@ public class InboundSubscriptionEvent implements AndesInboundStateEvent {
 
     private String routingKey;
 
+    public InboundSubscriptionEvent(ProtocolType protocol,
+                                    String subscriptionIdentifier,
+                                    String boundStorageQueueName,
+                                    String routingKey,
+                                    SubscriberConnection subscription,
+                                    Runnable sendConsumeOk) {
+        this.protocol = protocol;
+        this.subscriptionIdentifier = subscriptionIdentifier;
+        this.boundStorageQueueName = boundStorageQueueName;
+        this.routingKey = routingKey;
+        this.subscriberConnection = subscription;
+        this.postOpenSubscriptionAction = sendConsumeOk;
+    }
 
     public InboundSubscriptionEvent(ProtocolType protocol,
                                     String subscriptionIdentifier,

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionManager.java
@@ -193,7 +193,8 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
 
         clusterNotificationAgent.notifySubscriptionsChange(subscription,
                 ClusterNotificationListener.SubscriptionChange.Added);
-
+        subscriptionRequest.getPostOpenSubscriptionAction().run();
+        subscriptionRequest.getSubscriber().setIsReadyToDeliver(true);
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/OutBoundMessageTracker.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/OutBoundMessageTracker.java
@@ -32,6 +32,16 @@ import java.util.List;
  */
 public class OutBoundMessageTracker {
 
+    /*
+        This parameter is used to keep hasRoomToAcceptMessages check in fault state, until we send the
+        consume-ok frame to the consumer.
+    */
+    private boolean readyToDeliver = false;
+
+    public void setReadyToDeliver(boolean ready) {
+        readyToDeliver = ready;
+    }
+
     /**
      * Map to track messages being sent <message id, MsgData reference>. This map bares message
      * reference at kernel side
@@ -102,6 +112,15 @@ public class OutBoundMessageTracker {
 
             return false;
         }
+    }
+
+    /**
+     * To check whether consume-ok frame is sent.
+     *
+     * @return true if consume-ok frame is sent.
+     */
+    public boolean isReadyToDeliver() {
+        return readyToDeliver;
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/SubscriberConnection.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/SubscriberConnection.java
@@ -269,6 +269,14 @@ public class SubscriberConnection {
         return outBoundMessageTracker.hasRoomToAcceptMessages();
     }
 
+    public boolean isReadyToDeliver() {
+        return outBoundMessageTracker.isReadyToDeliver();
+    }
+
+    public void setIsReadyToDeliver(boolean value) {
+        outBoundMessageTracker.setReadyToDeliver(value);
+    }
+
     /**
      * Returns if the subscription is marked as suspended.
      *

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
@@ -642,16 +642,13 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
      *
      * @param noLocal   Flag stopping own messages being receivied.
      * @param exclusive Flag requesting exclusive access to the queue
+     * @param sendConsumeOk A thread to send Consume_ok frame to consumer.
      * @return the consumer tag. This is returned to the subscriber and used in subsequent unsubscribe requests
-     *
-     * @throws AMQException                  if something goes wrong
+     * @throws AMQException if something goes wrong
      */
     public AMQShortString subscribeToQueue(AMQShortString tag, AMQQueue queue, boolean acks,
-                                           FieldTable filters, boolean noLocal, boolean exclusive) throws AMQException {
-        if (tag == null)
-        {
-            tag = new AMQShortString("sgen_" + getNextConsumerTag());
-        }
+                                           FieldTable filters, boolean noLocal, boolean exclusive,
+                                           Runnable sendConsumeOk) throws AMQException {
 
         if (_tag2SubscriptionMap.size() > 0)
         {
@@ -669,7 +666,7 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
             //tell Andes Kernel to register a subscription
             queue.registerSubscription(subscription, exclusive);
             try {
-                QpidAndesBridge.createAMQPSubscription(subscription, queue);
+                QpidAndesBridge.createAMQPSubscription(subscription, queue, sendConsumeOk);
             } catch (AMQException e) {
                 queue.unregisterSubscription(subscription);
                 throw e;

--- a/modules/andes-core/broker/src/test/java/org/wso2/andes/server/util/InternalBrokerBaseCase.java
+++ b/modules/andes-core/broker/src/test/java/org/wso2/andes/server/util/InternalBrokerBaseCase.java
@@ -60,6 +60,13 @@ public class InternalBrokerBaseCase extends QpidTestCase
     private XMLConfiguration _configXml = new XMLConfiguration();
     private boolean _started = false;
 
+    Runnable tempRunnable = new Runnable() {
+        @Override
+        public void run() {
+            //created without implementation since test methods are not used.
+        }
+    };
+
     public void setUp() throws Exception
     {
         super.setUp();
@@ -165,7 +172,7 @@ public class InternalBrokerBaseCase extends QpidTestCase
     {
         try
         {
-            return channel.subscribeToQueue(null, queue, true, null, false, true);
+            return channel.subscribeToQueue(null, queue, true, null, false, true, tempRunnable);
         }
         catch (AMQException e)
         {
@@ -184,7 +191,7 @@ public class InternalBrokerBaseCase extends QpidTestCase
             FieldTable filters = new FieldTable();
             filters.put(AMQPFilterTypes.NO_CONSUME.getValue(), true);
 
-            return channel.subscribeToQueue(null, queue, true, filters, false, true);
+            return channel.subscribeToQueue(null, queue, true, filters, false, true, tempRunnable);
         }
         catch (AMQException e)
         {


### PR DESCRIPTION
## Purpose
> Fix wso2/product-ei/issues/1845

## Goals
> Sends consume-ok before start sending messages to subscriber

## Approach
> Use a runnable object to send comsume-ok frame in AndesSubscriptionManager Class. 
Use a new setReadyToDeliver method to hold outbound from start sending messages to consumers.
After consume-ok frame sent by the thread. We are releasing outbound using setReadyToDeliver(true)

## Test environment
> JDK 8, Ubuntu 16.04