### PR TITLE
Fix EI-2154

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/protocol/AMQProtocolEngine.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/protocol/AMQProtocolEngine.java
@@ -449,6 +449,13 @@ public class AMQProtocolEngine implements ProtocolEngine, Managable, AMQProtocol
                 _logger.info(e.getMessage() + " whilst processing:" + methodBody);
                 closeConnection(channelId, ce, false);
             }
+            catch (AMQException e)
+            {
+                AMQConnectionException ce = evt.getMethod().getConnectionException(AMQConstant.INTERNAL_ERROR, e.getMessage());
+                _logger.info(e.getMessage() + " whilst processing:" + methodBody);
+                closeConnection(channelId, ce, false);
+            }
+
         }
         catch (Exception e)
         {


### PR DESCRIPTION
## Purpose

Fix: https://github.com/wso2/product-ei/issues/2154

## Goals
When MB Client throws a javax.jms.IllegalStateException ESB continuously failover to same node. Fix is to prevent throwing  javax.jms.IllegalStateException and notify closing the connection. 


## Automation tests
 N/A 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 8
 
