### PR TITLE
Improve local address sanitisation for IPv6 support

### DIFF
--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/AMQProtocolSession.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/AMQProtocolSession.java
@@ -391,8 +391,8 @@ public class AMQProtocolSession implements AMQVersionAwareProtocolSession
         {
             id = _queueId++;
         }
-        // convert '.', '/', ':' and ';' to single '_', for spec compliance and readability
-        String localAddress = _protocolHandler.getLocalAddress().toString().replaceAll("[./:;]", "_");
+        // convert '.', '/', ':', ';', '[' and ']' to single '_', for spec compliance and readability
+        String localAddress = _protocolHandler.getLocalAddress().toString().replaceAll("[./:;\\[\\]]", "_");
         String queueName = "tmp_" + localAddress + "_" + id;
         return new AMQShortString(queueName.replaceAll("_+", "_"));
     }

--- a/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/AMQProtocolSession.java
+++ b/modules/andes-core/client/src/main/java/org/wso2/andes/client/protocol/AMQProtocolSession.java
@@ -391,8 +391,8 @@ public class AMQProtocolSession implements AMQVersionAwareProtocolSession
         {
             id = _queueId++;
         }
-        // convert '.', '/', ':', ';', '[' and ']' to single '_', for spec compliance and readability
-        String localAddress = _protocolHandler.getLocalAddress().toString().replaceAll("[./:;\\[\\]]", "_");
+        // convert '.', '/', ':', ';', '[', ']' and '%' to single '_', for spec compliance and readability
+        String localAddress = _protocolHandler.getLocalAddress().toString().replaceAll("[./:;\\[\\]%]", "_");
         String queueName = "tmp_" + localAddress + "_" + id;
         return new AMQShortString(queueName.replaceAll("_+", "_"));
     }


### PR DESCRIPTION
## Purpose

- Resolves: https://github.com/wso2/api-manager/issues/5005

This pull request updates the queue name generation logic to improve compliance by handling additional special characters in the local address.

Queue name generation update:

* In `AMQProtocolSession.java`, the `generateQueueName()` method now replaces not only `.`, `/`, `:`, and `;`, but also `[`, `]` and `%` with underscores in the local address when generating a temporary queue name.