### PR TITLE
Fix message broker unstable with subscription issue

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextInformationManager.java
@@ -332,11 +332,17 @@ public class AndesContextInformationManager {
         // Check whether active subscriptions exists for the given storage queue
         // At this point subscriptions exist means there was some disorder in the events. Therefore notify add queue
         // and binding instead of proceeding with delete.
-        if (subscriptionManager.isActiveLocalSubscriptionsExistForQueue(storageQueueName)) {
-            AndesBinding binding = new AndesBinding(storageQueue.getMessageRouter().getName(),
-                    storageQueue, storageQueue.getMessageRouterBindingKey());
 
-            clusterNotificationAgent.notifyQueueChange(storageQueue, ClusterNotificationListener.QueueChange.Added);
+        if (subscriptionManager.isActiveLocalSubscriptionsExistForQueue(storageQueueName)) {
+            StorageQueue queue = AndesContext.getInstance().getStorageQueueRegistry()
+                                                 .getStorageQueue(storageQueueName);
+
+            String messageRouterName = queue.getMessageRouter().getName();
+            String bindingKey = queue.getMessageRouterBindingKey();
+
+            AndesBinding binding = new AndesBinding(messageRouterName, storageQueue, bindingKey);
+
+            clusterNotificationAgent.notifyQueueChange(queue, ClusterNotificationListener.QueueChange.Added);
             clusterNotificationAgent.notifyBindingsChange(binding, ClusterNotificationListener.BindingChange.Added);
 
             log.info("Queue Add and Binding Add notification sent due to active subscription.");

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesContextStore.java
@@ -114,6 +114,13 @@ public interface AndesContextStore extends HealthAwareStore {
     void removeDurableSubscription(AndesSubscription subscription) throws AndesException;
 
     /**
+     * Remove all durable and non-durable subscriptions from the cluster.
+     *
+     * @throws AndesException if an error occurs while removing subscriptions
+     */
+    void removeAllSubscriptions() throws AndesException;
+
+    /**
      * Store details of node.
      *
      * @param nodeID id of the node

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesKernelBoot.java
@@ -156,6 +156,7 @@ public class AndesKernelBoot {
                 hazelcastAgent.acquireInitializationLock();
                 if (!hazelcastAgent.isClusterInitializedSuccessfully()) {
                     removeNonDurableQueues();
+                    removeAllSubscriptions();
 
                     clearSlotStorage();
 
@@ -170,6 +171,8 @@ public class AndesKernelBoot {
                 hazelcastAgent.releaseInitializationLock();
             }
         } else {
+            removeNonDurableQueues();
+            removeAllSubscriptions();
             recoverMapsForEachQueue();
         }
     }
@@ -185,6 +188,10 @@ public class AndesKernelBoot {
                 messageStore.removeQueue(queueName);
             }
         }
+    }
+
+    private static void removeAllSubscriptions() throws AndesException {
+        contextStore.removeAllSubscriptions();
     }
 
     /**

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingAndesContextStore.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/FailureObservingAndesContextStore.java
@@ -190,6 +190,20 @@ public class FailureObservingAndesContextStore extends FailureObservingStore<And
      * {@inheritDoc}
      */
     @Override
+    public void removeAllSubscriptions() throws AndesException {
+        try {
+            wrappedInstance.removeAllSubscriptions();
+        } catch (AndesStoreUnavailableException exception) {
+            notifyFailures(exception);
+            throw exception;
+        }
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Map<String, String> getAllStoredNodeData() throws AndesException {
         try {
             return wrappedInstance.getAllStoredNodeData();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSAndesContextStoreImpl.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSAndesContextStoreImpl.java
@@ -393,6 +393,32 @@ public class RDBMSAndesContextStoreImpl implements AndesContextStore {
      * {@inheritDoc}
      */
     @Override
+    public void removeAllSubscriptions() throws AndesException {
+        Connection connection = null;
+        PreparedStatement preparedStatement = null;
+
+        String task = RDBMSConstants.TASK_REMOVING_ALL_SUBSCRIPTIONS;
+        Context contextWrite = MetricManager.timer(MetricsConstants.DB_WRITE, Level.INFO).start();
+
+        try {
+            connection = getConnection();
+            preparedStatement = connection.prepareStatement(RDBMSConstants.PS_DELETE_FROM_DURABLE_SUB_TABLE);
+            preparedStatement.executeUpdate();
+            connection.commit();
+        } catch (SQLException e) {
+            rollback(connection, task);
+            throw rdbmsStoreUtils.convertSQLException("error occurred while " + task, e);
+        } finally {
+            contextWrite.stop();
+            close(preparedStatement, task);
+            close(connection, task);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Map<String, String> getAllStoredNodeData() throws AndesException {
         Connection connection = null;
         PreparedStatement preparedStatement = null;

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/store/rdbms/RDBMSConstants.java
@@ -399,6 +399,9 @@ public class RDBMSConstants {
             + " WHERE " + DESTINATION_IDENTIFIER + "=?"
             + " AND " + DURABLE_SUB_ID + "=?";
 
+    protected static final String PS_DELETE_FROM_DURABLE_SUB_TABLE =
+            "DELETE FROM " + DURABLE_SUB_TABLE;
+
     protected static final String PS_INSERT_NODE_INFO =
             "INSERT INTO " + NODE_INFO_TABLE + " ( "
             + NODE_ID + ","
@@ -1214,6 +1217,7 @@ public class RDBMSConstants {
     protected static final String TASK_RETRIEVING_ALL_DURABLE_SUBSCRIPTIONS = "retrieving all durable subscriptions. ";
     protected static final String TASK_CHECK_SUBSCRIPTION_EXISTENCE = "checking subscription existence";
     protected static final String TASK_REMOVING_DURABLE_SUBSCRIPTION = "removing durable subscription. ";
+    protected static final String TASK_REMOVING_ALL_SUBSCRIPTIONS = "removing all subscriptions. ";
     protected static final String TASK_STORING_NODE_INFORMATION = "storing node information";
     protected static final String TASK_STORING_CLUSTER_EVENT = "storing cluster event";
     protected static final String TASK_RETRIEVING_CLUSTER_EVENTS = "retrieving cluster events";


### PR DESCRIPTION
Fix wso2/product-ei#4336
Fix wso2/product-ei#4337

## Approach

Unable to create a durable topic subscription with the same name when the servers crash
This was fixed by removing all durable and non-durable subscriptions in cluster initialization.

NullPointerException in MB clusters when there are network delays
This was fixed by establishing the same old binding when a network delay occurs.