### PR TITLE
Modify expirery+arrival times upon restore from DLC

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AMQPMetaDataHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AMQPMetaDataHandler.java
@@ -18,6 +18,7 @@
 package org.wso2.andes.kernel;
 
 import org.wso2.andes.framing.AMQShortString;
+import org.wso2.andes.framing.BasicContentHeaderProperties;
 import org.wso2.andes.framing.ContentHeaderBody;
 import org.wso2.andes.framing.abstraction.MessagePublishInfo;
 import org.wso2.andes.server.message.CustomMessagePublishInfo;
@@ -42,11 +43,16 @@ public class AMQPMetaDataHandler {
      * @return copy of the metadata as a byte array
      */
     public static byte[] constructMetadata(String routingKey, ByteBuffer buf, StorableMessageMetaData originalMetadata,
-                                           String exchange) {
+                                           String exchange, long arrivalTime) {
         ContentHeaderBody contentHeaderBody = ((MessageMetaData) originalMetadata).getContentHeaderBody();
         int contentChunkCount = ((MessageMetaData) originalMetadata).getContentChunkCount();
-        long arrivalTime = ((MessageMetaData) originalMetadata).getArrivalTime();
         long sessionID = ((MessageMetaData) originalMetadata).getPublisherSessionID();
+
+        //Set expiration value to 0 to indicate no expiration
+        BasicContentHeaderProperties props = (BasicContentHeaderProperties) contentHeaderBody.getProperties();
+        if (props.getExpiration() != 0) {
+            props.setExpiration(0);
+        }
 
         // modify routing key to the binding name
         MessagePublishInfo messagePublishInfo = new CustomMessagePublishInfo(originalMetadata);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessageMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesMessageMetadata.java
@@ -301,8 +301,8 @@ public class AndesMessageMetadata implements Comparable<AndesMessageMetadata> {
      * @param newDestination  new routing key to set
      * @param newExchangeName new exchange name to set
      */
-    public void updateMetadata(String newDestination, String newExchangeName) {
-        this.metadata = createNewMetadata(this.metadata, newDestination, newExchangeName);
+    public void updateMetadata(String newDestination, String newExchangeName, long newArrivalTime) {
+        this.metadata = createNewMetadata(this.metadata, newDestination, newExchangeName, newArrivalTime);
         this.destination = newDestination;
         if (log.isDebugEnabled()) {
             log.debug("updated andes message metadata id= " + messageID + " new destination = " + newDestination);
@@ -374,7 +374,7 @@ public class AndesMessageMetadata implements Comparable<AndesMessageMetadata> {
      * @param exchangeName     exchange of the message
      * @return copy of the metadata as a byte array
      */
-    private byte[] createNewMetadata(byte[] originalMetadata, String routingKey, String exchangeName) {
+    private byte[] createNewMetadata(byte[] originalMetadata, String routingKey, String exchangeName, long arrivalTime) {
         ByteBuffer buf = ByteBuffer.wrap(originalMetadata);
         buf.position(1);
         buf = buf.slice();
@@ -387,7 +387,8 @@ public class AndesMessageMetadata implements Comparable<AndesMessageMetadata> {
         if ((MessageMetaDataType.META_DATA_MQTT).equals(type)) {
             underlying = MQTTMetaDataHandler.constructMetadata(routingKey, buf, originalMessageMetadata, exchangeName);
         } else {
-            underlying = AMQPMetaDataHandler.constructMetadata(routingKey, buf, originalMessageMetadata, exchangeName);
+            underlying = AMQPMetaDataHandler.constructMetadata(routingKey, buf,
+                    originalMessageMetadata, exchangeName, arrivalTime);
         }
 
         return underlying;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/information/management/QueueManagementInformationMBean.java
@@ -1121,14 +1121,19 @@ public class QueueManagementInformationMBean extends AMQManagedObject implements
             }
             AndesMessageMetadata metadata = Andes.getInstance().getMessageMetaData(messageId);
             if (!restoreToOriginalQueue) {
-                StorageQueue newStorageQueue = AndesContext.getInstance().getStorageQueueRegistry()
-                        .getStorageQueue(targetQueue);
-
                 // Set the new destination queue
+                StorageQueue newStorageQueue = AndesContext.getInstance().
+                        getStorageQueueRegistry().getStorageQueue(targetQueue);
                 metadata.setDestination(targetQueue);
                 metadata.setStorageQueueName(targetQueue);
                 metadata.setMessageRouterName(newStorageQueue.getMessageRouter().getName());
-                metadata.updateMetadata(targetQueue, newStorageQueue.getMessageRouter().getName());
+                //update metadata with new queue, router and publish time
+                metadata.updateMetadata(targetQueue,
+                        newStorageQueue.getMessageRouter().getName(), System.currentTimeMillis());
+            } else {
+                //update metadata with new publish time
+                metadata.updateMetadata(metadata.getDestination(),
+                        metadata.getMessageRouterName(), System.currentTimeMillis());
             }
 
             //set new expiration time. This will be time now + original TTL


### PR DESCRIPTION
## Purpose
> Fixes : wso2/product-ei#1914

## Goals
 
This improvement is to modify message expire time when moving message

Back to the original queue
Reroute to a different queue
This will modify expire time of the original message to 0 to indicate no expiration. 

## Approach

Calculation is done by

New expire time = Current time + (original expire time - original arrival time)

## User stories

If you reroute or restore DLC messages, if expire time was specified in original message, it is ignored and message will never expire when rerouting/restoring. 

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Update: https://docs.wso2.com/display/MB320/Using+the+Dead+Letter+Channel (relevant page on next version)

## Training
N/A

## Certification
N/A - small feature

## Marketing
N/A

## Automation tests
 - Will be added when integration framework support JMS Tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
https://github.com/wso2/andes/pull/965

## Migrations (if applicable)
N/A

## Test environment

Java 8 (Oracle) , Mac OS X
 
## Learning
N/A