### PR TITLE
[Fix EI-4795] MB XDeliveryCount header does not reflect correct values

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/amqp/QpidAndesBridge.java
@@ -307,7 +307,7 @@ public class QpidAndesBridge {
             boolean isMessageBeyondLastRollback = channel.isMessageBeyondLastRollback(message.getMessageNumber());
 
             log.info("Reject received id = " + message.getMessageId() + " channel id= " + channel.getChannelId()
-                    + "regueue = " + reQueue);
+                    + "requeue = " + reQueue);
 
             Andes.getInstance().messageRejected(message.getMessageId(), channel.getId(),
                     reQueue, isMessageBeyondLastRollback);

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/DeliverableAndesMetadata.java
@@ -251,10 +251,14 @@ public class DeliverableAndesMetadata extends AndesMessageMetadata {
         channelInformation.addChannelStatus(ChannelMessageStatus.DISPATCHED);
 
         if (!this.isBeyondLastRollbackedMessage) {
-            channelInformation.incrementDeliveryCount();
+            int i = channelInformation.incrementDeliveryCount();
+            MessageTracer.trace(getMessageID(), getDestination(), "Message within rollback id. "
+                    + "Current count " + i);
         } else {
             // No need to increase deliveryCount if this message is beyond the last rollback.
             MessageTracer.trace(getMessageID(), getDestination(), MessageTracer.MESSAGE_BEYOND_LAST_ROLLBACK);
+            MessageTracer.trace(getMessageID(), getDestination(), MessageTracer.MESSAGE_BEYOND_LAST_ROLLBACK
+                    + " current count = " + channelInformation.getDeliveryCount());
         }
     }
 

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundMessageRejectEvent.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/disruptor/inbound/InboundMessageRejectEvent.java
@@ -98,8 +98,8 @@ public class InboundMessageRejectEvent implements AndesInboundStateEvent {
         AndesSubscription subscription = AndesContext.getInstance().
                 getAndesSubscriptionManager().getSubscriptionByProtocolChannel(channelId);
         if (subscription != null) {
-            DeliverableAndesMetadata rejectedMessage = subscription.onMessageReject(messageId, reQueue);
-            rejectedMessage.setIsBeyondLastRollbackedMessage(isMessageBeyondLastRollback);
+            DeliverableAndesMetadata rejectedMessage = subscription.onMessageReject(messageId, reQueue,
+                    isMessageBeyondLastRollback);
             //Tracing message activity
             MessageTracer.trace(rejectedMessage, MessageTracer.MESSAGE_REJECTED);
         } else {

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscription.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/subscription/AndesSubscription.java
@@ -248,12 +248,14 @@ public class AndesSubscription {
      *
      * @param messageID id of the message acknowledged
      * @param reQueue true if message should be re-queued to subscriber
+     * @param isMessageBeyondLastRollback true if message was rejected after last rollback
      * @throws AndesException on a message re-schedule issue
      * @return DeliverableAndesMetadata reference of rejected message
      */
-    public DeliverableAndesMetadata onMessageReject(long messageID, boolean reQueue)
-            throws AndesException {
+    public DeliverableAndesMetadata onMessageReject(long messageID, boolean reQueue,
+                                                    boolean isMessageBeyondLastRollback) throws AndesException {
         DeliverableAndesMetadata rejectedMessage = subscriberConnection.onMessageReject(messageID);
+        rejectedMessage.setIsBeyondLastRollbackedMessage(isMessageBeyondLastRollback);
         //Adding metrics meter for ack rate
         Meter ackMeter = MetricManager.meter(MetricsConstants.REJECT_RECEIVE_RATE, Level.INFO);
         ackMeter.mark();

--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/server/AMQChannel.java
@@ -1968,7 +1968,10 @@ public class AMQChannel implements SessionConfig, AMQSessionModel
      * @return true if the message is placed after the last rollbacked message.
      */
     public boolean isMessageBeyondLastRollback(long messageId) {
-
+        if (_logger.isDebugEnabled()) {
+            _logger.debug("check if message is beyond last rollback. Last rollback id " + lastRollbackedMessageId
+                    + " current message id " + messageId);
+        }
         if (lastRollbackedMessageId < 0) {
             // (1) Message is either within the last committed transaction or,
             // (2) this channel is not session-transacted.


### PR DESCRIPTION
## Purpose

[Fix EI-4795] MB XDeliveryCount header does not reflect correct values

## Goals

Fixes: https://github.com/wso2/product-ei/issues/4795

## Approach

Fix the race condition on requeing messages 


## Documentation

N/A

## Training

N/A

## Certification

N/A

## Marketing

N/A

## Automation tests

Will add integration test 

## Security checks

yes

## Samples
> Provide high-level details about the samples related to this feature
