### PR TITLE
Fix duplicate primary keys issue

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/thrift/MBThriftClient.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/thrift/MBThriftClient.java
@@ -162,6 +162,9 @@ public class MBThriftClient {
         boolean updateSuccess = false;
 
         for (int i = 0; i <= RETRY_COUNT; i++) {
+            if (updateSuccess) {
+                break;
+            }
             SlotManagementService.Client client = null;
 
             try {
@@ -231,6 +234,9 @@ public class MBThriftClient {
         boolean reassignSuccess = false;
 
         for (int i = 0; i <= RETRY_COUNT; i++) {
+            if (reassignSuccess) {
+                break;
+            }
             SlotManagementService.Client client = null;
 
             try {
@@ -264,6 +270,9 @@ public class MBThriftClient {
         boolean success = false;
 
         for (int i = 0; i <= RETRY_COUNT; i++) {
+            if (success) {
+                break;
+            }
             SlotManagementService.Client client = null;
 
             try {


### PR DESCRIPTION
## Purpose
> To fix the "java.sql.SQLIntegrityConstraintViolationException: Duplicate entry 'xxxx' for key 'PRIMARY'” database error, caused when inserting Slot Message IDs to MB_SLOT_MESSAGE_ID table.

## Goals
> To stop retrying once the operation becomes successful.
> Fix [wso2/andes#1013](https://github.com/wso2/andes/issues/1013)