### PR TITLE
Fix [EI-2432] EI cannot re-connect to MB after DB failure

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnection.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnection.java
@@ -29,6 +29,7 @@ import org.wso2.andes.AMQProtocolException;
 import org.wso2.andes.AMQUnresolvedAddressException;
 import org.wso2.andes.client.failover.FailoverException;
 import org.wso2.andes.client.failover.FailoverProtectedOperation;
+import org.wso2.andes.client.pool.NamedThreadFactoryBuilder;
 import org.wso2.andes.client.protocol.AMQProtocolHandler;
 import org.wso2.andes.configuration.ClientProperties;
 import org.wso2.andes.exchange.ExchangeDefaults;
@@ -86,6 +87,14 @@ public class AMQConnection extends Closeable implements Connection, QueueConnect
 {
     private static final Logger _logger = LoggerFactory.getLogger(AMQConnection.class);
 
+    /**
+     * A separate executor service is used to notify the connection exception listeners. We cannot use the JOB pool
+     * threads for notifying the exception listeners since it will block the frame processing which is critical for
+     * activities like connection handshakes.
+     */
+    private static final ExecutorService EXCEPTION_NOTIFIER_EXECUTOR
+            = Executors.newCachedThreadPool(new NamedThreadFactoryBuilder().setNameFormat("ExceptionNotifyingThread-%d")
+                                                                           .build());
 
     /**
      * This is the "root" mutex that must be held when doing anything that could be impacted by failover. This must be
@@ -1350,13 +1359,6 @@ public class AMQConnection extends Closeable implements Connection, QueueConnect
             }
         }
 
-        // deliver the exception if there is a listener
-        if (_exceptionListener != null) {
-            _exceptionListener.onException(je);
-        } else {
-            _logger.warn("Throwable Received but no listener set.", cause);
-        }
-
         // if we are closing the connection, close sessions first
         if (closer) {
             // get the failover mutex before trying to close
@@ -1367,6 +1369,18 @@ public class AMQConnection extends Closeable implements Connection, QueueConnect
                     _logger.error("Error closing all sessions.", e);
                 }
             }
+        }
+
+        // deliver the exception if there is a listener
+        if (_exceptionListener != null) {
+            EXCEPTION_NOTIFIER_EXECUTOR.submit(new Runnable() {
+                @Override
+                public void run() {
+                    _exceptionListener.onException(je);
+                }
+            });
+        } else {
+            _logger.error("Throwable Received but no listener set.", cause);
         }
     }
 

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/pool/NamedThreadFactoryBuilder.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/pool/NamedThreadFactoryBuilder.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *    http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.andes.client.pool;
+
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.Locale;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * This class is extracted from the ThreadFactoryBuilder in Guava library.
+ *
+ * https://github.com/google/guava/
+ */
+public class NamedThreadFactoryBuilder {
+
+    private String nameFormat = null;
+    private Boolean daemon = null;
+    private Integer priority = null;
+    private UncaughtExceptionHandler uncaughtExceptionHandler = null;
+    private ThreadFactory backingThreadFactory = null;
+
+    /**
+     * Creates a new {@link ThreadFactory} builder.
+     */
+    public NamedThreadFactoryBuilder() {
+    }
+
+    /**
+     * Sets the naming format to use when naming threads ({@link Thread#setName}) which are created
+     * with this ThreadFactory.
+     *
+     * @param nameFormat a {@link String#format(String, Object...)}-compatible format String, to which
+     *                   a unique integer (0, 1, etc.) will be supplied as the single parameter. This integer will
+     *                   be unique to the built instance of the ThreadFactory and will be assigned sequentially. For
+     *                   example, {@code "rpc-pool-%d"} will generate thread names like {@code "rpc-pool-0"}, {@code
+     *                   "rpc-pool-1"}, {@code "rpc-pool-2"}, etc.
+     * @return this for the builder pattern
+     */
+    public NamedThreadFactoryBuilder setNameFormat(String nameFormat) {
+        String unused = format(nameFormat, 0); // fail fast if the format is bad or null
+        this.nameFormat = nameFormat;
+        return this;
+    }
+
+    /**
+     * Sets daemon or not for new threads created with this ThreadFactory.
+     *
+     * @param daemon whether or not new Threads created with this ThreadFactory will be daemon threads
+     * @return this for the builder pattern
+     */
+    public NamedThreadFactoryBuilder setDaemon(boolean daemon) {
+        this.daemon = daemon;
+        return this;
+    }
+
+    /**
+     * Sets the priority for new threads created with this ThreadFactory.
+     *
+     * @param priority the priority for new Threads created with this ThreadFactory
+     * @return this for the builder pattern
+     */
+    public NamedThreadFactoryBuilder setPriority(int priority) {
+        this.priority = priority;
+        return this;
+    }
+
+    /**
+     * Sets the {@link UncaughtExceptionHandler} for new threads created with this ThreadFactory.
+     *
+     * @param uncaughtExceptionHandler the uncaught exception handler for new Threads created with
+     *                                 this ThreadFactory
+     * @return this for the builder pattern
+     */
+    public NamedThreadFactoryBuilder setUncaughtExceptionHandler(UncaughtExceptionHandler uncaughtExceptionHandler) {
+        this.uncaughtExceptionHandler = uncaughtExceptionHandler;
+        return this;
+    }
+
+    /**
+     * Sets the backing {@link ThreadFactory} for new threads created with this ThreadFactory. Threads
+     * will be created by invoking #newThread(Runnable) on this backing {@link ThreadFactory}.
+     *
+     * @param backingThreadFactory the backing {@link ThreadFactory} which will be delegated to during
+     *                             thread creation.
+     * @return this for the builder pattern
+     */
+    public NamedThreadFactoryBuilder setThreadFactory(ThreadFactory backingThreadFactory) {
+        this.backingThreadFactory = backingThreadFactory;
+        return this;
+    }
+
+    /**
+     * Returns a new thread factory using the options supplied during the building process. After
+     * building, it is still possible to change the options used to build the ThreadFactory and/or
+     * build again. State is not shared amongst built instances.
+     *
+     * @return the fully constructed {@link ThreadFactory}
+     */
+    public ThreadFactory build() {
+        return doBuild(this);
+    }
+
+    private ThreadFactory doBuild(NamedThreadFactoryBuilder builder) {
+        final String nameFormat = builder.nameFormat;
+        final Boolean daemon = builder.daemon;
+        final Integer priority = builder.priority;
+        final UncaughtExceptionHandler uncaughtExceptionHandler = builder.uncaughtExceptionHandler;
+        final ThreadFactory backingThreadFactory =
+                (builder.backingThreadFactory != null)
+                        ? builder.backingThreadFactory
+                        : Executors.defaultThreadFactory();
+        final AtomicLong count = (nameFormat != null) ? new AtomicLong(0) : null;
+        return new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable runnable) {
+                Thread thread = backingThreadFactory.newThread(runnable);
+                if (nameFormat != null) {
+                    thread.setName(format(nameFormat, count.getAndIncrement()));
+                }
+                if (daemon != null) {
+                    thread.setDaemon(daemon);
+                }
+                if (priority != null) {
+                    thread.setPriority(priority);
+                }
+                if (uncaughtExceptionHandler != null) {
+                    thread.setUncaughtExceptionHandler(uncaughtExceptionHandler);
+                }
+                return thread;
+            }
+        };
+    }
+
+    private static String format(String format, Object... args) {
+        return String.format(Locale.ROOT, format, args);
+    }
+}

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/pool/ReferenceCountingClientExecutorService.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/pool/ReferenceCountingClientExecutorService.java
@@ -25,7 +25,6 @@ import org.wso2.andes.pool.ReadWriteJobQueue;
 import org.wso2.andes.pool.ReferenceCountingService;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -89,7 +88,8 @@ public class ReferenceCountingClientExecutorService implements ReferenceCounting
     /**
      * Thread Factory used to create Job thread pool.
      */
-    private ThreadFactory _threadFactory = Executors.defaultThreadFactory();
+    private ThreadFactory _threadFactory = new NamedThreadFactoryBuilder().setNameFormat("AndesJobPoolThread-%d")
+                                                                          .build();
 
     private final boolean _useBiasedPool = Boolean.getBoolean("org.apache.qpid.use_write_biased_pool");
 


### PR DESCRIPTION
## Purpose
> Fix issue https://github.com/wso2/product-ei/issues/2432

## Goals
> Fixing an issue regarding EI re-connect to MB after DB failure at MB. 

## Approach
> A separate executor service is introduced to notify the connection exception listeners. We cannot use the JOB pool threads for notifying the exception listeners since it will block the frame processing which is critical for activities like connection handshakes.

## User stories
> EI should automatically reconnect once MB recovers from failure 

## Release note
> N/A

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   >  Not added 
 - Integration tests
   > Not Added

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 8
 
## Learning
> N/A