### PR TITLE
Fix wso2/product-ei/issues/2864

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscriptionManager.java
@@ -276,11 +276,11 @@ public class AndesSubscriptionManager implements NetworkPartitionListener, Store
             storageQueue.unbindSubscription(subscription);
             if (!storeUnavailable) {
                 andesContextStore.removeDurableSubscription(subscription);
+                clusterNotificationAgent.notifySubscriptionsChange(subscription,
+                        ClusterNotificationListener.SubscriptionChange.Closed);
             } else {
                 log.warn("Cannot not remove subscription from store since the store is non-operational");
             }
-            clusterNotificationAgent.notifySubscriptionsChange(subscription,
-                    ClusterNotificationListener.SubscriptionChange.Closed);
 
             // If there are no subscriptions for this queue, then delete it
             if (!storageQueue.isDurable() && storageQueue.getBoundSubscriptions().isEmpty()) {


### PR DESCRIPTION
## Purpose
> Fixes wso2/product-ei/issues/2864

## Goals
> Cluster coordination fails when DB disconnected. It should recover after the DB connected.  

## Approach
> Sender cluster notification only if the store is available
