### PR TITLE
Move expired messages to DLC

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -595,6 +595,13 @@ public enum AndesConfiguration implements ConfigurationProperty {
     PERFORMANCE_TUNING_EXPIRE_MESSAGES_IN_DLC
             ("performanceTuning/messageExpiration/expireMessagesInDLC", "false", Boolean.class),
 
+    /**
+     * Enable/Disable moving expired messages to DLC.
+     */
+    PERFORMANCE_TUNING_MOVE_EXPIRED_MESSAGES_TO_DLC
+            ("performanceTuning/messageExpiration/moveExpiredMessagesToDLC", "false", Boolean.class),
+
+
      /**
      * In order to have a batch delete for the expired messages captured at the message flusher, accumulate them
      * in to a queue and delete them periodically as a batch. specified in seconds

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/MessageStatus.java
@@ -133,7 +133,7 @@ public enum MessageStatus {
         ACKED_BY_ALL.next = EnumSet.of(PREPARED_TO_DELETE, SLOT_RETURNED);
         ACKED_BY_ALL.previous = EnumSet.of(SCHEDULED_TO_SEND);
 
-        EXPIRED.next = EnumSet.of(PREPARED_TO_DELETE, SLOT_RETURNED);
+        EXPIRED.next = EnumSet.of(PREPARED_TO_DELETE, SLOT_RETURNED, DLC_MESSAGE);
         EXPIRED.previous = EnumSet.allOf(MessageStatus.class);
 
         DLC_MESSAGE.next = EnumSet.of(EXPIRED, BUFFERED, SLOT_REMOVED, SLOT_RETURNED);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
@@ -1131,6 +1131,10 @@ public class QueueManagementInformationMBean extends AMQManagedObject implements
                 metadata.updateMetadata(targetQueue, newStorageQueue.getMessageRouter().getName());
             }
 
+            //set new expiration time. This will be time now + original TTL
+            long now = System.currentTimeMillis();
+            metadata.setExpirationTime(now + (metadata.getExpirationTime() - metadata.getArrivalTime()));
+
             AndesMessageMetadata clonedMetadata = metadata.shallowCopy(metadata.getMessageID());
             AndesMessage andesMessage = new AndesMessage(clonedMetadata);
 


### PR DESCRIPTION
## Purpose
New Improvement : Move expired messages to DLC

To enable edit [MB_HOME]/repository/conf/broker.xml file and define below parameter.
```

<performanceTuning> ...
     <messageExpiration> ...
        <moveExpiredMessagesToDLC> true </moveExpiredMessagesToDLC>
```


## Goals
Fixes : wso2/product-ei#1914

## Approach
> Read a global setting from broker.xml to control the behavior. 

## User stories
> Expired messages should not be deleted. They should be move into Dead Letter Channel instead.  

## Release note
> Feature : expired messages are not removed, but routed to DLC. You can restore them back with expiry time reset. 

## Documentation
> Refer above

## Training
> Move expired messages to DLC and see.

## Certification
> N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

##Related PR
https://github.com/wso2/carbon-business-messaging/pull/624