### PR TITLE
Fix Issue in Active Durable Subscription Search

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionManager.java
@@ -584,7 +584,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
                     filteredSubscriptions.add(subscription);
                 } else if (subscription.isDurable() && subscription.getStorageQueue().getMessageRouter().getName()
                         .equals(AMQPUtils.TOPIC_EXCHANGE_NAME)) {
-                    if (subscriptionIdPattern.equalsIgnoreCase(subscription.getSubscriptionId())) {
+                    if (subscriptionIdPattern.equalsIgnoreCase(subscription.getStorageQueue().getName())) {
                         filteredSubscriptions.add(subscription);
                     }
                 }
@@ -595,7 +595,7 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
                     filteredSubscriptions.add(subscription);
                 } else if (subscription.isDurable() && subscription.getStorageQueue().getMessageRouter().getName()
                         .equals(AMQPUtils.TOPIC_EXCHANGE_NAME)) {
-                    if (StringUtils.containsIgnoreCase(subscription.getSubscriptionId(), subscriptionIdPattern)) {
+                    if (StringUtils.containsIgnoreCase(subscription.getStorageQueue().getName(), subscriptionIdPattern)) {
                         filteredSubscriptions.add(subscription);
                     }
                 }


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/product-ei/issues/2320

## Approach
Fixes the issue of active durable subscriptions not being listed once searched by the subscription identifier, by having the filtration done using the storage queue associated with the subscription as well as the subscription id.