### PR TITLE
Improve Reroute All From DLC

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/configuration/enums/AndesConfiguration.java
@@ -662,12 +662,6 @@ public enum AndesConfiguration implements ConfigurationProperty {
             "/maximumMessageDisplayLength", "100000", Integer.class),
 
     /**
-     * Enable users to all reroute messages from a specific destination(queue or durable topic) to a specific queue.
-     */
-    MANAGEMENT_CONSOLE_ALLOW_REREOUTE_ALL_IN_DLC("managementConsole" +
-                                                "/allowReRouteAllInDLC", "false", Boolean.class),
-
-    /**
      * This is the per publisher buffer size low limit which disable the flow control for a channel if the flow-control
      * was enabled previously.
      */


### PR DESCRIPTION
Enables the functionality of re-routing all messages that belong to a
queue by default as opposed to a configuration in broker.xml.
Resolves: https://github.com/wso2/product-ei/issues/2322

## Related PRs
https://github.com/wso2/carbon-business-messaging/pull/641
