### PR TITLE
Add JMSXDeliveryCount Header to WSO2 MB

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/MaximumNumOfDeliveryRule.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/MaximumNumOfDeliveryRule.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.andes.configuration.AndesConfigurationManager;
 import org.wso2.andes.configuration.enums.AndesConfiguration;
+import org.wso2.andes.kernel.AMQPMetaDataHandler;
 import org.wso2.andes.kernel.AndesException;
 import org.wso2.andes.kernel.ProtocolMessage;
 import org.wso2.andes.server.message.AMQMessage;
@@ -53,6 +54,9 @@ public class MaximumNumOfDeliveryRule implements AMQPDeliveryRule {
         //since we set the limit on maxRedeliveryTries rather than maxDeliveryTries
         ProtocolMessage protocolMessage = ((AMQMessage)message.getMessage()).getAndesMetadataReference();
         int numOfDeliveriesOfCurrentMsg = protocolMessage.getNumberOfDeliveriesForProtocolChannel();
+
+        //set delivery count as JMSXDeliveryCount property
+        AMQPMetaDataHandler.setIntProperty((AMQMessage)message.getMessage(), numOfDeliveriesOfCurrentMsg);
 
         MessageTracer.trace(messageID, numOfDeliveriesOfCurrentMsg, protocolMessage.getChannelID(), "Delivery count "
                 + "evaluated");

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesConstants.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/AndesConstants.java
@@ -40,4 +40,6 @@ public class AndesConstants {
      */
     public static final String DURABLE_SUBSCRIPTION_QUEUE_PREFIX = "carbon:";
 
+    public static final String JMSX_DELIVERY_COUNT_HEADER = "JMSXDeliveryCount";
+
 }


### PR DESCRIPTION
For customers sometimes it is an important feature to know the delivery count of the message.
Following are instances messages are redelivered from the broker.

if client rollbacked the session (on a transacted session)
recover the session before acknowledging
application did not acknowledge, client will send NAC upon ack time out.
JMS 2.0 brings up a solution by introducing standard Int type header called JMSXDeliveryCount. It can be used by JMS 1.1 applications as well because, both APIs have the ability to read the JMS header properties.

In WSO2 EI this property can be read as a transport level header in an incoming message from `Axis2 JMS Transport` or `Inbound JMS Transport`.

Fixes: https://github.com/wso2/product-ei/issues/4636
Port: https://github.com/wso2-support/andes/pull/197