### PR TITLE
 Fix issues in authorization

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/binding/BindingFactory.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/binding/BindingFactory.java
@@ -174,6 +174,8 @@ public class BindingFactory {
             }
         }
 
+        authoriseBind(bindingKey, queue, exchange);
+
         BindingImpl binding = new BindingImpl(bindingKey, queue, exchange, arguments);
         boolean isBindingExist = _bindings.contains(binding);
         /**
@@ -197,11 +199,6 @@ public class BindingFactory {
                 }
             }
 
-            //Perform ACLs ONLY after removing/updating any existing bindings.
-            if (!getVirtualHost().getSecurityManager().authoriseBind(exchange, queue, new AMQShortString(bindingKey))) {
-                throw new AMQSecurityException("Permission denied: binding " + bindingKey);
-            }
-
             //save only durable bindings
             if (binding.isDurable() && !restore) {
                 _configSource.getDurableConfigurationStore().bindQueue
@@ -218,11 +215,14 @@ public class BindingFactory {
 
             return true;
         } else {
-
-            if (!getVirtualHost().getSecurityManager().authoriseBind(exchange, queue, new AMQShortString(bindingKey))) {
-                throw new AMQSecurityException("Permission denied: binding " + bindingKey);
-            }
             return false;
+        }
+    }
+
+    public void authoriseBind(String bindingKey, AMQQueue queue, Exchange exchange) throws AMQSecurityException {
+        //Perform ACLs ONLY after removing/updating any existing bindings.
+        if (!getVirtualHost().getSecurityManager().authoriseBind(exchange, queue, new AMQShortString(bindingKey))) {
+            throw new AMQSecurityException("Permission denied: binding " + bindingKey);
         }
     }
 
@@ -320,4 +320,6 @@ public class BindingFactory {
         BindingImpl b = new BindingImpl(bindingKey, queue, exchange, arguments);
         return _bindings.get(b);
     }
+
+
 }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/binding/BindingFactory.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/binding/BindingFactory.java
@@ -128,7 +128,9 @@ public class BindingFactory {
             throws AMQSecurityException, AMQInternalException {
         boolean bindingAdded = makeBinding(bindingKey, queue, exchange, arguments, false, false);
         //tell Andes kernel to create binding
-        QpidAndesBridge.createBinding(exchange, new AMQShortString(bindingKey), queue);
+        if (bindingAdded) {
+            QpidAndesBridge.createBinding(exchange, new AMQShortString(bindingKey), queue);
+        }
         return bindingAdded;
     }
 
@@ -139,7 +141,9 @@ public class BindingFactory {
                                   AMQInternalException {
         boolean isBindingAdded = makeBinding(bindingKey, queue, exchange, arguments, false, true);
         //tell Andes kernel to create binding
-        QpidAndesBridge.createBinding(exchange, new AMQShortString(bindingKey), queue);
+        if (isBindingAdded) {
+            QpidAndesBridge.createBinding(exchange, new AMQShortString(bindingKey), queue);
+        }
         return isBindingAdded;
     }
 
@@ -171,12 +175,12 @@ public class BindingFactory {
         }
 
         BindingImpl binding = new BindingImpl(bindingKey, queue, exchange, arguments);
-        BindingImpl existingMapping = _bindings.putIfAbsent(binding, binding);
+        boolean isBindingExist = _bindings.contains(binding);
         /**
          * For the durable topic, subscribers subscribe with the same subId but different topic, we do not replace
          * binding rather keep the old and not allow to changed the binding.
          */
-        if (existingMapping == null || force) {
+        if (!isBindingExist || force) {
 
             if (_logger.isDebugEnabled()) {
                 _logger.debug("bindingKey: " + bindingKey + ", queue: " + queue + ", exchange: " + exchange);
@@ -204,6 +208,7 @@ public class BindingFactory {
                         (exchange, new AMQShortString(bindingKey), queue, FieldTable.convertToFieldTable(arguments));
             }
 
+            _bindings.put(binding, binding);
             queue.addQueueDeleteTask(binding);
             exchange.addCloseTask(binding);
             queue.addBinding(binding);
@@ -213,6 +218,10 @@ public class BindingFactory {
 
             return true;
         } else {
+
+            if (!getVirtualHost().getSecurityManager().authoriseBind(exchange, queue, new AMQShortString(bindingKey))) {
+                throw new AMQSecurityException("Permission denied: binding " + bindingKey);
+            }
             return false;
         }
     }

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueBindHandler.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/handler/QueueBindHandler.java
@@ -120,9 +120,9 @@ public class QueueBindHandler implements StateAwareMethodListener<QueueBindBody>
                 }
             }
 
+            String bindingKey = String.valueOf(routingKey);
             if (!exch.isBound(routingKey, null, queue))
             {
-                String bindingKey = String.valueOf(routingKey);
                 Map<String,Object> arguments = FieldTable.convertToMap(body.getArguments());
 
                 if(!virtualHost.getBindingFactory().addBinding(bindingKey, queue, exch, arguments))
@@ -132,9 +132,11 @@ public class QueueBindHandler implements StateAwareMethodListener<QueueBindBody>
                     Map<String, Object> oldArgs = oldBinding.getArguments();
                     if((oldArgs == null && !arguments.isEmpty()) || (oldArgs != null && !oldArgs.equals(arguments)))
                     {
-                        virtualHost.getBindingFactory().replaceBinding(bindingKey, queue, exch, arguments);    
+                        virtualHost.getBindingFactory().replaceBinding(bindingKey, queue, exch, arguments);
                     }
                 }
+            } else {
+                virtualHost.getBindingFactory().authoriseBind(bindingKey, queue, exch);
             }
         }
         catch (AMQException e)


### PR DESCRIPTION
## Purpose
Permission for queue consume is granted during the binding
authorization. The issue was caused due to the fact that the permission
check for binding was done after adding the binding. This existence of
the incorrect binding causes the next consume call to be directly
checked for autherization skipping necessary permission granting
in binding creation.
Resolves: wso2/product-ei#2631

A user is granted permission to consume from a queue upon being authorized for the binding. Authorization for binding only happens for a new binding. The second user with the same subscription id is not granted permission to consume from the queue since binding authorization is skipped.
Resolves: wso2/product-ei#2603