### PR TITLE
Make redelivery delay a configurable connection option

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/jms/ConnectionURL.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/jms/ConnectionURL.java
@@ -45,6 +45,7 @@ public interface ConnectionURL
     public static final String OPTIONS_DEFAULT_QUEUE_EXCHANGE = "defaultQueueExchange";
     public static final String OPTIONS_TEMPORARY_TOPIC_EXCHANGE = "temporaryTopicExchange";
     public static final String OPTIONS_TEMPORARY_QUEUE_EXCHANGE = "temporaryQueueExchange";
+    public static final String OPTIONS_CONNECTION_REDELIVERY_DELAY = "redeliverydelay";
     public static final byte  URL_0_8 = 1;
     public static final byte  URL_0_10 = 2;
     

--- a/modules/andes-core/client/src/test/java/org/wso2/andes/unit/client/connectionurl/ConnectionURLTest.java
+++ b/modules/andes-core/client/src/test/java/org/wso2/andes/unit/client/connectionurl/ConnectionURLTest.java
@@ -59,6 +59,24 @@ public class ConnectionURLTest extends TestCase
 
     }
 
+    public void testRedeliveryURL() throws URLSyntaxException {
+
+        String url = "amqp://ram:you@/test?redeliveryDelay='3000'&brokerlist='tcp://localhost:5672'";
+        ConnectionURL amqConnectionURL = new AMQConnectionURL(url);
+
+        assertEquals("3000", ((AMQConnectionURL) amqConnectionURL).getOptions()
+                .get(ConnectionURL.OPTIONS_CONNECTION_REDELIVERY_DELAY));
+        assertTrue(amqConnectionURL.getUsername().equals("ram"));
+        assertTrue(amqConnectionURL.getPassword().equals("you"));
+        assertTrue(amqConnectionURL.getVirtualHost().equals("/test"));
+        assertTrue(amqConnectionURL.getBrokerCount() == 1);
+
+        BrokerDetails service = amqConnectionURL.getBrokerDetails(0);
+        assertTrue(service.getTransport().equals("tcp"));
+        assertTrue(service.getHost().equals("localhost"));
+        assertTrue(service.getPort() == 5672);
+    }
+
     public void testSingleTransportUsernamePasswordURL() throws URLSyntaxException
     {
         String url = "amqp://ritchiem:bob@/test?brokerlist='tcp://localhost:5672'";


### PR DESCRIPTION
Fix https://github.com/wso2/product-ei/issues/1952

## Purpose
> Currently redelivery delay can be set as System Property "AndesRedeliveryDelay". With this fix, we are enabling for the delay to be set as a connection string in addition to system property.


## Goals
> Making redelivery delay a connection parameter.


## Approach
>Adding a connection option named **redeliverydelay** for the connection url.

Eg:-

connectionfactory.QueueConnectionFactory = amqp://admin:admin@clientID/carbon?brokerlist='tcp://localhost:5673'
connectionfactory.QueueConnectionFactory1 = amqp://admin:admin@clientID/carbon?redeliverydelay='15000'&brokerlist='tcp://localhost:5673'


## Release note
> With this fix, users can configure redelivery delay as a connection option.

## Documentation
> https://docs.wso2.com/display/MB320/Setting+the+Connection+URL

## Automation tests
 - Unit tests > Provided
  
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes

## Test environment
> JDK 1.8, Ubuntu 16.04, WSO2 MB 3.2.0 , EI 6.1.1
 