### PR TITLE
Fix to avoid NPE when try to run post subscription action

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundSubscriptionEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundSubscriptionEvent.java
@@ -21,7 +21,9 @@ package org.wso2.andes.kernel.disruptor.inbound;
 import com.google.common.util.concurrent.SettableFuture;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.andes.kernel.*;
+import org.wso2.andes.kernel.AndesException;
+import org.wso2.andes.kernel.ProtocolType;
+import org.wso2.andes.kernel.SubscriptionAlreadyExistsException;
 import org.wso2.andes.kernel.subscription.AndesSubscriptionManager;
 import org.wso2.andes.kernel.subscription.SubscriberConnection;
 
@@ -115,6 +117,12 @@ public class InboundSubscriptionEvent implements AndesInboundStateEvent {
         this.boundStorageQueueName = boundStorageQueueName;
         this.routingKey = routingKey;
         this.subscriberConnection = subscription;
+        this.postOpenSubscriptionAction = new Runnable() {
+            @Override
+            public void run() {
+                //Setting empty runnable to avoid NPE when try to run post subscription action later.
+            }
+        };
     }
 
     public SubscriberConnection getSubscriber() {


### PR DESCRIPTION
## Purpose
> Fix to avoid NPE when try to run post subscription action.

## Goals
> NPE throws from Andes kernel when tries to subscribe to a MQTT topic. This is to fix that issue

## Approach
> Initialize postOpenSubscriptionAction runnable in InboundSubscriptionEvent class inside the overloaded constructor which doesn't allow to set it externally. 

## User stories
> N/A, Bug fix

## Release note
> Fix to avoid NPE when try to run post subscription action

## Documentation
> N/A, Bug fix

## Training
> N/A, Bug fix

## Certification
> N/A, Bug fix

## Marketing
> N/A, Bug fix

## Automation tests
> N/A, Bug fix

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A, Bug fix

## Related PRs
> https://github.com/wso2/andes/pull/958

## Migrations (if applicable)
> N/A, Bug fix

## Test environment
> Fedora 23 x64, Oracle JDK 1.8.91
 
## Learning
> N/A, Bug fix