### PR TITLE
Improve thread usage for message rejection

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnection.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnection.java
@@ -168,8 +168,10 @@ public class AMQConnection extends Closeable implements Connection, QueueConnect
     private AMQShortString _temporaryQueueExchangeName = ExchangeDefaults.DIRECT_EXCHANGE_NAME;
 
     /** Thread Pool for executing connection level processes. Such as returning bounced messages. */
-    private final ExecutorService _taskPool = Executors.newCachedThreadPool();
-    private static final long DEFAULT_TIMEOUT = 1000 * 30;
+    private final ExecutorService _taskPool =
+            Executors.newCachedThreadPool(new NamedThreadFactoryBuilder()
+                                                  .setNameFormat("amq-connection-task-pool-%d").build());
+    private static final long DEFAULT_TIMEOUT = 1000 * 30L;
 
     protected AMQConnectionDelegate _delegate;
 

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQSession.java
@@ -43,6 +43,7 @@ import org.wso2.andes.client.message.JMSStreamMessage;
 import org.wso2.andes.client.message.JMSTextMessage;
 import org.wso2.andes.client.message.MessageFactoryRegistry;
 import org.wso2.andes.client.message.UnprocessedMessage;
+import org.wso2.andes.client.pool.NamedThreadFactoryBuilder;
 import org.wso2.andes.client.protocol.AMQProtocolHandler;
 import org.wso2.andes.client.util.FlowControllingBlockingQueue;
 import org.wso2.andes.common.AMQPFilterTypes;
@@ -71,6 +72,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -348,8 +350,13 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
     /** fixed delay in seconds for the task that rejects message to run periodically*/
     private long messageRejectionTaskPeriod = 10;
 
+    private static final int DEFAULT_CORE_POOL_SIZE = 2;
     /** executor to run scheduler task rejecting messages which have passed the ack_wait_time*/
-    private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private static final ScheduledExecutorService REJECT_MESSAGE_SCHEDULER =
+            Executors.newScheduledThreadPool(DEFAULT_CORE_POOL_SIZE,
+                                             new NamedThreadFactoryBuilder()
+                                                     .setNameFormat("andes-message-reject-handler-%d").build());
+
 
     /** All the delivered message tags */
     protected ConcurrentLinkedQueue<Long> _deliveredMessageTags = new ConcurrentLinkedQueue<Long>();
@@ -442,6 +449,8 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
     private boolean _dirty;
     /** Has failover occured on this session with outstanding actions to commit? */
     private boolean _failedOverDirty;
+
+    private final ScheduledFuture rejectHandlerTask;
     
     private static final class FlowControlIndicator
     {
@@ -589,7 +598,7 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
         effectiveAckWaitTimeOut = ackWaitTimeOut - messageRejectionTaskPeriod * 1000;
 
         //start a separate task that inspect and reject messages for which we have not acked within ack_wait_timeout
-        scheduler.scheduleAtFixedRate(new Runnable() {
+        rejectHandlerTask = REJECT_MESSAGE_SCHEDULER.scheduleAtFixedRate(new Runnable() {
             @Override
             public void run() {
                 try {
@@ -651,7 +660,7 @@ public abstract class AMQSession<C extends BasicMessageConsumer, P extends Basic
         // Requires permission java.lang.RuntimePermission "modifyThread"
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
             public Void run() {
-                scheduler.shutdown();
+                rejectHandlerTask.cancel(true);
                 return null; // nothing to return
             }
         });


### PR DESCRIPTION
Create a single thread pool for message rejection task for
Andes client

Fixes : https://github.com/wso2/product-ei/issues/3897
