### PR TITLE
[APIM][4.4.0] Configure Broker Connect Timeout to avoid Indefinite Waiting

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionDelegate_8_0.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/AMQConnectionDelegate_8_0.java
@@ -95,6 +95,7 @@ public class AMQConnectionDelegate_8_0 implements AMQConnectionDelegate
         settings.setHost(brokerDetail.getHost());
         settings.setPort(brokerDetail.getPort());
         settings.setProtocol(brokerDetail.getTransport());
+        settings.setTransportTimeout(brokerDetail.getTimeout());
 
         // if there are ssl options mentioned in current broker options SSLConfiguration is genereated with them
         boolean sslEnabled = Boolean.parseBoolean(brokerDetail.getProperty(AMQBrokerDetails.OPTIONS_SSL));

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/jms/BrokerDetails.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/jms/BrokerDetails.java
@@ -59,7 +59,7 @@ public interface BrokerDetails
     public static final String URL_FORMAT_EXAMPLE =
             "<transport>://<hostname>[:<port Default=\"" + DEFAULT_PORT + "\">][?<option>='<value>'[,<option>='<value>']]";
 
-    public static final long DEFAULT_CONNECT_TIMEOUT = 30000L;
+    public static final long DEFAULT_CONNECT_TIMEOUT = 120000L;
     public static final boolean USE_SSL_DEFAULT = false;
 
     // pulled these properties from the new BrokerDetails class in the qpid package

--- a/modules/andes-core/common/src/main/java/org/wso2/andes/transport/network/mina/MinaNetworkTransport.java
+++ b/modules/andes-core/common/src/main/java/org/wso2/andes/transport/network/mina/MinaNetworkTransport.java
@@ -176,6 +176,7 @@ public class MinaNetworkTransport implements OutgoingNetworkTransport, IncomingN
             final SocketAddress address;
             final String protocol = settings.getProtocol();
             final int port = settings.getPort();
+            final long timeout = settings.getTransportTimeout();
 
             if (Transport.TCP.equalsIgnoreCase(protocol))
             {
@@ -218,10 +219,11 @@ public class MinaNetworkTransport implements OutgoingNetworkTransport, IncomingN
             }
 
             ConnectFuture future = ioConnector.connect(address, new MinaNetworkHandler(null), ioConnector.getDefaultConfig());
-            future.join();
+            future.join(timeout);
             if (!future.isConnected())
             {
-                throw new TransportException("Could not open connection");
+                throw new TransportException(
+                        "Could not open connection within " + timeout + " milliseconds on Port: " + port);
             }
             IoSession session = future.getSession();
             session.setAttachment(receiver);


### PR DESCRIPTION
### Purpose
In a distributed WSO2 API Manager setup, throttling functionality was not working correctly when one or more traffic manager nodes were unavailable. Specifically, when one traffic manager node could not establish a connection while another was still active, event duplication led to threads becoming stuck, causing throttling failures.
- Resolves https://github.com/wso2/api-manager/issues/3125

### Fix
Use the broker connection timeout property to introduce a waiting timeout for the broker pooled connection establishment

### Impact
The process of establishing a broker connection will continue trying until the specified timeout is reached. If a timeout is defined in the broker's URL properties, that value will be used. Otherwise, the connection attempt will default to a 120-second timeout if no specific connect timeout is provided.